### PR TITLE
Added ability to use custom conventions for naming exchanges and queues.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@
 *.DS_Store
 [Tt]humbs.db 
 _ReSharper.*
+
+# Ignore NCrunch cache files.
+*.crunchproject.local.xml
+*.crunchsolution.local.xml

--- a/EasyNetQ.Scheduler.Tests/MockRawByteBus.cs
+++ b/EasyNetQ.Scheduler.Tests/MockRawByteBus.cs
@@ -6,10 +6,10 @@ namespace EasyNetQ.Scheduler.Tests
     {
         public Action<string, byte[]> RawPublishDelegate { get; set; }
 
-        public void RawPublish(string typeName, byte[] messageBody)
+        public void RawPublish(string exchangeName, byte[] messageBody)
         {
             if (RawPublishDelegate != null)
-                RawPublishDelegate(typeName, messageBody);
+                RawPublishDelegate(exchangeName, messageBody);
         }
     }
 }

--- a/EasyNetQ.Tests/ConventionsTests.cs
+++ b/EasyNetQ.Tests/ConventionsTests.cs
@@ -1,0 +1,108 @@
+// ReSharper disable InconsistentNaming
+
+using NUnit.Framework;
+using RabbitMQ.Client;
+
+namespace EasyNetQ.Tests
+{
+	[TestFixture]
+	public class When_using_default_conventions
+	{
+		private Conventions conventions;
+
+		[SetUp]
+		public void SetUp()
+		{
+			conventions = new Conventions();
+		}
+
+		[Test]
+		public void The_default_exchange_naming_convention_should_use_the_TypeNameSerializers_Serialize_method()
+		{
+			var result = conventions.ExchangeNamingConvention.Invoke(typeof (TestMessage));
+			result.ShouldEqual(TypeNameSerializer.Serialize(typeof (TestMessage)));
+		}
+
+		[Test]
+		public void The_default_topic_naming_convention_should_use_the_TypeNameSerializers_Serialize_method()
+		{
+			var result = conventions.TopicNamingConvention.Invoke(typeof (TestMessage));
+			result.ShouldEqual(TypeNameSerializer.Serialize(typeof (TestMessage)));
+		}
+
+		[Test]
+		public void The_default_queue_naming_convention_should_use_the_TypeNameSerializers_Serialize_method_then_an_underscore_then_the_subscription_id()
+		{
+			const string subscriptionId = "test";
+			var result = conventions.QueueNamingConveition.Invoke(typeof (TestMessage), subscriptionId);
+			result.ShouldEqual(TypeNameSerializer.Serialize(typeof (TestMessage)) + "_" + subscriptionId);
+		}
+	}
+
+	[TestFixture]
+	public class When_publishing_a_message
+	{
+		private RabbitBus bus;
+		private MockModel mockModel;
+		private string createdExchangeName;
+		private string publishedToExchangeName;
+		private string publishedToTopic;
+
+		[SetUp]
+		public void SetUp()
+		{
+			var mockModel = new MockModel
+			            	{
+			            		ExchangeDeclareAction = (exchangeName, type, durable, autoDelete, arguments) => createdExchangeName = exchangeName,
+								BasicPublishAction = (exchangeName, topic, properties, messageBody) =>
+								                     	{
+								                     		publishedToExchangeName = exchangeName;
+								                     		publishedToTopic = topic;
+								                     	}
+			            	};
+
+
+			var customConventions = new Conventions
+			                  	{
+			                  		ExchangeNamingConvention = x => "CustomExchangeNamingConvention",
+			                  		QueueNamingConveition = (x, y) => "CustomQueueNamingConvention",
+			                  		TopicNamingConvention = x => "CustomTopicNamingConvention"
+			                  	};
+			CreateBus(customConventions, mockModel);
+			bus.Publish(new TestMessage());
+		}
+
+		private void CreateBus(Conventions conventions, IModel model)
+		{
+			bus = new RabbitBus(
+				x => TypeNameSerializer.Serialize(x.GetType()),
+				new JsonSerializer(),
+				new MockConsumerFactory(),
+				new MockConnectionFactory(new MockConnection(model)),
+				new MockLogger(),
+				CorrelationIdGenerator.GetCorrelationId,
+				conventions
+				);
+		}
+
+		[Test]
+		public void Should_use_exchange_name_from_conventions_to_create_the_exchange()
+		{
+			createdExchangeName.ShouldEqual("CustomExchangeNamingConvention");
+		}
+
+		[Test]
+		public void Should_use_exchange_name_from_conventions_as_the_exchange_to_publish_to()
+		{
+			publishedToExchangeName.ShouldEqual("CustomExchangeNamingConvention");
+		}
+
+		[Test]
+		public void Should_use_topic_name_from_conventions_as_the_topic_to_publish_to()
+		{
+			publishedToTopic.ShouldEqual("CustomTopicNamingConvention");
+		}
+	}
+}
+
+// ReSharper restore InconsistentNaming

--- a/EasyNetQ.Tests/EasyNetQ.Tests.csproj
+++ b/EasyNetQ.Tests/EasyNetQ.Tests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="ConnectionErrorConditionsTests.cs" />
     <Compile Include="ConnectionStringTests.cs" />
     <Compile Include="ConsumerErrorConditionsTests.cs" />
+    <Compile Include="ConventionsTests.cs" />
     <Compile Include="CorrelationIdTests.cs" />
     <Compile Include="DefaultConsumerErrorStrategyTests.cs" />
     <Compile Include="ExceptionConditionsTests.cs" />
@@ -79,6 +80,7 @@
     <Compile Include="MockBasicProperties.cs" />
     <Compile Include="MockConnection.cs" />
     <Compile Include="MockConnectionFactory.cs" />
+    <Compile Include="MockConsumerFactory.cs" />
     <Compile Include="MockLogger.cs" />
     <Compile Include="MockModel.cs" />
     <Compile Include="ModelCleanupTests.cs" />

--- a/EasyNetQ.Tests/MockConsumerFactory.cs
+++ b/EasyNetQ.Tests/MockConsumerFactory.cs
@@ -1,0 +1,21 @@
+using System;
+using RabbitMQ.Client;
+
+namespace EasyNetQ.Tests
+{
+	public class MockConsumerFactory : IConsumerFactory
+	{
+		public void Dispose()
+		{
+		}
+
+		public DefaultBasicConsumer CreateConsumer(IModel model, MessageCallback callback)
+		{
+			return null;
+		}
+
+		public void ClearConsumers()
+		{
+		}
+	}
+}

--- a/EasyNetQ.Tests/MockModel.cs
+++ b/EasyNetQ.Tests/MockModel.cs
@@ -60,7 +60,7 @@ namespace EasyNetQ.Tests
 
         public void ExchangeDeclare(string exchange, string type, bool durable)
         {
-            
+        	ExchangeDeclareAction(exchange, type, durable, true, null);
         }
 
         public void ExchangeDeclare(string exchange, string type)

--- a/EasyNetQ/Conventions.cs
+++ b/EasyNetQ/Conventions.cs
@@ -1,0 +1,39 @@
+using System;
+
+
+namespace EasyNetQ
+{
+	public delegate string ExchangeNameConvention(Type messageType);
+	public delegate string TopicNameConvention(Type messageType);
+	public delegate string QueueNameConvention(Type messageType, string subscriberId);
+
+	public interface IConventions
+	{
+
+		ExchangeNameConvention ExchangeNamingConvention { get; set; }
+		TopicNameConvention TopicNamingConvention { get; set; }
+		QueueNameConvention QueueNamingConveition { get; set; }
+	}
+
+
+	public class Conventions : IConventions
+	{
+		public Conventions()
+		{
+			// Establish default conventions.
+			ExchangeNamingConvention = TypeNameSerializer.Serialize;
+			TopicNamingConvention = TypeNameSerializer.Serialize;
+			QueueNamingConveition =
+					(messageType, subscriptionId) =>
+					{
+						var typeName = TypeNameSerializer.Serialize(messageType);
+						return string.Format("{0}_{1}", typeName, subscriptionId);
+					};
+		}
+
+
+		public ExchangeNameConvention ExchangeNamingConvention { get; set; }
+		public TopicNameConvention TopicNamingConvention { get; set; }
+		public QueueNameConvention QueueNamingConveition { get; set; }
+	}
+}

--- a/EasyNetQ/EasyNetQ.csproj
+++ b/EasyNetQ/EasyNetQ.csproj
@@ -49,6 +49,7 @@
     </Compile>
     <Compile Include="BinarySerializer.cs" />
     <Compile Include="ConnectionString.cs" />
+    <Compile Include="Conventions.cs" />
     <Compile Include="CorrelationIdGenerator.cs" />
     <Compile Include="DefaultConsumerErrorStrategy.cs" />
     <Compile Include="Delegates.cs" />

--- a/EasyNetQ/IRawByteBus.cs
+++ b/EasyNetQ/IRawByteBus.cs
@@ -2,6 +2,6 @@ namespace EasyNetQ
 {
     public interface IRawByteBus
     {
-        void RawPublish(string typeName, byte[] messageBody);
+        void RawPublish(string exchangeName, byte[] messageBody);
     }
 }


### PR DESCRIPTION
I committed this to master, then moved it to a branch for this pull request. Hopefully it works properly such that if I commit more to master, it doesn't show up in this pull request like last time...

I added comments in the commit so you can see why I made certain decisions. You can see these by looking at the diffs in github.

I didn't use Rhino Mocks as it would have resulted in a more complex test given the design of the interfaces. All the other mocks were there, so it was not difficult to add another.

There are places where the conventions are not used, such as in declaring some of the static queues used for request response, etc. Let me know if I missed a place where the naming conventions should have been applied.
