### PR TITLE
Scheduler Service not starting due to IRawByteBus

### DIFF
--- a/Source/EasyNetQ.Scheduler/SchedulerService.cs
+++ b/Source/EasyNetQ.Scheduler/SchedulerService.cs
@@ -58,6 +58,13 @@ namespace EasyNetQ.Scheduler
             {
                 purgeTimer.Dispose();
             }
+            if (rawByteBus != null)
+            {
+                if(rawByteBus is IDisposable)
+                {
+                  ((IDisposable)rawByteBus).Dispose();
+                }
+            }
             if (bus != null)
             {
                 bus.Dispose();

--- a/Source/EasyNetQ.Scheduler/SchedulerServiceFactory.cs
+++ b/Source/EasyNetQ.Scheduler/SchedulerServiceFactory.cs
@@ -9,7 +9,7 @@ namespace EasyNetQ.Scheduler
         {
             var bus = RabbitHutch.CreateBus();
 
-            var rawByteBus = bus as IRawByteBus;
+            var rawByteBus = bus.OpenPublishChannel() as IRawByteBus;
             if (rawByteBus == null)
             {
                 throw new EasyNetQException("Bus does not implement IRawByteBus");


### PR DESCRIPTION
Hey Mike,

I wasn't able to get the scheduler service started due to RabbitBus not implementing IRawByteBus. I have added code to OpenPublishChannel() when the service starts and dispose the IRawByteBus if it implements IDisposible.

Just starting to test out EasyNetQ - I presume this was just a side effect of this: http://mikehadlow.blogspot.com.au/2012/05/easynetq-breaking-change.html

cheers
Andrew
