### PR TITLE
New QueueDeclare method that takes arguments

### DIFF
--- a/Source/EasyNetQ.Tests/Topology/TopologyTests.cs
+++ b/Source/EasyNetQ.Tests/Topology/TopologyTests.cs
@@ -1,5 +1,6 @@
 ﻿// ReSharper disable InconsistentNaming
 
+using System.Collections.Generic;
 using EasyNetQ.Topology;
 using NUnit.Framework;
 using RabbitMQ.Client;
@@ -16,6 +17,7 @@ namespace EasyNetQ.Tests.Topology
         private const string exchangeName = "speedster";
         private const string queueName = "roadster";
         private const string routingKey = "drop_head";
+        private static readonly Dictionary<string, string> arguments = new Dictionary<string, string>() { { "argKey", "argValue" } };
 
         [SetUp]
         public void SetUp()
@@ -72,6 +74,15 @@ namespace EasyNetQ.Tests.Topology
             queue.Visit(visitor);
 
             model.AssertWasCalled(x => x.QueueDeclare(queueName, true, false, false, null));
+        }
+
+        [Test]
+        public void Should_create_a_durable_queue_with_arguments()
+        {
+            var queue = Queue.DeclareDurable(queueName, arguments);
+            queue.Visit(visitor);
+
+            model.AssertWasCalled(x => x.QueueDeclare(queueName, true, false, false, arguments));
         }
 
         // QT

--- a/Source/EasyNetQ/Topology/ITopologyVisitor.cs
+++ b/Source/EasyNetQ/Topology/ITopologyVisitor.cs
@@ -1,9 +1,11 @@
+using System.Collections.Generic;
+
 namespace EasyNetQ.Topology
 {
     public interface ITopologyVisitor
     {
         void CreateExchange(string exchangeName, string exchangeType);
-        void CreateQueue(string queueName, bool durable, bool exclusive, bool autoDelete);
+        void CreateQueue(string queueName, bool durable, bool exclusive, bool autoDelete, Dictionary<string, string> arguments);
         string CreateQueue();
         void CreateBinding(IBindable bindable, IExchange exchange, string[] routingKeys);
     }

--- a/Source/EasyNetQ/Topology/Queue.cs
+++ b/Source/EasyNetQ/Topology/Queue.cs
@@ -9,26 +9,32 @@ namespace EasyNetQ.Topology
         readonly bool durable;
         readonly bool exclusive;
         readonly bool autoDelete;
+        private readonly Dictionary<string, string> arguments;
 
         private readonly IList<IBinding> bindings = new List<IBinding>();
 
         public static IQueue DeclareDurable(string queueName)
         {
-            return new Queue(true, false, false, queueName);
+            return new Queue(true, false, false, queueName, null);
+        }
+
+        public static IQueue DeclareDurable(string queueName, Dictionary<string, string> arguments)
+        {
+            return new Queue(true, false, false, queueName, arguments);
         }
 
         public static IQueue DeclareTransient(string queueName)
         {
-            return new Queue(false, true, true, queueName);
+            return new Queue(false, true, true, queueName, null);
         }
 
         public static IQueue DeclareTransient()
         {
-            return new Queue(false, true, true);
+            return new Queue(false, true, true, null);
         }
 
-        protected Queue(bool durable, bool exclusive, bool autoDelete, string name) 
-            : this(durable, exclusive, autoDelete)
+        protected Queue(bool durable, bool exclusive, bool autoDelete, string name, Dictionary<string, string> arguements)
+            : this(durable, exclusive, autoDelete, arguements)
         {
             if(string.IsNullOrEmpty(name))
             {
@@ -37,11 +43,12 @@ namespace EasyNetQ.Topology
             Name = name;
         }
 
-        protected Queue(bool durable, bool exclusive, bool autoDelete)
+        protected Queue(bool durable, bool exclusive, bool autoDelete, Dictionary<string, string> arguments)
         {
             this.autoDelete = autoDelete;
             this.exclusive = exclusive;
             this.durable = durable;
+            this.arguments = arguments;
 
             // making this assumption for now, that declaring a queue as autoDelete means that 
             // you only want to get one message and then Dispose.
@@ -88,7 +95,7 @@ namespace EasyNetQ.Topology
             }
             else
             {
-                visitor.CreateQueue(Name, durable, exclusive, autoDelete);
+                visitor.CreateQueue(Name, durable, exclusive, autoDelete, arguments);
             }
             foreach (var binding in bindings)
             {

--- a/Source/EasyNetQ/Topology/TopologyBuilder.cs
+++ b/Source/EasyNetQ/Topology/TopologyBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using RabbitMQ.Client;
 
@@ -28,14 +29,14 @@ namespace EasyNetQ.Topology
             model.ExchangeDeclare(exchangeName, exchangeType, true);
         }
 
-        public void CreateQueue(string queueName, bool durable, bool exclusive, bool autoDelete)
+        public void CreateQueue(string queueName, bool durable, bool exclusive, bool autoDelete, Dictionary<string, string> arguments)
         {
             if (string.IsNullOrEmpty(queueName))
             {
                 throw new ArgumentException("queueName is null or empty");
             }
 
-            model.QueueDeclare(queueName, durable, exclusive, autoDelete, null);
+            model.QueueDeclare(queueName, durable, exclusive, autoDelete, arguments);
         }
 
         public string CreateQueue()


### PR DESCRIPTION
I'm using HA in my RabbitMQ setup. To do that with EasyNetQ I need to send some arguments to QueueDeclare (x-ha-policy: all)

Another possible, and preferred, solution would be to disable queue declaration. 
