### PR TITLE
AMQP arguments on all subscription queues.

### DIFF
--- a/Source/EasyNetQ.Scheduler.Tests/MockBus.cs
+++ b/Source/EasyNetQ.Scheduler.Tests/MockBus.cs
@@ -33,7 +33,17 @@ namespace EasyNetQ.Scheduler.Tests
             throw new NotImplementedException();
         }
 
+        public void Subscribe<T>(string subscriptionId, Action<T> onMessage, IDictionary<string, object> arguments)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Subscribe<T>(string subscriptionId, string topic, Action<T> onMessage)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Subscribe<T>(string subscriptionId, string topic, Action<T> onMessage, IDictionary<string, object> arguments)
         {
             throw new NotImplementedException();
         }
@@ -43,7 +53,17 @@ namespace EasyNetQ.Scheduler.Tests
             throw new NotImplementedException();
         }
 
+        public void Subscribe<T>(string subscriptionId, IEnumerable<string> topics, Action<T> onMessage, IDictionary<string, object> arguments)
+        {
+            throw new NotImplementedException();
+        }
+
         public void SubscribeAsync<T>(string subscriptionId, Func<T, Task> onMessage)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SubscribeAsync<T>(string subscriptionId, Func<T, Task> onMessage, IDictionary<string, object> arguments)
         {
             throw new NotImplementedException();
         }
@@ -53,7 +73,17 @@ namespace EasyNetQ.Scheduler.Tests
             throw new NotImplementedException();
         }
 
+        public void SubscribeAsync<T>(string subscriptionId, string topic, Func<T, Task> onMessage, IDictionary<string, object> arguments)
+        {
+            throw new NotImplementedException();
+        }
+
         public void SubscribeAsync<T>(string subscriptionId, IEnumerable<string> topics, Func<T, Task> onMessage)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SubscribeAsync<T>(string subscriptionId, IEnumerable<string> topics, Func<T, Task> onMessage, IDictionary<string, object> arguments)
         {
             throw new NotImplementedException();
         }
@@ -63,12 +93,22 @@ namespace EasyNetQ.Scheduler.Tests
             throw new NotImplementedException();
         }
 
-        public void Respond<TRequest, TResponse>(Func<TRequest, TResponse> responder)
+        public void Respond<TRequest, TResponse>(Func<TRequest, TResponse> responder, IDictionary<string, object> arguments)
         {
             throw new NotImplementedException();
         }
 
+        public void Respond<TRequest, TResponse>(Func<TRequest, TResponse> responder)
+        {
+            throw new NotImplementedException();
+        }
+        
         public void RespondAsync<TRequest, TResponse>(Func<TRequest, Task<TResponse>> responder)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RespondAsync<TRequest, TResponse>(Func<TRequest, Task<TResponse>> responder, IDictionary<string, object> arguments)
         {
             throw new NotImplementedException();
         }

--- a/Source/EasyNetQ/IBus.cs
+++ b/Source/EasyNetQ/IBus.cs
@@ -33,6 +33,23 @@ namespace EasyNetQ
         void Subscribe<T>(string subscriptionId, Action<T> onMessage);
 
         /// <summary>
+        /// Subscribes to a stream of messages that match a .NET type.
+        /// </summary>
+        /// <typeparam name="T">The type to subscribe to</typeparam>
+        /// <param name="subscriptionId">
+        /// A unique identifier for the subscription. Two subscriptions with the same subscriptionId
+        /// and type will get messages delivered in turn. This is useful if you want multiple subscribers
+        /// to load balance a subscription in a round-robin fashion.
+        /// </param>
+        /// <param name="onMessage">
+        /// The action to run when a message arrives. When onMessage completes the message
+        /// recipt is Ack'd. All onMessage delegates are processed on a single thread so you should
+        /// avoid long running blocking IO operations. Consider using SubscribeAsync
+        /// </param>
+        /// <param name="arguments">AMQP arguments. For e.q. Message TTL("x-message-ttl", "60"), High Availability policy("x-ha-policy", "all") and so on.</param>
+        void Subscribe<T>(string subscriptionId, Action<T> onMessage, IDictionary<string, object> arguments);
+
+        /// <summary>
         /// Subscribes to a stream of messages that match a .NET type and the given topic
         /// </summary>
         /// <typeparam name="T">The type to subscribe to</typeparam>
@@ -60,6 +77,26 @@ namespace EasyNetQ
         /// and type will get messages delivered in turn. This is useful if you want multiple subscribers
         /// to load balance a subscription in a round-robin fashion.
         /// </param>
+        /// <param name="topic">
+        /// The topic to match on
+        /// </param>
+        /// <param name="onMessage">
+        /// The action to run when a message arrives. When onMessage completes the message
+        /// recipt is Ack'd. All onMessage delegates are processed on a single thread so you should
+        /// avoid long running blocking IO operations. Consider using SubscribeAsync
+        /// </param>
+        /// <param name="arguments">AMQP arguments. For e.q. Message TTL("x-message-ttl", "60"), High Availability policy("x-ha-policy", "all") and so on.</param>
+        void Subscribe<T>(string subscriptionId, string topic, Action<T> onMessage, IDictionary<string, object> arguments);
+
+        /// <summary>
+        /// Subscribes to a stream of messages that match a .NET type and the given topic
+        /// </summary>
+        /// <typeparam name="T">The type to subscribe to</typeparam>
+        /// <param name="subscriptionId">
+        /// A unique identifier for the subscription. Two subscriptions with the same subscriptionId
+        /// and type will get messages delivered in turn. This is useful if you want multiple subscribers
+        /// to load balance a subscription in a round-robin fashion.
+        /// </param>
         /// <param name="topics">
         /// The topics to match on. Each topic string creates a new binding between the exchange and 
         /// subscription queue.
@@ -70,6 +107,27 @@ namespace EasyNetQ
         /// avoid long running blocking IO operations. Consider using SubscribeAsync
         /// </param>
         void Subscribe<T>(string subscriptionId, IEnumerable<string> topics, Action<T> onMessage);
+
+        /// <summary>
+        /// Subscribes to a stream of messages that match a .NET type and the given topic
+        /// </summary>
+        /// <typeparam name="T">The type to subscribe to</typeparam>
+        /// <param name="subscriptionId">
+        /// A unique identifier for the subscription. Two subscriptions with the same subscriptionId
+        /// and type will get messages delivered in turn. This is useful if you want multiple subscribers
+        /// to load balance a subscription in a round-robin fashion.
+        /// </param>
+        /// <param name="topics">
+        /// The topics to match on. Each topic string creates a new binding between the exchange and 
+        /// subscription queue.
+        /// </param>
+        /// <param name="onMessage">
+        /// The action to run when a message arrives. When onMessage completes the message
+        /// recipt is Ack'd. All onMessage delegates are processed on a single thread so you should
+        /// avoid long running blocking IO operations. Consider using SubscribeAsync
+        /// </param>
+        /// <param name="arguments">AMQP arguments. For e.q. Message TTL("x-message-ttl", "60"), High Availability policy("x-ha-policy", "all") and so on.</param>
+        void Subscribe<T>(string subscriptionId, IEnumerable<string> topics, Action<T> onMessage, IDictionary<string, object> arguments);
 
         /// <summary>
         /// Subscribes to a stream of messages that match a .NET type.
@@ -87,6 +145,24 @@ namespace EasyNetQ
         /// Ack'd.
         /// </param>
         void SubscribeAsync<T>(string subscriptionId, Func<T, Task> onMessage);
+
+        /// <summary>
+        /// Subscribes to a stream of messages that match a .NET type.
+        /// Allows the subscriber to complete asynchronously.
+        /// </summary>
+        /// <typeparam name="T">The type to subscribe to</typeparam>
+        /// <param name="subscriptionId">
+        /// A unique identifier for the subscription. Two subscriptions with the same subscriptionId
+        /// and type will get messages delivered in turn. This is useful if you want multiple subscribers
+        /// to load balance a subscription in a round-robin fashion.
+        /// </param>
+        /// <param name="onMessage">
+        /// The action to run when a message arrives. onMessage can immediately return a Task and
+        /// then continue processing asynchronously. When the Task completes the message will be
+        /// Ack'd.
+        /// </param>
+        /// <param name="arguments">AMQP arguments. For e.q. Message TTL("x-message-ttl", "60"), High Availability policy("x-ha-policy", "all") and so on.</param>
+        void SubscribeAsync<T>(string subscriptionId, Func<T, Task> onMessage, IDictionary<string, object> arguments);
 
         /// <summary>
         /// Subscribes to a stream of messages that match a .NET type.
@@ -118,6 +194,27 @@ namespace EasyNetQ
         /// and type will get messages delivered in turn. This is useful if you want multiple subscribers
         /// to load balance a subscription in a round-robin fashion.
         /// </param>
+        /// <param name="topic">
+        /// The topic to match on
+        /// </param>
+        /// <param name="onMessage">
+        /// The action to run when a message arrives. onMessage can immediately return a Task and
+        /// then continue processing asynchronously. When the Task completes the message will be
+        /// Ack'd.
+        /// </param>
+        /// <param name="arguments">AMQP arguments. For e.q. Message TTL("x-message-ttl", "60"), High Availability policy("x-ha-policy", "all") and so on.</param>
+        void SubscribeAsync<T>(string subscriptionId, string topic, Func<T, Task> onMessage, IDictionary<string, object> arguments);
+
+        /// <summary>
+        /// Subscribes to a stream of messages that match a .NET type.
+        /// Allows the subscriber to complete asynchronously.
+        /// </summary>
+        /// <typeparam name="T">The type to subscribe to</typeparam>
+        /// <param name="subscriptionId">
+        /// A unique identifier for the subscription. Two subscriptions with the same subscriptionId
+        /// and type will get messages delivered in turn. This is useful if you want multiple subscribers
+        /// to load balance a subscription in a round-robin fashion.
+        /// </param>
         /// <param name="topics">
         /// The topics to match on. Each topic string creates a new binding between the queue and the
         /// exchange.
@@ -130,6 +227,28 @@ namespace EasyNetQ
         void SubscribeAsync<T>(string subscriptionId, IEnumerable<string> topics, Func<T, Task> onMessage);
 
         /// <summary>
+        /// Subscribes to a stream of messages that match a .NET type.
+        /// Allows the subscriber to complete asynchronously.
+        /// </summary>
+        /// <typeparam name="T">The type to subscribe to</typeparam>
+        /// <param name="subscriptionId">
+        /// A unique identifier for the subscription. Two subscriptions with the same subscriptionId
+        /// and type will get messages delivered in turn. This is useful if you want multiple subscribers
+        /// to load balance a subscription in a round-robin fashion.
+        /// </param>
+        /// <param name="topics">
+        /// The topics to match on. Each topic string creates a new binding between the queue and the
+        /// exchange.
+        /// </param>
+        /// <param name="onMessage">
+        /// The action to run when a message arrives. onMessage can immediately return a Task and
+        /// then continue processing asynchronously. When the Task completes the message will be
+        /// Ack'd.
+        /// </param>
+        /// <param name="arguments">AMQP arguments. For e.q. Message TTL("x-message-ttl", "60"), High Availability policy("x-ha-policy", "all") and so on.</param>
+        void SubscribeAsync<T>(string subscriptionId, IEnumerable<string> topics, Func<T, Task> onMessage, IDictionary<string, object> arguments);
+
+        /// <summary>
         /// Responds to an RPC request.
         /// </summary>
         /// <typeparam name="TRequest">The request type.</typeparam>
@@ -140,6 +259,17 @@ namespace EasyNetQ
         void Respond<TRequest, TResponse>(Func<TRequest, TResponse> responder);
 
         /// <summary>
+        /// Responds to an RPC request.
+        /// </summary>
+        /// <typeparam name="TRequest">The request type.</typeparam>
+        /// <typeparam name="TResponse">The response type.</typeparam>
+        /// <param name="responder">
+        /// A function to run when the request is received. It should return the response.
+        /// </param>
+        /// <param name="arguments">AMQP arguments. For e.q. Message TTL("x-message-ttl", "60"), High Availability policy("x-ha-policy", "all") and so on.</param>
+        void Respond<TRequest, TResponse>(Func<TRequest, TResponse> responder, IDictionary<string, object> arguments);
+
+        /// <summary>
         /// Responds to an RPC request asynchronously.
         /// </summary>
         /// <typeparam name="TRequest">The request type.</typeparam>
@@ -148,6 +278,17 @@ namespace EasyNetQ
         /// A function to run when the request is received.
         /// </param>
         void RespondAsync<TRequest, TResponse>(Func<TRequest, Task<TResponse>> responder);
+
+        /// <summary>
+        /// Responds to an RPC request asynchronously.
+        /// </summary>
+        /// <typeparam name="TRequest">The request type.</typeparam>
+        /// <typeparam name="TResponse">The response type</typeparam>
+        /// <param name="responder">
+        /// A function to run when the request is received.
+        /// </param>
+        /// <param name="arguments">AMQP arguments. For e.q. Message TTL("x-message-ttl", "60"), High Availability policy("x-ha-policy", "all") and so on.</param>
+        void RespondAsync<TRequest, TResponse>(Func<TRequest, Task<TResponse>> responder, IDictionary<string, object> arguments);
 
         /// <summary>
         /// Fires once the bus has connected to a RabbitMQ server.

--- a/Source/EasyNetQ/IPublishChannel.cs
+++ b/Source/EasyNetQ/IPublishChannel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace EasyNetQ
 {
@@ -31,6 +32,16 @@ namespace EasyNetQ
         /// <param name="request">The request message.</param>
         /// <param name="onResponse">The action to run when the response is received.</param>
         void Request<TRequest, TResponse>(TRequest request, Action<TResponse> onResponse);
+
+        /// <summary>
+        /// Makes an RPC style asynchronous request.
+        /// </summary>
+        /// <typeparam name="TRequest">The request type.</typeparam>
+        /// <typeparam name="TResponse">The response type.</typeparam>
+        /// <param name="request">The request message.</param>
+        /// <param name="onResponse">The action to run when the response is received.</param>
+        /// <param name="arguments">AMQP arguments. For e.q. Message TTL("x-message-ttl", "60"), High Availability policy("x-ha-policy", "all") and so on.</param>
+        void Request<TRequest, TResponse>(TRequest request, Action<TResponse> onResponse, IDictionary<string, object> arguments);
 
         /// <summary>
         /// The bus that created this channel

--- a/Source/EasyNetQ/Topology/Queue.cs
+++ b/Source/EasyNetQ/Topology/Queue.cs
@@ -47,6 +47,11 @@ namespace EasyNetQ.Topology
             return new Queue(false, true, true, queueName, null);
         }
 
+        public static IQueue DeclareTransient(string queueName, IDictionary<string, object> arguments)
+        {
+            return new Queue(false, true, true, queueName, arguments);
+        }
+
         public static IQueue DeclareTransient()
         {
             return new Queue(false, true, true, null);


### PR DESCRIPTION
Extended IBus and IPublishChannel interfaces to accept arguments parameter for all "subscribtion" methods. This allows usage of special AMQP arguments on each created queue(if required). Ex. of arguments: Message TTL("x-message-ttl", "60"), High Availability policy("x-ha-policy", "all")...
