### PR TITLE
Set default topic when using the fluent API

### DIFF
--- a/Source/EasyNetQ.Tests/PublishSubscribeWithTopicsTests.cs
+++ b/Source/EasyNetQ.Tests/PublishSubscribeWithTopicsTests.cs
@@ -77,6 +77,29 @@ namespace EasyNetQ.Tests
 
             countdownEvent.Wait(500);
         }
+
+        [Test, Explicit("Needs a Rabbit instance on localhost to work")]
+        public void Publish_a_messages_without_a_topic()
+        {
+            using (var publishChannel = bus.OpenPublishChannel())
+            {
+                publishChannel.Publish(CreateMessage());
+            }
+        }
+
+        [Test, Explicit("Needs a Rabbit instance on localhost to work")]
+        public void Subscribe_to_messages_without_a_topic_with_arguments()
+        {
+            var countdownEvent = new CountdownEvent(7);
+
+            bus.Subscribe<MyMessage>("id1", msg =>
+            {
+                Console.WriteLine("I Get X: {0}", msg.Text);
+                countdownEvent.Signal();
+            }, x => x.WithArgument("x-made-up-argument", "any value"));
+
+            countdownEvent.Wait(1000);
+        }
     }
 }
 

--- a/Source/EasyNetQ/RabbitBus.cs
+++ b/Source/EasyNetQ/RabbitBus.cs
@@ -72,7 +72,7 @@ namespace EasyNetQ
 
         public void Subscribe<T>(string subscriptionId, Action<T> onMessage)
         {
-            Subscribe(subscriptionId, onMessage, x => x.WithTopic("#"));
+            Subscribe(subscriptionId, onMessage, x => { });
         }
 
         public void Subscribe<T>(string subscriptionId, Action<T> onMessage, Action<ISubscriptionConfiguration<T>> configure)
@@ -96,7 +96,7 @@ namespace EasyNetQ
 
         public void SubscribeAsync<T>(string subscriptionId, Func<T, Task> onMessage)
         {
-            SubscribeAsync(subscriptionId, onMessage, x => x.WithTopic("#"));
+            SubscribeAsync(subscriptionId, onMessage, x => { });
         }
 
         public void SubscribeAsync<T>(string subscriptionId, Func<T, Task> onMessage, Action<ISubscriptionConfiguration<T>> configure)
@@ -119,7 +119,15 @@ namespace EasyNetQ
 
             var queue = Queue.DeclareDurable(queueName, configuration.Arguments);
             var exchange = Exchange.DeclareTopic(exchangeName);
-            queue.BindTo(exchange, configuration.Topics.ToArray());
+
+            var topics = configuration.Topics.ToArray();
+
+            if(topics.Length == 0)
+            {
+                topics = new[]{"#"};
+            }
+
+            queue.BindTo(exchange, topics);
 
             advancedBus.Subscribe<T>(queue, (message, messageRecievedInfo) => onMessage(message.Body));
         }


### PR DESCRIPTION
When using the fluent configuration to specify other arguments the default
topic was not set. This pull will check whether you have specified a topic in your fluent configuration and default to "#". Not having a topic was throwing exceptions.
