### PR TITLE
Changed JsonSerializer to include .NET type information

### DIFF
--- a/Source/EasyNetQ.Tests/JsonSerializerTests.cs
+++ b/Source/EasyNetQ.Tests/JsonSerializerTests.cs
@@ -74,9 +74,24 @@ namespace EasyNetQ.Tests
 
             getPropertiesString(originalProperties).ShouldEqual(getPropertiesString(newProperties));
         }
+
+        class A { }
+        class B : A {}
+        class PolyMessage
+        {
+            public A AorB { get; set; }
+        }
+
+        [Test]
+        public void Should_be_able_to_serialize_and_deserialize_polymorphic_properties()
+        {
+            var bytes = serializer.MessageToBytes<PolyMessage>(new PolyMessage { AorB = new B() });
+
+            var result = serializer.BytesToMessage<PolyMessage>(bytes);
+
+            Assert.IsInstanceOf<B>(result.AorB);
+        }
     }
-
-
 }
 
 // ReSharper restore InconsistentNaming

--- a/Source/EasyNetQ/JsonSerializer.cs
+++ b/Source/EasyNetQ/JsonSerializer.cs
@@ -5,14 +5,19 @@ namespace EasyNetQ
 {
     public class JsonSerializer : ISerializer
     {
+        private readonly JsonSerializerSettings serializerSettings = new JsonSerializerSettings
+        {
+            TypeNameHandling = TypeNameHandling.Auto
+        };
+
         public byte[] MessageToBytes<T>(T message)
         {
-            return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message));
+            return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message, serializerSettings));
         }
 
         public T BytesToMessage<T>(byte[] bytes)
         {
-            return JsonConvert.DeserializeObject<T>(Encoding.UTF8.GetString(bytes));
+            return JsonConvert.DeserializeObject<T>(Encoding.UTF8.GetString(bytes), serializerSettings);
         }
     }
 }


### PR DESCRIPTION
.. when needed to allow polymorphic properties in messages.

This does not affect how messages are routed.
