### PR TITLE
use C# property names instead of underscored property names

### DIFF
--- a/Source/EasyNetQ.Management.Client.Tests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/ManagementClientTests.cs
@@ -29,21 +29,21 @@ namespace EasyNetQ.Management.Client.Tests
         {
             var overview = managementClient.GetOverview();
 
-            Console.Out.WriteLine("overview.management_version = {0}", overview.management_version);
-            foreach (var exchangeType in overview.exchange_types)
+            Console.Out.WriteLine("overview.management_version = {0}", overview.ManagementVersion);
+            foreach (var exchangeType in overview.ExchangeTypes)
             {
-                Console.Out.WriteLine("exchangeType.name = {0}", exchangeType.name);
+                Console.Out.WriteLine("exchangeType.name = {0}", exchangeType.Name);
             }
-            foreach (var listener in overview.listeners)
+            foreach (var listener in overview.Listeners)
             {
-                Console.Out.WriteLine("listener.ip_address = {0}", listener.ip_address);
+                Console.Out.WriteLine("listener.ip_address = {0}", listener.IpAddress);
             }
 
-            Console.Out.WriteLine("overview.queue_totals = {0}", overview.queue_totals.messages);
+            Console.Out.WriteLine("overview.queue_totals = {0}", overview.QueueTotals.Messages);
 
-            foreach (var context in overview.contexts)
+            foreach (var context in overview.Contexts)
             {
-                Console.Out.WriteLine("context.description = {0}", context.description);
+                Console.Out.WriteLine("context.description = {0}", context.Description);
             }
         }
 
@@ -53,7 +53,7 @@ namespace EasyNetQ.Management.Client.Tests
             var nodes = managementClient.GetNodes();
 
             nodes.Count().ShouldEqual(1);
-            nodes.First().name.ShouldEqual("rabbit@THOMAS");
+            nodes.First().Name.ShouldEqual("rabbit@THOMAS");
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace EasyNetQ.Management.Client.Tests
         {
             var definitions = managementClient.GetDefinitions();
 
-            definitions.rabbit_version.ShouldEqual("3.0.0");
+            definitions.RabbitVersion.ShouldEqual("3.0.0");
         }
 
         [Test]
@@ -71,14 +71,14 @@ namespace EasyNetQ.Management.Client.Tests
 
             foreach (var connection in connections)
             {
-                Console.Out.WriteLine("connection.name = {0}", connection.name);
-                Console.WriteLine("user:\t{0}", connection.client_properties.user);
-                Console.WriteLine("application:\t{0}", connection.client_properties.application);
-                Console.WriteLine("client_api:\t{0}", connection.client_properties.client_api);
-                Console.WriteLine("application_location:\t{0}", connection.client_properties.application_location);
-                Console.WriteLine("connected:\t{0}", connection.client_properties.connected);
-                Console.WriteLine("easynetq_version:\t{0}", connection.client_properties.easynetq_version);
-                Console.WriteLine("machine_name:\t{0}", connection.client_properties.machine_name);
+                Console.Out.WriteLine("connection.name = {0}", connection.Name);
+                Console.WriteLine("user:\t{0}", connection.ClientProperties.User);
+                Console.WriteLine("application:\t{0}", connection.ClientProperties.Application);
+                Console.WriteLine("client_api:\t{0}", connection.ClientProperties.ClientApi);
+                Console.WriteLine("application_location:\t{0}", connection.ClientProperties.ApplicationLocation);
+                Console.WriteLine("connected:\t{0}", connection.ClientProperties.Connected);
+                Console.WriteLine("easynetq_version:\t{0}", connection.ClientProperties.EasynetqVersion);
+                Console.WriteLine("machine_name:\t{0}", connection.ClientProperties.MachineName);
             }
         }
 
@@ -95,7 +95,7 @@ namespace EasyNetQ.Management.Client.Tests
         [Test, ExpectedException(typeof(EasyNetQManagementException))]
         public void Should_throw_when_trying_to_close_unknown_connection()
         {
-            var connection = new Connection {name = "unknown"};
+            var connection = new Connection {Name = "unknown"};
             managementClient.CloseConnection(connection);
         }
 
@@ -106,9 +106,9 @@ namespace EasyNetQ.Management.Client.Tests
 
             foreach (var channel in channels)
             {
-                Console.Out.WriteLine("channel.name = {0}", channel.name);
-                Console.Out.WriteLine("channel.user = {0}", channel.user);
-                Console.Out.WriteLine("channel.prefetch_count = {0}", channel.prefetch_count);
+                Console.Out.WriteLine("channel.name = {0}", channel.Name);
+                Console.Out.WriteLine("channel.user = {0}", channel.User);
+                Console.Out.WriteLine("channel.prefetch_count = {0}", channel.PrefetchCount);
             }
         }
 
@@ -119,7 +119,7 @@ namespace EasyNetQ.Management.Client.Tests
 
             foreach (Exchange exchange in exchanges)
             {
-                Console.Out.WriteLine("exchange.name = {0}", exchange.name);
+                Console.Out.WriteLine("exchange.name = {0}", exchange.Name);
             }
         }
 
@@ -128,26 +128,26 @@ namespace EasyNetQ.Management.Client.Tests
         [Test]
         public void Should_be_able_to_get_an_individual_exchange_by_name()
         {
-            var vhost = new Vhost { name = "/" };
+            var vhost = new Vhost { Name = "/" };
             var exchange = managementClient.GetExchange(testExchange, vhost);
 
-            exchange.name.ShouldEqual(testExchange);
+            exchange.Name.ShouldEqual(testExchange);
         }
 
         [Test]
         public void Should_be_able_to_create_an_exchange()
         {
-            var vhost = new Vhost {name = "/"};
+            var vhost = new Vhost {Name = "/"};
 
             var exchangeInfo = new ExchangeInfo(testExchange, "direct");
             var exchange = managementClient.CreateExchange(exchangeInfo, vhost);
-            exchange.name.ShouldEqual(testExchange);
+            exchange.Name.ShouldEqual(testExchange);
         }
 
         [Test]
         public void Should_be_able_to_delete_an_exchange()
         {
-            var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.name == testExchange);
+            var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.Name == testExchange);
             if (exchange == null)
             {
                 throw new ApplicationException(
@@ -160,7 +160,7 @@ namespace EasyNetQ.Management.Client.Tests
         [Test]
         public void Should_get_all_bindings_for_which_the_exchange_is_the_source()
         {
-            var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.name == testExchange);
+            var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.Name == testExchange);
             if (exchange == null)
             {
                 throw new ApplicationException(
@@ -171,14 +171,14 @@ namespace EasyNetQ.Management.Client.Tests
 
             foreach (var binding in bindings)
             {
-                Console.Out.WriteLine("binding.routing_key = {0}", binding.routing_key);
+                Console.Out.WriteLine("binding.routing_key = {0}", binding.RoutingKey);
             }
         }
 
         [Test]
         public void Should_get_all_bindings_for_which_the_exchange_is_the_destination()
         {
-            var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.name == testExchange);
+            var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.Name == testExchange);
             if (exchange == null)
             {
                 throw new ApplicationException(
@@ -189,14 +189,14 @@ namespace EasyNetQ.Management.Client.Tests
 
             foreach (var binding in bindings)
             {
-                Console.Out.WriteLine("binding.routing_key = {0}", binding.routing_key);
+                Console.Out.WriteLine("binding.routing_key = {0}", binding.RoutingKey);
             }
         }
 
         [Test]
         public void Should_be_able_to_publish_to_an_exchange()
         {
-            var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.name == testExchange);
+            var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.Name == testExchange);
             if (exchange == null)
             {
                 throw new ApplicationException(
@@ -207,7 +207,7 @@ namespace EasyNetQ.Management.Client.Tests
             var result = managementClient.Publish(exchange, publishInfo);
 
             // the testExchange isn't bound to a queue
-            result.routed.ShouldBeFalse();
+            result.Routed.ShouldBeFalse();
         }
 
         private const string testQueue = "management_api_test_queue";
@@ -219,16 +219,16 @@ namespace EasyNetQ.Management.Client.Tests
 
             foreach (Queue queue in queues)
             {
-                Console.Out.WriteLine("queue.name = {0}", queue.name);
+                Console.Out.WriteLine("queue.name = {0}", queue.Name);
             }
         }
 
         [Test]
         public void Should_be_able_to_get_a_queue_by_name()
         {
-            var vhost = new Vhost { name = "/" };
+            var vhost = new Vhost { Name = "/" };
             var queue = managementClient.GetQueue(testQueue, vhost);
-            queue.name.ShouldEqual(testQueue);
+            queue.Name.ShouldEqual(testQueue);
         }
 
         [Test]
@@ -237,13 +237,13 @@ namespace EasyNetQ.Management.Client.Tests
             var vhost = managementClient.GetVhost("/");
             var queueInfo = new QueueInfo(testQueue);
             var queue = managementClient.CreateQueue(queueInfo, vhost);
-            queue.name.ShouldEqual(testQueue);
+            queue.Name.ShouldEqual(testQueue);
         }
 
         [Test]
         public void Should_be_able_to_delete_a_queue()
         {
-            var queue = managementClient.GetQueues().SingleOrDefault(x => x.name == testQueue);
+            var queue = managementClient.GetQueues().SingleOrDefault(x => x.Name == testQueue);
             if (queue == null)
             {
                 throw new ApplicationException("Test queue has not been created");
@@ -255,7 +255,7 @@ namespace EasyNetQ.Management.Client.Tests
         [Test]
         public void Should_be_able_to_get_all_the_bindings_for_a_queue()
         {
-            var queue = managementClient.GetQueues().SingleOrDefault(x => x.name == testQueue);
+            var queue = managementClient.GetQueues().SingleOrDefault(x => x.Name == testQueue);
             if (queue == null)
             {
                 throw new ApplicationException("Test queue has not been created");
@@ -265,14 +265,14 @@ namespace EasyNetQ.Management.Client.Tests
 
             foreach (var binding in bindings)
             {
-                Console.Out.WriteLine("binding.routing_key = {0}", binding.routing_key);
+                Console.Out.WriteLine("binding.routing_key = {0}", binding.RoutingKey);
             }
         }
 
         [Test]
         public void Should_purge_a_queue()
         {
-            var queue = managementClient.GetQueues().SingleOrDefault(x => x.name == testQueue);
+            var queue = managementClient.GetQueues().SingleOrDefault(x => x.Name == testQueue);
             if (queue == null)
             {
                 throw new ApplicationException("Test queue has not been created");
@@ -284,13 +284,13 @@ namespace EasyNetQ.Management.Client.Tests
         [Test]
         public void Should_be_able_to_get_messages_from_a_queue()
         {
-            var queue = managementClient.GetQueues().SingleOrDefault(x => x.name == testQueue);
+            var queue = managementClient.GetQueues().SingleOrDefault(x => x.Name == testQueue);
             if (queue == null)
             {
                 throw new ApplicationException("Test queue has not been created");
             }
 
-            var defaultExchange = new Exchange { name = "amq.default", vhost = "/" };
+            var defaultExchange = new Exchange { Name = "amq.default", Vhost = "/" };
 
             var properties = new Dictionary<string, string>
             {
@@ -306,8 +306,8 @@ namespace EasyNetQ.Management.Client.Tests
 
             foreach (var message in messages)
             {
-                Console.Out.WriteLine("message.payload = {0}", message.payload);
-                foreach (var property in message.properties)
+                Console.Out.WriteLine("message.payload = {0}", message.Payload);
+                foreach (var property in message.Properties)
                 {
                     Console.Out.WriteLine("key: '{0}', value: '{1}'", property.Key, property.Value);
                 }
@@ -321,21 +321,21 @@ namespace EasyNetQ.Management.Client.Tests
 
             foreach (var binding in bindings)
             {
-                Console.Out.WriteLine("binding.destination = {0}", binding.destination);
-                Console.Out.WriteLine("binding.source = {0}", binding.source);
-                Console.Out.WriteLine("binding.properties_key = {0}", binding.properties_key);
+                Console.Out.WriteLine("binding.destination = {0}", binding.Destination);
+                Console.Out.WriteLine("binding.source = {0}", binding.Source);
+                Console.Out.WriteLine("binding.properties_key = {0}", binding.PropertiesKey);
             }
         }
 
         [Test]
         public void Should_be_able_to_get_a_list_of_bindings_between_an_exchange_and_a_queue()
         {
-            var queue = managementClient.GetQueues().SingleOrDefault(x => x.name == testQueue);
+            var queue = managementClient.GetQueues().SingleOrDefault(x => x.Name == testQueue);
             if (queue == null)
             {
                 throw new ApplicationException("Test queue has not been created");
             }
-            var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.name == testExchange);
+            var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.Name == testExchange);
             if (exchange == null)
             {
                 throw new ApplicationException(
@@ -346,8 +346,8 @@ namespace EasyNetQ.Management.Client.Tests
 
             foreach (var binding in bindings)
             {
-                Console.Out.WriteLine("binding.routing_key = {0}", binding.routing_key);
-                Console.Out.WriteLine("binding.properties_key = {0}", binding.properties_key);
+                Console.Out.WriteLine("binding.routing_key = {0}", binding.RoutingKey);
+                Console.Out.WriteLine("binding.properties_key = {0}", binding.PropertiesKey);
             }
         }
 
@@ -385,7 +385,7 @@ namespace EasyNetQ.Management.Client.Tests
 
             foreach (var vhost in vhosts)
             {
-                Console.Out.WriteLine("vhost.name = {0}", vhost.name);
+                Console.Out.WriteLine("vhost.name = {0}", vhost.Name);
             }
         }
 
@@ -395,14 +395,14 @@ namespace EasyNetQ.Management.Client.Tests
         public void Should_be_able_to_get_an_individual_vhost()
         {
             var vhost = managementClient.GetVhost(testVHost);
-            vhost.name.ShouldEqual(testVHost);
+            vhost.Name.ShouldEqual(testVHost);
         }
 
         [Test]
         public void Should_create_a_virtual_host()
         {
             var vhost = managementClient.CreateVirtualHost(testVHost);
-            vhost.name.ShouldEqual(testVHost);
+            vhost.Name.ShouldEqual(testVHost);
         }
 
         [Test]
@@ -419,7 +419,7 @@ namespace EasyNetQ.Management.Client.Tests
 
             foreach (var user in users)
             {
-                Console.Out.WriteLine("user.name = {0}", user.name);
+                Console.Out.WriteLine("user.name = {0}", user.Name);
             }
         }
 
@@ -429,7 +429,7 @@ namespace EasyNetQ.Management.Client.Tests
         public void Should_be_able_to_get_a_user_by_name()
         {
             var user = managementClient.GetUser(testUser);
-            user.name.ShouldEqual(testUser);
+            user.Name.ShouldEqual(testUser);
         }
 
         [Test]
@@ -438,7 +438,7 @@ namespace EasyNetQ.Management.Client.Tests
             var userInfo = new UserInfo(testUser, "topSecret").AddTag("administrator");
 
             var user = managementClient.CreateUser(userInfo);
-            user.name.ShouldEqual(testUser);
+            user.Name.ShouldEqual(testUser);
         }
 
         [Test]
@@ -455,23 +455,23 @@ namespace EasyNetQ.Management.Client.Tests
 
             foreach (var permission in permissions)
             {
-                Console.Out.WriteLine("permission.user = {0}", permission.user);
-                Console.Out.WriteLine("permission.vhost = {0}", permission.vhost);
-                Console.Out.WriteLine("permission.configure = {0}", permission.configure);
-                Console.Out.WriteLine("permission.read = {0}", permission.read);
-                Console.Out.WriteLine("permission.write = {0}", permission.write);
+                Console.Out.WriteLine("permission.user = {0}", permission.User);
+                Console.Out.WriteLine("permission.vhost = {0}", permission.Vhost);
+                Console.Out.WriteLine("permission.configure = {0}", permission.Configure);
+                Console.Out.WriteLine("permission.read = {0}", permission.Read);
+                Console.Out.WriteLine("permission.write = {0}", permission.Write);
             }
         }
 
         [Test]
         public void Should_be_able_to_create_permissions()
         {
-            var user = managementClient.GetUsers().SingleOrDefault(x => x.name == testUser);
+            var user = managementClient.GetUsers().SingleOrDefault(x => x.Name == testUser);
             if (user == null)
             {
                 throw new ApplicationException(string.Format("user '{0}' hasn't been created", testUser));
             }
-            var vhost = managementClient.GetVHosts().SingleOrDefault(x => x.name == testVHost);
+            var vhost = managementClient.GetVHosts().SingleOrDefault(x => x.Name == testVHost);
             if (vhost == null)
             {
                 throw new ApplicationException(string.Format("Test vhost: '{0}' has not been created", testVHost));
@@ -485,7 +485,7 @@ namespace EasyNetQ.Management.Client.Tests
         public void Should_be_able_to_delete_permissions()
         {
             var permission = managementClient.GetPermissions()
-                .SingleOrDefault(x => x.user == testUser && x.vhost == testVHost);
+                .SingleOrDefault(x => x.User == testUser && x.Vhost == testVHost);
 
             if (permission == null)
             {
@@ -499,7 +499,7 @@ namespace EasyNetQ.Management.Client.Tests
         [Test]
         public void Should_check_that_the_broker_is_alive()
         {
-            var vhost = managementClient.GetVHosts().SingleOrDefault(x => x.name == testVHost);
+            var vhost = managementClient.GetVHosts().SingleOrDefault(x => x.Name == testVHost);
             if (vhost == null)
             {
                 throw new ApplicationException(string.Format("Test vhost: '{0}' has not been created", testVHost));

--- a/Source/EasyNetQ.Management.Client.Tests/Model/MessageSerializationTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/MessageSerializationTests.cs
@@ -25,10 +25,10 @@ namespace EasyNetQ.Management.Client.Tests.Model
 
             var message = JsonConvert.DeserializeObject<Message>(json, new PropertyConverter());
 
-            message.properties.Count.ShouldEqual(1);
-            message.payload.ShouldEqual("Hello World");
-            message.properties["delivery_mode"].ShouldEqual("2");
-            message.properties.headers["key"].ShouldEqual("value");
+            message.Properties.Count.ShouldEqual(1);
+            message.Payload.ShouldEqual("Hello World");
+            message.Properties["delivery_mode"].ShouldEqual("2");
+            message.Properties.Headers["key"].ShouldEqual("value");
         }
 
         [Test]
@@ -41,7 +41,7 @@ namespace EasyNetQ.Management.Client.Tests.Model
 
             var message = JsonConvert.DeserializeObject<Message>(json, new PropertyConverter());
 
-            message.properties.Count.ShouldEqual(0);
+            message.Properties.Count.ShouldEqual(0);
         }
     }
 }

--- a/Source/EasyNetQ.Management.Client.Tests/Model/NodeSerializationTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/NodeSerializationTests.cs
@@ -28,8 +28,8 @@ namespace EasyNetQ.Management.Client.Tests.Model
         {
             var node = nodes[0];
 
-            node.name.ShouldEqual("rabbit@THOMAS");
-            node.uptime.ShouldEqual(98495039);
+            node.Name.ShouldEqual("rabbit@THOMAS");
+            node.Uptime.ShouldEqual(98495039);
         }
     }
 }

--- a/Source/EasyNetQ.Management.Client.Tests/Model/OverviewSerializationTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/OverviewSerializationTests.cs
@@ -20,16 +20,16 @@ namespace EasyNetQ.Management.Client.Tests.Model
         [Test]
         public void Should_contain_management_version()
         {
-            overview.management_version.ShouldEqual("2.8.6");
-            overview.statistics_level.ShouldEqual("fine");
+            overview.ManagementVersion.ShouldEqual("2.8.6");
+            overview.StatisticsLevel.ShouldEqual("fine");
         }
 
         [Test]
         public void Should_congtain_exchange_types()
         {
-            overview.exchange_types[0].name.ShouldEqual("topic");
-            overview.exchange_types[0].description.ShouldEqual("AMQP topic exchange, as per the AMQP specification");
-            overview.exchange_types[0].enabled.ShouldBeTrue();
+            overview.ExchangeTypes[0].Name.ShouldEqual("topic");
+            overview.ExchangeTypes[0].Description.ShouldEqual("AMQP topic exchange, as per the AMQP specification");
+            overview.ExchangeTypes[0].Enabled.ShouldBeTrue();
         }
     }
 }

--- a/Source/EasyNetQ.Management.Client.Tests/Model/PermissionInfoTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/PermissionInfoTests.cs
@@ -15,29 +15,29 @@ namespace EasyNetQ.Management.Client.Tests.Model
         [SetUp]
         public void SetUp()
         {
-            user = new User {name = "mikey"};
-            vhost = new Vhost {name = "theVHostName"};
+            user = new User { Name = "mikey" };
+            vhost = new Vhost { Name = "theVHostName" };
             permissionInfo = new PermissionInfo(user, vhost);
         }
 
         [Test]
         public void Should_return_the_correct_user_name()
         {
-            permissionInfo.GetUserName().ShouldEqual(user.name);
+            permissionInfo.GetUserName().ShouldEqual(user.Name);
         }
 
         [Test]
         public void Should_return_the_correct_vhost_name()
         {
-            permissionInfo.GetVirtualHostName().ShouldEqual(vhost.name);
+            permissionInfo.GetVirtualHostName().ShouldEqual(vhost.Name);
         }
 
         [Test]
         public void Should_set_default_permissions_to_allow_all()
         {
-            permissionInfo.configure.ShouldEqual(".*");
-            permissionInfo.write.ShouldEqual(".*");
-            permissionInfo.read.ShouldEqual(".*");
+            permissionInfo.Configure.ShouldEqual(".*");
+            permissionInfo.Write.ShouldEqual(".*");
+            permissionInfo.Read.ShouldEqual(".*");
         }
 
         [Test]
@@ -45,19 +45,19 @@ namespace EasyNetQ.Management.Client.Tests.Model
         {
             var permissions = permissionInfo.DenyAllConfigure().DenyAllRead().DenyAllWrite();
 
-            permissions.configure.ShouldEqual("^$");
-            permissions.write.ShouldEqual("^$");
-            permissions.read.ShouldEqual("^$");
+            permissions.Configure.ShouldEqual("^$");
+            permissions.Write.ShouldEqual("^$");
+            permissions.Read.ShouldEqual("^$");
         }
 
         [Test]
         public void Should_be_able_to_set_arbitrary_permissions()
         {
-            var permissions = permissionInfo.Configure("abc").Read("def").Write("xyz");
+            var permissions = permissionInfo.SetConfigure("abc").SetRead("def").SetWrite("xyz");
 
-            permissions.configure.ShouldEqual("abc");
-            permissions.write.ShouldEqual("xyz");
-            permissions.read.ShouldEqual("def");
+            permissions.Configure.ShouldEqual("abc");
+            permissions.Write.ShouldEqual("xyz");
+            permissions.Read.ShouldEqual("def");
         }
     }
 }

--- a/Source/EasyNetQ.Management.Client.Tests/Model/UserInfoTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/UserInfoTests.cs
@@ -23,14 +23,14 @@ namespace EasyNetQ.Management.Client.Tests.Model
         public void Should_have_correct_name_and_password()
         {
             userInfo.GetName().ShouldEqual(userName);
-            userInfo.password.ShouldEqual(password);
+            userInfo.Password.ShouldEqual(password);
         }
 
         [Test]
         public void Should_be_able_to_add_tags()
         {
             userInfo.AddTag("administrator").AddTag("management");
-            userInfo.tags.ShouldEqual("administrator,management");
+            userInfo.Tags.ShouldEqual("administrator,management");
         }
 
         [Test, ExpectedException(typeof(ArgumentException))]
@@ -48,7 +48,7 @@ namespace EasyNetQ.Management.Client.Tests.Model
         [Test]
         public void Should_have_a_default_tag_of_administrator()
         {
-            userInfo.tags.ShouldEqual("administrator");
+            userInfo.Tags.ShouldEqual("administrator");
         }
     }
 }

--- a/Source/EasyNetQ.Management.Client.Tests/ScenarioTest.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/ScenarioTest.cs
@@ -34,7 +34,7 @@ namespace EasyNetQ.Management.Client.Tests
             initial.CreatePermission(new PermissionInfo(user, vhost));
 
             // now log in again as the new user
-            var management = new ManagementClient("http://localhost", user.name, "topSecret");
+            var management = new ManagementClient("http://localhost", user.Name, "topSecret");
 
             // test that everything's OK
             management.IsAlive(vhost);
@@ -56,7 +56,7 @@ namespace EasyNetQ.Management.Client.Tests
 
             foreach (var message in messages)
             {
-                Console.Out.WriteLine("message.payload = {0}", message.payload);
+                Console.Out.WriteLine("message.payload = {0}", message.Payload);
             }
         }
     }

--- a/Source/EasyNetQ.Management.Client/EasyNetQ.Management.Client.csproj
+++ b/Source/EasyNetQ.Management.Client/EasyNetQ.Management.Client.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Model\UserInfo.cs" />
     <Compile Include="Model\Vhost.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RabbitContractResolver.cs" />
     <Compile Include="Serialization\PropertyConverter.cs" />
     <Compile Include="UnexpectedHttpStatusCodeException.cs" />
   </ItemGroup>

--- a/Source/EasyNetQ.Management.Client/ManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClient.cs
@@ -15,12 +15,20 @@ namespace EasyNetQ.Management.Client
         private readonly string username;
         private readonly string password;
         private readonly int portNumber;
+        private readonly JsonSerializerSettings settings;
 
         public ManagementClient(
-            string hostUrl, 
-            string username, 
-            string password) : this(hostUrl, username, password, 15672)
+            string hostUrl,
+            string username,
+            string password)
+            : this(hostUrl, username, password, 15672)
         {
+            settings = new JsonSerializerSettings
+            {
+                ContractResolver = new RabbitContractResolver(),
+            };
+
+            settings.Converters.Add(new PropertyConverter());
         }
 
         public string HostUrl
@@ -83,12 +91,12 @@ namespace EasyNetQ.Management.Client
 
         public void CloseConnection(Connection connection)
         {
-            if(connection == null)
+            if (connection == null)
             {
                 throw new ArgumentNullException("connection");
             }
 
-            Delete(string.Format("connections/{0}", connection.name));
+            Delete(string.Format("connections/{0}", connection.Name));
         }
 
         public IEnumerable<Channel> GetChannels()
@@ -104,74 +112,74 @@ namespace EasyNetQ.Management.Client
         public Exchange GetExchange(string exchangeName, Vhost vhost)
         {
             return Get<Exchange>(string.Format("exchanges/{0}/{1}",
-                SanitiseVhostName(vhost.name), exchangeName));
+                SanitiseVhostName(vhost.Name), exchangeName));
         }
 
         public Queue GetQueue(string queueName, Vhost vhost)
         {
             return Get<Queue>(string.Format("queues/{0}/{1}",
-                SanitiseVhostName(vhost.name), queueName));
+                SanitiseVhostName(vhost.Name), queueName));
         }
 
         public Exchange CreateExchange(ExchangeInfo exchangeInfo, Vhost vhost)
         {
-            if(exchangeInfo == null)
+            if (exchangeInfo == null)
             {
                 throw new ArgumentNullException("exchangeInfo");
             }
-            if(vhost == null)
+            if (vhost == null)
             {
                 throw new ArgumentNullException("vhost");
             }
 
-            Put(string.Format("exchanges/{0}/{1}", SanitiseVhostName(vhost.name), exchangeInfo.GetName()), exchangeInfo);
+            Put(string.Format("exchanges/{0}/{1}", SanitiseVhostName(vhost.Name), exchangeInfo.GetName()), exchangeInfo);
 
             return GetExchange(exchangeInfo.GetName(), vhost);
         }
 
         public void DeleteExchange(Exchange exchange)
         {
-            if(exchange == null)
+            if (exchange == null)
             {
                 throw new ArgumentNullException("exchange");
             }
 
-            Delete(string.Format("exchanges/{0}/{1}", SanitiseVhostName(exchange.vhost), exchange.name));
+            Delete(string.Format("exchanges/{0}/{1}", SanitiseVhostName(exchange.Vhost), exchange.Name));
         }
 
         public IEnumerable<Binding> GetBindingsWithSource(Exchange exchange)
         {
-            if(exchange == null)
+            if (exchange == null)
             {
                 throw new ArgumentNullException("exchange");
             }
 
-            return Get<IEnumerable<Binding>>(string.Format("exchanges/{0}/{1}/bindings/source", SanitiseVhostName(exchange.vhost), exchange.name));
+            return Get<IEnumerable<Binding>>(string.Format("exchanges/{0}/{1}/bindings/source", SanitiseVhostName(exchange.Vhost), exchange.Name));
         }
 
         public IEnumerable<Binding> GetBindingsWithDestination(Exchange exchange)
         {
-            if(exchange == null)
+            if (exchange == null)
             {
                 throw new ArgumentNullException("exchange");
             }
 
-            return Get<IEnumerable<Binding>>(string.Format("exchanges/{0}/{1}/bindings/destination", SanitiseVhostName(exchange.vhost), exchange.name));
+            return Get<IEnumerable<Binding>>(string.Format("exchanges/{0}/{1}/bindings/destination", SanitiseVhostName(exchange.Vhost), exchange.Name));
         }
 
         public PublishResult Publish(Exchange exchange, PublishInfo publishInfo)
         {
-            if(exchange == null)
+            if (exchange == null)
             {
                 throw new ArgumentNullException("exchange");
             }
-            if(publishInfo == null)
+            if (publishInfo == null)
             {
                 throw new ArgumentNullException("publishInfo");
             }
 
             return Post<PublishInfo, PublishResult>(
-                string.Format("exchanges/{0}/{1}/publish", SanitiseVhostName(exchange.vhost), exchange.name), 
+                string.Format("exchanges/{0}/{1}/publish", SanitiseVhostName(exchange.Vhost), exchange.Name),
                 publishInfo);
         }
 
@@ -182,60 +190,60 @@ namespace EasyNetQ.Management.Client
 
         public Queue CreateQueue(QueueInfo queueInfo, Vhost vhost)
         {
-            if(queueInfo == null)
+            if (queueInfo == null)
             {
                 throw new ArgumentNullException("queueInfo");
             }
-            if(vhost == null)
+            if (vhost == null)
             {
                 throw new ArgumentNullException("vhost");
             }
 
-            Put(string.Format("queues/{0}/{1}", SanitiseVhostName(vhost.name), queueInfo.GetName()), queueInfo);
+            Put(string.Format("queues/{0}/{1}", SanitiseVhostName(vhost.Name), queueInfo.GetName()), queueInfo);
 
             return GetQueue(queueInfo.GetName(), vhost);
         }
 
         public void DeleteQueue(Queue queue)
         {
-            if(queue == null)
+            if (queue == null)
             {
                 throw new ArgumentNullException("queue");
             }
 
-            Delete(string.Format("queues/{0}/{1}", SanitiseVhostName(queue.vhost), queue.name));
+            Delete(string.Format("queues/{0}/{1}", SanitiseVhostName(queue.Vhost), queue.Name));
         }
 
         public IEnumerable<Binding> GetBindingsForQueue(Queue queue)
         {
-            if(queue == null)
+            if (queue == null)
             {
                 throw new ArgumentNullException("queue");
             }
 
             return Get<IEnumerable<Binding>>(
-                string.Format("queues/{0}/{1}/bindings", SanitiseVhostName(queue.vhost), queue.name));
+                string.Format("queues/{0}/{1}/bindings", SanitiseVhostName(queue.Vhost), queue.Name));
         }
 
         public void Purge(Queue queue)
         {
-            if(queue == null)
+            if (queue == null)
             {
                 throw new ArgumentNullException("queue");
             }
 
-            Delete(string.Format("queues/{0}/{1}/contents", SanitiseVhostName(queue.vhost), queue.name));
+            Delete(string.Format("queues/{0}/{1}/contents", SanitiseVhostName(queue.Vhost), queue.Name));
         }
 
         public IEnumerable<Message> GetMessagesFromQueue(Queue queue, GetMessagesCriteria criteria)
         {
-            if(queue == null)
+            if (queue == null)
             {
                 throw new ArgumentNullException("queue");
             }
 
             return Post<GetMessagesCriteria, IEnumerable<Message>>(
-                string.Format("queues/{0}/{1}/get", SanitiseVhostName(queue.vhost), queue.name),
+                string.Format("queues/{0}/{1}/get", SanitiseVhostName(queue.Vhost), queue.Name),
                 criteria);
         }
 
@@ -246,52 +254,52 @@ namespace EasyNetQ.Management.Client
 
         public void CreateBinding(Exchange exchange, Queue queue, BindingInfo bindingInfo)
         {
-            if(exchange == null)
+            if (exchange == null)
             {
                 throw new ArgumentNullException("exchange");
             }
-            if(queue == null)
+            if (queue == null)
             {
                 throw new ArgumentNullException("queue");
             }
-            if(bindingInfo == null)
+            if (bindingInfo == null)
             {
                 throw new ArgumentNullException("bindingInfo");
             }
 
             Post<BindingInfo, object>(
-                string.Format("bindings/{0}/e/{1}/q/{2}", SanitiseVhostName(queue.vhost), exchange.name, queue.name), 
+                string.Format("bindings/{0}/e/{1}/q/{2}", SanitiseVhostName(queue.Vhost), exchange.Name, queue.Name),
                 bindingInfo);
         }
 
         public IEnumerable<Binding> GetBindings(Exchange exchange, Queue queue)
         {
-            if(exchange == null)
+            if (exchange == null)
             {
                 throw new ArgumentNullException("exchange");
             }
-            if(queue == null)
+            if (queue == null)
             {
                 throw new ArgumentNullException("queue");
             }
 
             return Get<IEnumerable<Binding>>(
-                string.Format("bindings/{0}/e/{1}/q/{2}", SanitiseVhostName(queue.vhost),
-                    exchange.name, queue.name));
+                string.Format("bindings/{0}/e/{1}/q/{2}", SanitiseVhostName(queue.Vhost),
+                    exchange.Name, queue.Name));
         }
 
         public void DeleteBinding(Binding binding)
         {
-            if(binding == null)
+            if (binding == null)
             {
                 throw new ArgumentNullException("binding");
             }
 
-            Delete(string.Format("bindings/{0}/e/{1}/q/{2}/{3}", 
-                SanitiseVhostName(binding.vhost),
-                binding.source, 
-                binding.destination, 
-                RecodeBindingPropertiesKey(binding.properties_key)));
+            Delete(string.Format("bindings/{0}/e/{1}/q/{2}/{3}",
+                SanitiseVhostName(binding.Vhost),
+                binding.Source,
+                binding.Destination,
+                RecodeBindingPropertiesKey(binding.PropertiesKey)));
         }
 
         public IEnumerable<Vhost> GetVHosts()
@@ -306,7 +314,7 @@ namespace EasyNetQ.Management.Client
 
         public Vhost CreateVirtualHost(string virtualHostName)
         {
-            if(string.IsNullOrEmpty(virtualHostName))
+            if (string.IsNullOrEmpty(virtualHostName))
             {
                 throw new ArgumentException("virtualHostName is null or empty");
             }
@@ -318,12 +326,12 @@ namespace EasyNetQ.Management.Client
 
         public void DeleteVirtualHost(Vhost vhost)
         {
-            if(vhost == null)
+            if (vhost == null)
             {
                 throw new ArgumentNullException("vhost");
             }
 
-            Delete(string.Format("vhosts/{0}", vhost.name));
+            Delete(string.Format("vhosts/{0}", vhost.Name));
         }
 
         public IEnumerable<User> GetUsers()
@@ -338,7 +346,7 @@ namespace EasyNetQ.Management.Client
 
         public User CreateUser(UserInfo userInfo)
         {
-            if(userInfo == null)
+            if (userInfo == null)
             {
                 throw new ArgumentNullException("userInfo");
             }
@@ -350,12 +358,12 @@ namespace EasyNetQ.Management.Client
 
         public void DeleteUser(User user)
         {
-            if(user == null)
+            if (user == null)
             {
                 throw new ArgumentNullException("user");
             }
 
-            Delete(string.Format("users/{0}", user.name));
+            Delete(string.Format("users/{0}", user.Name));
         }
 
 
@@ -366,40 +374,40 @@ namespace EasyNetQ.Management.Client
 
         public void CreatePermission(PermissionInfo permissionInfo)
         {
-            if(permissionInfo == null)
+            if (permissionInfo == null)
             {
                 throw new ArgumentNullException("permissionInfo");
             }
 
-            Put(string.Format("permissions/{0}/{1}", 
-                    permissionInfo.GetVirtualHostName(), 
-                    permissionInfo.GetUserName()), 
+            Put(string.Format("permissions/{0}/{1}",
+                    permissionInfo.GetVirtualHostName(),
+                    permissionInfo.GetUserName()),
                 permissionInfo);
         }
 
         public void DeletePermission(Permission permission)
         {
-            if(permission == null)
+            if (permission == null)
             {
                 throw new ArgumentNullException("permission");
             }
 
             Delete(string.Format("permissions/{0}/{1}",
-                permission.vhost,
-                permission.user));
+                permission.Vhost,
+                permission.User));
         }
 
         public bool IsAlive(Vhost vhost)
         {
-            if(vhost == null)
+            if (vhost == null)
             {
                 throw new ArgumentNullException("vhost");
             }
 
             var result = Get<AlivenessTestResult>(string.Format("aliveness-test/{0}",
-                SanitiseVhostName(vhost.name)));
+                SanitiseVhostName(vhost.Name)));
 
-            return result.status == "ok";
+            return result.Status == "ok";
         }
 
         private T Get<T>(string path)
@@ -496,10 +504,11 @@ namespace EasyNetQ.Management.Client
             }
         }
 
-        private static void InsertRequestBody<T>(HttpWebRequest request, T item)
+        private void InsertRequestBody<T>(HttpWebRequest request, T item)
         {
             request.ContentType = "application/json";
-            var body = JsonConvert.SerializeObject(item);
+
+            var body = JsonConvert.SerializeObject(item, settings);
             using (var requestStream = request.GetRequestStream())
             using (var writer = new StreamWriter(requestStream))
             {
@@ -507,10 +516,10 @@ namespace EasyNetQ.Management.Client
             }
         }
 
-        private static T DeserializeResponse<T>(HttpWebResponse response)
+        private T DeserializeResponse<T>(HttpWebResponse response)
         {
             var responseBody = GetBodyFromResponse(response);
-            return JsonConvert.DeserializeObject<T>(responseBody, new PropertyConverter());
+            return JsonConvert.DeserializeObject<T>(responseBody, settings);
         }
 
         private static string GetBodyFromResponse(HttpWebResponse response)

--- a/Source/EasyNetQ.Management.Client/Model/AlivenessTestResult.cs
+++ b/Source/EasyNetQ.Management.Client/Model/AlivenessTestResult.cs
@@ -2,6 +2,6 @@
 {
     public class AlivenessTestResult
     {
-        public string status { get; set; }     
+        public string Status { get; set; }     
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/Application.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Application.cs
@@ -2,8 +2,8 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class Application
     {
-        public string name { get; set; }
-        public string description { get; set; }
-        public string version { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string Version { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/AuthMechanism.cs
+++ b/Source/EasyNetQ.Management.Client/Model/AuthMechanism.cs
@@ -2,8 +2,8 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class AuthMechanism
     {
-        public string name { get; set; }
-        public string description { get; set; }
-        public bool enabled { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public bool Enabled { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/BackingQueueStatus.cs
+++ b/Source/EasyNetQ.Management.Client/Model/BackingQueueStatus.cs
@@ -4,21 +4,21 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class BackingQueueStatus
     {
-        public int q1 { get; set; }
-        public int q2 { get; set; }
-        public List<object> delta { get; set; }
-        public int q3 { get; set; }
-        public int q4 { get; set; }
-        public int len { get; set; }
-        public int pending_acks { get; set; }
-        public string target_ram_count { get; set; }
-        public int ram_msg_count { get; set; }
-        public int ram_ack_count { get; set; }
-        public int next_seq_id { get; set; }
-        public int persistent_count { get; set; }
-        public double avg_ingress_rate { get; set; }
-        public double avg_egress_rate { get; set; }
-        public double avg_ack_ingress_rate { get; set; }
-        public double avg_ack_egress_rate { get; set; }
+        public int Q1 { get; set; }
+        public int Q2 { get; set; }
+        public List<object> Delta { get; set; }
+        public int Q3 { get; set; }
+        public int Q4 { get; set; }
+        public int Len { get; set; }
+        public int PendingAcks { get; set; }
+        public string TargetRamCount { get; set; }
+        public int RamMsgCount { get; set; }
+        public int RamAckCount { get; set; }
+        public int NextSeqId { get; set; }
+        public int PersistentCount { get; set; }
+        public double AvgIngressRate { get; set; }
+        public double AvgEgressRate { get; set; }
+        public double AvgAckIngressRate { get; set; }
+        public double AvgAckEgressRate { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/Binding.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Binding.cs
@@ -2,12 +2,12 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class Binding
     {
-        public string source { get; set; }
-        public string vhost { get; set; }
-        public string destination { get; set; }
-        public string destination_type { get; set; }
-        public string routing_key { get; set; }
-        public Arguments arguments { get; set; }
-        public string properties_key { get; set; }
+        public string Source { get; set; }
+        public string Vhost { get; set; }
+        public string Destination { get; set; }
+        public string DestinationType { get; set; }
+        public string RoutingKey { get; set; }
+        public Arguments Arguments { get; set; }
+        public string PropertiesKey { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/BindingInfo.cs
+++ b/Source/EasyNetQ.Management.Client/Model/BindingInfo.cs
@@ -2,16 +2,17 @@
 {
     public class BindingInfo
     {
-        public string routing_key { get; private set; }
-        public InputArguments arguments { get; private set; }
+        public string RoutingKey { get; private set; }
+        public InputArguments Arguments { get; private set; }
 
         public BindingInfo(string routingKey, InputArguments arguments)
         {
-            routing_key = routingKey;
-            this.arguments = arguments;
+            RoutingKey = routingKey;
+            Arguments = arguments;
         }
 
-        public BindingInfo(string routingKey) : this(routingKey, new InputArguments())
+        public BindingInfo(string routingKey)
+            : this(routingKey, new InputArguments())
         {
         }
     }

--- a/Source/EasyNetQ.Management.Client/Model/Capabilities.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Capabilities.cs
@@ -2,9 +2,9 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class Capabilities
     {
-        public bool basic_nack { get; set; }
-        public bool publisher_confirms { get; set; }
-        public bool consumer_cancel_notify { get; set; }
-        public bool exchange_exchange_bindings { get; set; }
+        public bool BasicNack { get; set; }
+        public bool PublisherConfirms { get; set; }
+        public bool ConsumerCancelNotify { get; set; }
+        public bool ExchangeExchangeBindings { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/Channel.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Channel.cs
@@ -2,21 +2,21 @@
 {
     public class Channel
     {
-        public ConnectionDetails connection_details { get; set; }
-        public string idle_since { get; set; }
-        public bool transactional { get; set; }
-        public bool confirm { get; set; }
-        public int consumer_count { get; set; }
-        public int messages_unacknowledged { get; set; }
-        public int messages_unconfirmed { get; set; }
-        public int messages_uncommitted { get; set; }
-        public int acks_uncommitted { get; set; }
-        public int prefetch_count { get; set; }
-        public bool client_flow_blocked { get; set; }
-        public string node { get; set; }
-        public string name { get; set; }
-        public int number { get; set; }
-        public string user { get; set; }
-        public string vhost { get; set; }
+        public ConnectionDetails ConnectionDetails { get; set; }
+        public string IdleSince { get; set; }
+        public bool Transactional { get; set; }
+        public bool Confirm { get; set; }
+        public int ConsumerCount { get; set; }
+        public int MessagesUnacknowledged { get; set; }
+        public int MessagesUnconfirmed { get; set; }
+        public int MessagesUncommitted { get; set; }
+        public int AcksUncommitted { get; set; }
+        public int PrefetchCount { get; set; }
+        public bool ClientFlowBlocked { get; set; }
+        public string Node { get; set; }
+        public string Name { get; set; }
+        public int Number { get; set; }
+        public string User { get; set; }
+        public string Vhost { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/ClientProperties.cs
+++ b/Source/EasyNetQ.Management.Client/Model/ClientProperties.cs
@@ -4,13 +4,13 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class ClientProperties
     {
-        public Capabilities capabilities { get; set; }
-        public string user { get; set; }
-        public string application { get; set; }
-        public string client_api { get; set; }
-        public string application_location { get; set; }
-        public DateTime connected { get; set; }
-        public string easynetq_version { get; set; }
-        public string machine_name { get; set; }
+        public Capabilities Capabilities { get; set; }
+        public string User { get; set; }
+        public string Application { get; set; }
+        public string ClientApi { get; set; }
+        public string ApplicationLocation { get; set; }
+        public DateTime Connected { get; set; }
+        public string EasynetqVersion { get; set; }
+        public string MachineName { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/Connection.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Connection.cs
@@ -2,36 +2,36 @@
 {
     public class Connection
     {
-        public int recv_oct { get; set; }
-        public int recv_cnt { get; set; }
-        public int send_oct { get; set; }
-        public int send_cnt { get; set; }
-        public int send_pend { get; set; }
-        public string state { get; set; }
-        public string last_blocked_by { get; set; }
-        public string last_blocked_age { get; set; }
-        public int channels { get; set; }
-        public string type { get; set; }
-        public string node { get; set; }
-        public string name { get; set; }
-        public string address { get; set; }
-        public int port { get; set; }
-        public string peer_address { get; set; }
-        public int peer_port { get; set; }
-        public bool ssl { get; set; }
-        public string peer_cert_subject { get; set; }
-        public string peer_cert_issuer { get; set; }
-        public string peer_cert_validity { get; set; }
-        public string auth_mechanism { get; set; }
-        public string ssl_protocol { get; set; }
-        public string ssl_key_exchange { get; set; }
-        public string ssl_cipher { get; set; }
-        public string ssl_hash { get; set; }
-        public string protocol { get; set; }
-        public string user { get; set; }
-        public string vhost { get; set; }
-        public int timeout { get; set; }
-        public int frame_max { get; set; }
-        public ClientProperties client_properties { get; set; }
+        public int RecvOct { get; set; }
+        public int RecvCnt { get; set; }
+        public int SendOct { get; set; }
+        public int SendCnt { get; set; }
+        public int SendPend { get; set; }
+        public string State { get; set; }
+        public string LastBlockedBy { get; set; }
+        public string LastBlockedAge { get; set; }
+        public int Channels { get; set; }
+        public string Type { get; set; }
+        public string Node { get; set; }
+        public string Name { get; set; }
+        public string Address { get; set; }
+        public int Port { get; set; }
+        public string PeerAddress { get; set; }
+        public int PeerPort { get; set; }
+        public bool Ssl { get; set; }
+        public string PeerCertSubject { get; set; }
+        public string PeerCertIssuer { get; set; }
+        public string PeerCertValidity { get; set; }
+        public string AuthMechanism { get; set; }
+        public string SslProtocol { get; set; }
+        public string SslKeyExchange { get; set; }
+        public string SslCipher { get; set; }
+        public string SslHash { get; set; }
+        public string Protocol { get; set; }
+        public string User { get; set; }
+        public string Vhost { get; set; }
+        public int Timeout { get; set; }
+        public int FrameMax { get; set; }
+        public ClientProperties ClientProperties { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/ConnectionDetails.cs
+++ b/Source/EasyNetQ.Management.Client/Model/ConnectionDetails.cs
@@ -2,8 +2,8 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class ConnectionDetails
     {
-        public string name { get; set; }
-        public string peer_address { get; set; }
-        public int peer_port { get; set; }
+        public string Name { get; set; }
+        public string PeerAddress { get; set; }
+        public int PeerPort { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/Context.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Context.cs
@@ -2,9 +2,9 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class Context
     {
-        public string node { get; set; }
-        public string description { get; set; }
-        public string path { get; set; }
-        public int port { get; set; }
+        public string Node { get; set; }
+        public string Description { get; set; }
+        public string Path { get; set; }
+        public int Port { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/Definitions.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Definitions.cs
@@ -4,12 +4,12 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class Definitions
     {
-        public string rabbit_version { get; set; }
-        public List<User> users { get; set; }
-        public List<Vhost> vhosts { get; set; }
-        public List<Permission> permissions { get; set; }
-        public List<Queue> queues { get; set; }
-        public List<Exchange> exchanges { get; set; }
-        public List<Binding> bindings { get; set; }
+        public string RabbitVersion { get; set; }
+        public List<User> Users { get; set; }
+        public List<Vhost> Vhosts { get; set; }
+        public List<Permission> Permissions { get; set; }
+        public List<Queue> Queues { get; set; }
+        public List<Exchange> Exchanges { get; set; }
+        public List<Binding> Bindings { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/Exchange.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Exchange.cs
@@ -2,12 +2,12 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class Exchange
     {
-        public string name { get; set; }
-        public string vhost { get; set; }
-        public string type { get; set; }
-        public bool durable { get; set; }
-        public bool auto_delete { get; set; }
-        public bool @internal { get; set; }
-        public Arguments arguments { get; set; }
+        public string Name { get; set; }
+        public string Vhost { get; set; }
+        public string Type { get; set; }
+        public bool Durable { get; set; }
+        public bool AutoDelete { get; set; }
+        public bool Internal { get; set; }
+        public Arguments Arguments { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/ExchangeInfo.cs
+++ b/Source/EasyNetQ.Management.Client/Model/ExchangeInfo.cs
@@ -5,11 +5,11 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class ExchangeInfo
     {
-        public string type { get; private set; }
-        public bool auto_delete { get; private set; }
-        public bool durable { get; private set; }
-        public bool @internal { get; private set; }
-        public Arguments arguments { get; private set; }
+        public string Type { get; private set; }
+        public bool AutoDelete { get; private set; }
+        public bool Durable { get; private set; }
+        public bool Internal { get; private set; }
+        public Arguments Arguments { get; private set; }
 
         private readonly string name;
 
@@ -40,11 +40,11 @@ namespace EasyNetQ.Management.Client.Model
             }
 
             this.name = name;
-            this.type = type;
-            auto_delete = autoDelete;
-            this.durable = durable;
-            this.@internal = @internal;
-            this.arguments = arguments;
+            Type = type;
+            AutoDelete = autoDelete;
+            Durable = durable;
+            Internal = @internal;
+            Arguments = arguments;
         }
 
         public string GetName()

--- a/Source/EasyNetQ.Management.Client/Model/ExchangeType.cs
+++ b/Source/EasyNetQ.Management.Client/Model/ExchangeType.cs
@@ -2,8 +2,8 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class ExchangeType
     {
-        public string name { get; set; }
-        public string description { get; set; }
-        public bool enabled { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public bool Enabled { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/GetMessagesCriteria.cs
+++ b/Source/EasyNetQ.Management.Client/Model/GetMessagesCriteria.cs
@@ -5,9 +5,9 @@
     /// </summary>
     public class GetMessagesCriteria
     {
-        public long count { get; private set; }
-        public bool requeue { get; private set; }
-        public string encoding { get; private set; }
+        public long Count { get; private set; }
+        public bool Requeue { get; private set; }
+        public string Encoding { get; private set; }
 
         /// <summary>
         /// Constructor
@@ -23,9 +23,9 @@
         /// </param>
         public GetMessagesCriteria(long count, bool requeue)
         {
-            this.requeue = requeue;
-            this.count = count;
-            encoding = "auto";
+            Requeue = requeue;
+            Count = count;
+            Encoding = "auto";
         }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/Listener.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Listener.cs
@@ -2,9 +2,9 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class Listener
     {
-        public string node { get; set; }
-        public string protocol { get; set; }
-        public string ip_address { get; set; }
-        public int port { get; set; }
+        public string Node { get; set; }
+        public string Protocol { get; set; }
+        public string IpAddress { get; set; }
+        public int Port { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/Message.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Message.cs
@@ -6,21 +6,21 @@ namespace EasyNetQ.Management.Client.Model
     {
         public Properties()
         {
-            headers = new Dictionary<string, string>();
+            Headers = new Dictionary<string, string>();
         }
 
-        public Dictionary<string, string> headers { get; set; } 
+        public Dictionary<string, string> Headers { get; set; } 
     }
 
     public class Message
     {
-        public int payload_bytes { get; set; }
-        public bool redelivered { get; set; }
-        public string exchange { get; set; }
-        public string routing_key { get; set; }
-        public int message_count { get; set; }
-        public Properties properties { get; set; }
-        public string payload { get; set; }
-        public string payload_encoding { get; set; }
+        public int PayloadBytes { get; set; }
+        public bool Redelivered { get; set; }
+        public string Exchange { get; set; }
+        public string RoutingKey { get; set; }
+        public int MessageCount { get; set; }
+        public Properties Properties { get; set; }
+        public string Payload { get; set; }
+        public string PayloadEncoding { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/MessagesDetails.cs
+++ b/Source/EasyNetQ.Management.Client/Model/MessagesDetails.cs
@@ -2,8 +2,8 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class MessagesDetails
     {
-        public long rate { get; set; }
-        public long interval { get; set; }
-        public long last_event { get; set; }
+        public long Rate { get; set; }
+        public long Interval { get; set; }
+        public long LastEvent { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/MessagesReadyDetails.cs
+++ b/Source/EasyNetQ.Management.Client/Model/MessagesReadyDetails.cs
@@ -2,8 +2,8 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class MessagesReadyDetails
     {
-        public long rate { get; set; }
-        public long longerval { get; set; }
-        public long last_event { get; set; }
+        public long Rate { get; set; }
+        public long Longerval { get; set; }
+        public long LastEvent { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/MessagesUnacknowledgedDetails.cs
+++ b/Source/EasyNetQ.Management.Client/Model/MessagesUnacknowledgedDetails.cs
@@ -2,8 +2,8 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class MessagesUnacknowledgedDetails
     {
-        public long rate { get; set; }
-        public long longerval { get; set; }
-        public long last_event { get; set; }
+        public long Rate { get; set; }
+        public long Longerval { get; set; }
+        public long LastEvent { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/Node.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Node.cs
@@ -4,36 +4,36 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class Node
     {
-        public string name { get; set; }
-        public string type { get; set; }
-        public bool running { get; set; }
-        public string os_pid { get; set; }
-        public int mem_ets { get; set; }
-        public int mem_binary { get; set; }
-        public int mem_proc { get; set; }
-        public int mem_proc_used { get; set; }
-        public int mem_atom { get; set; }
-        public int mem_atom_used { get; set; }
-        public int mem_code { get; set; }
-        public string fd_used { get; set; }
-        public int fd_total { get; set; }
-        public int sockets_used { get; set; }
-        public int sockets_total { get; set; }
-        public int mem_used { get; set; }
-        public long mem_limit { get; set; }
-        public bool mem_alarm { get; set; }
-        public int disk_free_limit { get; set; }
-        public long disk_free { get; set; }
-        public bool disk_free_alarm { get; set; }
-        public int proc_used { get; set; }
-        public int proc_total { get; set; }
-        public string statistics_level { get; set; }
-        public string erlang_version { get; set; }
-        public int uptime { get; set; }
-        public int run_queue { get; set; }
-        public int processors { get; set; }
-        public List<ExchangeType> exchange_types { get; set; }
-        public List<AuthMechanism> auth_mechanisms { get; set; }
-        public List<Application> applications { get; set; }
+        public string Name { get; set; }
+        public string Type { get; set; }
+        public bool Running { get; set; }
+        public string OsPid { get; set; }
+        public int MemEts { get; set; }
+        public int MemBinary { get; set; }
+        public int MemProc { get; set; }
+        public int MemProcUsed { get; set; }
+        public int MemAtom { get; set; }
+        public int MemAtomUsed { get; set; }
+        public int MemCode { get; set; }
+        public string FdUsed { get; set; }
+        public int FdTotal { get; set; }
+        public int SocketsUsed { get; set; }
+        public int SocketsTotal { get; set; }
+        public int MemUsed { get; set; }
+        public long MemLimit { get; set; }
+        public bool MemAlarm { get; set; }
+        public int DiskFreeLimit { get; set; }
+        public long DiskFree { get; set; }
+        public bool DiskFreeAlarm { get; set; }
+        public int ProcUsed { get; set; }
+        public int ProcTotal { get; set; }
+        public string StatisticsLevel { get; set; }
+        public string ErlangVersion { get; set; }
+        public int Uptime { get; set; }
+        public int RunQueue { get; set; }
+        public int Processors { get; set; }
+        public List<ExchangeType> ExchangeTypes { get; set; }
+        public List<AuthMechanism> AuthMechanisms { get; set; }
+        public List<Application> Applications { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/Overview.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Overview.cs
@@ -4,26 +4,26 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class Overview
     {
-        public string management_version { get; set; }
-        public string statistics_level { get; set; }
-        public List<ExchangeType> exchange_types { get; set; }
-        public string rabbitmq_version { get; set; }
-        public string erlang_version { get; set; }
-        public List<object> message_stats { get; set; }
-        public QueueTotals queue_totals { get; set; }
-        public ObjectTotals object_totals { get; set; }
-        public string node { get; set; }
-        public string statistics_db_node { get; set; }
-        public List<Listener> listeners { get; set; }
-        public List<Context> contexts { get; set; }
+        public string ManagementVersion { get; set; }
+        public string StatisticsLevel { get; set; }
+        public List<ExchangeType> ExchangeTypes { get; set; }
+        public string RabbitmqVersion { get; set; }
+        public string ErlangVersion { get; set; }
+        public List<object> MessageStats { get; set; }
+        public QueueTotals QueueTotals { get; set; }
+        public ObjectTotals ObjectTotals { get; set; }
+        public string Node { get; set; }
+        public string StatisticsDbNode { get; set; }
+        public List<Listener> Listeners { get; set; }
+        public List<Context> Contexts { get; set; }
     }
 
     public class ObjectTotals
     {
-        public int consumers { get; set; }
-        public int queues { get; set; }
-        public int exchanges { get; set; }
-        public int connections { get; set; }
-        public int channels { get; set; }
+        public int Consumers { get; set; }
+        public int Queues { get; set; }
+        public int Exchanges { get; set; }
+        public int Connections { get; set; }
+        public int Channels { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/Permission.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Permission.cs
@@ -2,10 +2,10 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class Permission
     {
-        public string user { get; set; }
-        public string vhost { get; set; }
-        public string configure { get; set; }
-        public string write { get; set; }
-        public string read { get; set; }
+        public string User { get; set; }
+        public string Vhost { get; set; }
+        public string Configure { get; set; }
+        public string Write { get; set; }
+        public string Read { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/PermissionInfo.cs
+++ b/Source/EasyNetQ.Management.Client/Model/PermissionInfo.cs
@@ -2,9 +2,9 @@
 {
     public class PermissionInfo
     {
-        public string configure { get; private set; }
-        public string write { get; private set; }
-        public string read { get; private set; }
+        public string Configure { get; private set; }
+        public string Write { get; private set; }
+        public string Read { get; private set; }
 
         private readonly User user;
         private readonly Vhost vhost;
@@ -17,53 +17,52 @@
             this.user = user;
             this.vhost = vhost;
 
-            configure = write = read = allowAll;
+            Configure = Write = Read = allowAll;
         }
 
         public string GetUserName()
         {
-            return user.name;
+            return user.Name;
         }
 
         public string GetVirtualHostName()
         {
-            return vhost.name;
+            return vhost.Name;
         }
 
-        public PermissionInfo Configure(string resourcesToAllow)
+        public PermissionInfo SetConfigure(string resourcesToAllow)
         {
-            configure = resourcesToAllow;
+            Configure = resourcesToAllow;
             return this;
         }
 
-        public PermissionInfo Write(string resourcedToAllow)
+        public PermissionInfo SetWrite(string resourcedToAllow)
         {
-            write = resourcedToAllow;
+            Write = resourcedToAllow;
             return this;
         }
 
-        public PermissionInfo Read(string resourcesToAllow)
+        public PermissionInfo SetRead(string resourcesToAllow)
         {
-            read = resourcesToAllow;
+            Read = resourcesToAllow;
             return this;
         }
-
 
         public PermissionInfo DenyAllConfigure()
         {
-            configure = denyAll;
+            Configure = denyAll;
             return this;
         }
 
         public PermissionInfo DenyAllWrite()
         {
-            write = denyAll;
+            Write = denyAll;
             return this;
         }
 
         public PermissionInfo DenyAllRead()
         {
-            read = denyAll;
+            Read = denyAll;
             return this;
         }
     }

--- a/Source/EasyNetQ.Management.Client/Model/PublishInfo.cs
+++ b/Source/EasyNetQ.Management.Client/Model/PublishInfo.cs
@@ -5,28 +5,28 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class PublishInfo
     {
-        public IDictionary<string, string> properties { get; private set; }
-        public string routing_key { get; private set; }
-        public string payload { get; private set; }
-        public string payload_encoding { get; private set; }
+        public IDictionary<string, string> Properties { get; private set; }
+        public string RoutingKey { get; private set; }
+        public string Payload { get; private set; }
+        public string PayloadEncoding { get; private set; }
 
-        private readonly ISet<string> payloadEncodings = new HashSet<string>{ "string", "base64" };
+        private readonly ISet<string> payloadEncodings = new HashSet<string> { "string", "base64" };
 
         public PublishInfo(IDictionary<string, string> properties, string routingKey, string payload, string payloadEncoding)
         {
-            if(properties == null)
+            if (properties == null)
             {
                 throw new ArgumentNullException("properties");
             }
-            if(routingKey == null)
+            if (routingKey == null)
             {
                 throw new ArgumentNullException("routingKey");
             }
-            if(payload == null)
+            if (payload == null)
             {
                 throw new ArgumentNullException("payload");
             }
-            if(payloadEncoding == null)
+            if (payloadEncoding == null)
             {
                 throw new ArgumentNullException("payloadEncoding");
             }
@@ -36,13 +36,13 @@ namespace EasyNetQ.Management.Client.Model
                     string.Join(", ", payloadEncodings)));
             }
 
-            this.properties = properties;
-            routing_key = routingKey;
-            this.payload = payload;
-            payload_encoding = payloadEncoding;
+            Properties = properties;
+            RoutingKey = routingKey;
+            Payload = payload;
+            PayloadEncoding = payloadEncoding;
         }
 
-        public PublishInfo(string routingKey, string payload) : 
+        public PublishInfo(string routingKey, string payload) :
             this(new Dictionary<string, string>(), routingKey, payload, "string")
         {
         }

--- a/Source/EasyNetQ.Management.Client/Model/PublishResult.cs
+++ b/Source/EasyNetQ.Management.Client/Model/PublishResult.cs
@@ -2,6 +2,6 @@
 {
     public class PublishResult
     {
-        public bool routed { get; set; }     
+        public bool Routed { get; set; }     
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/Queue.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Queue.cs
@@ -4,22 +4,22 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class Queue
     {
-        public int memory { get; set; }
-        public string idle_since { get; set; }
-        public string policy { get; set; }
-        public string exclusive_consumer_tag { get; set; }
-        public int messages_ready { get; set; }
-        public int messages_unacknowledged { get; set; }
-        public int messages { get; set; }
-        public int consumers { get; set; }
-        public int active_consumers { get; set; }
-        public BackingQueueStatus backing_queue_status { get; set; }
-        public List<object> consumer_details { get; set; }
-        public string name { get; set; }
-        public string vhost { get; set; }
-        public bool durable { get; set; }
-        public bool auto_delete { get; set; }
-        public Arguments arguments { get; set; }
-        public string node { get; set; }
+        public int Memory { get; set; }
+        public string IdleSince { get; set; }
+        public string Policy { get; set; }
+        public string ExclusiveConsumerTag { get; set; }
+        public int MessagesReady { get; set; }
+        public int MessagesUnacknowledged { get; set; }
+        public int Messages { get; set; }
+        public int Consumers { get; set; }
+        public int ActiveConsumers { get; set; }
+        public BackingQueueStatus BackingQueueStatus { get; set; }
+        public List<object> ConsumerDetails { get; set; }
+        public string Name { get; set; }
+        public string Vhost { get; set; }
+        public bool Durable { get; set; }
+        public bool AutoDelete { get; set; }
+        public Arguments Arguments { get; set; }
+        public string Node { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/QueueEx.cs
+++ b/Source/EasyNetQ.Management.Client/Model/QueueEx.cs
@@ -4,23 +4,22 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class QueueEx
     {
-        public int memory { get; set; }
-        public string idle_since { get; set; }
-        public string exclusive_consumer_tag { get; set; }
-        public int messages_ready { get; set; }
-        public int messages_unacknowledged { get; set; }
-        public int messages { get; set; }
-        public int consumers { get; set; }
-        public List<object> slave_nodes { get; set; }
-        public BackingQueueStatus backing_queue_status { get; set; }
-        public MessagesDetails messages_details { get; set; }
-        public MessagesReadyDetails messages_ready_details { get; set; }
-        public MessagesUnacknowledgedDetails messages_unacknowledged_details { get; set; }
-        public string name { get; set; }
-        public string vhost { get; set; }
-        public bool durable { get; set; }
-        public bool auto_delete { get; set; }
-        public Arguments arguments { get; set; }
-        public string node { get; set; }
+        public int Memory { get; set; }
+        public string IdleSince { get; set; }
+        public string ExclusiveConsumerTag { get; set; }
+        public int MessagesReady { get; set; }
+        public int MessagesUnacknowledged { get; set; }
+        public int Messages { get; set; }
+        public int Consumers { get; set; }
+        public List<object> SlaveNodes { get; set; }
+        public BackingQueueStatus BackingQueueStatus { get; set; }
+        public MessagesDetails MessagesDetails { get; set; }
+        public MessagesReadyDetails MessagesReadyDetails { get; set; }
+        public MessagesUnacknowledgedDetails MessagesUnacknowledgedDetails { get; set; }
+        public string Name { get; set; }
+        public string Vhost { get; set; }
+        public bool Durable { get; set; }
+        public bool AutoDelete { get; set; }
+        public Arguments Arguments { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/QueueInfo.cs
+++ b/Source/EasyNetQ.Management.Client/Model/QueueInfo.cs
@@ -6,25 +6,25 @@ namespace EasyNetQ.Management.Client.Model
     {
         private readonly string name;
 
-        public bool auto_delete { get; private set; }
-        public bool durable { get; private set; }
-        public InputArguments arguments { get; private set; }
+        public bool AutoDelete { get; private set; }
+        public bool Durable { get; private set; }
+        public InputArguments Arguments { get; private set; }
 
         public QueueInfo(string name, bool autoDelete, bool durable, InputArguments arguments)
         {
-            if(string.IsNullOrEmpty(name))
+            if (string.IsNullOrEmpty(name))
             {
                 throw new ArgumentNullException("name");
             }
-            if(arguments == null)
+            if (arguments == null)
             {
                 throw new ArgumentNullException("arguments");
             }
 
             this.name = name;
-            auto_delete = autoDelete;
-            this.durable = durable;
-            this.arguments = arguments;
+            AutoDelete = autoDelete;
+            this.Durable = durable;
+            this.Arguments = arguments;
         }
 
         public QueueInfo(string name) :

--- a/Source/EasyNetQ.Management.Client/Model/QueueTotals.cs
+++ b/Source/EasyNetQ.Management.Client/Model/QueueTotals.cs
@@ -2,11 +2,11 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class QueueTotals
     {
-        public int messages { get; set; }
-        public int messages_ready { get; set; }
-        public int messages_unacknowledged { get; set; }
-        public MessagesDetails messages_details { get; set; }
-        public MessagesReadyDetails messages_ready_details { get; set; }
-        public MessagesUnacknowledgedDetails messages_unacknowledged_details { get; set; }
+        public int Messages { get; set; }
+        public int MessagesReady { get; set; }
+        public int MessagesUnacknowledged { get; set; }
+        public MessagesDetails MessagesDetails { get; set; }
+        public MessagesReadyDetails MessagesReadyDetails { get; set; }
+        public MessagesUnacknowledgedDetails MessagesUnacknowledgedDetails { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/User.cs
+++ b/Source/EasyNetQ.Management.Client/Model/User.cs
@@ -2,8 +2,8 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class User
     {
-        public string name { get; set; }
-        public string password_hash { get; set; }
-        public string tags { get; set; }
+        public string Name { get; set; }
+        public string PasswordHash { get; set; }
+        public string Tags { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/UserInfo.cs
+++ b/Source/EasyNetQ.Management.Client/Model/UserInfo.cs
@@ -7,8 +7,8 @@ namespace EasyNetQ.Management.Client.Model
     public class UserInfo
     {
         private readonly string name;
-        public string password { get; private set; }
-        public string tags
+        public string Password { get; private set; }
+        public string Tags
         {
             get
             {
@@ -21,7 +21,7 @@ namespace EasyNetQ.Management.Client.Model
         private readonly ISet<string> allowedTags = new HashSet<string>
         {
             "administrator", "monitoring", "management"
-        }; 
+        };
 
         private readonly ISet<string> tagList = new HashSet<string>();
 
@@ -37,7 +37,7 @@ namespace EasyNetQ.Management.Client.Model
             }
 
             this.name = name;
-            this.password = password;
+            this.Password = password;
         }
 
         public UserInfo AddTag(string tag)

--- a/Source/EasyNetQ.Management.Client/Model/Vhost.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Vhost.cs
@@ -2,7 +2,7 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class Vhost
     {
-        public string name { get; set; }
-        public bool tracing { get; set; }
+        public string Name { get; set; }
+        public bool Tracing { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/RabbitContractResolver.cs
+++ b/Source/EasyNetQ.Management.Client/RabbitContractResolver.cs
@@ -1,0 +1,13 @@
+﻿using System.Text.RegularExpressions;
+using Newtonsoft.Json.Serialization;
+
+namespace EasyNetQ.Management.Client
+{
+    public class RabbitContractResolver : DefaultContractResolver
+    {
+        protected override string ResolvePropertyName(string propertyName)
+        {
+            return Regex.Replace(propertyName, "([a-z])([A-Z])", "$1_$2").ToLower();
+        }
+    }
+}

--- a/Source/EasyNetQ.Management.Client/Serialization/PropertyConverter.cs
+++ b/Source/EasyNetQ.Management.Client/Serialization/PropertyConverter.cs
@@ -33,7 +33,7 @@ namespace EasyNetQ.Management.Client.Serialization
                             var headers = (JObject) property.Value;
                             foreach (var header in headers.Properties())
                             {
-                                properties.headers.Add(header.Name, header.Value.ToString());
+                                properties.Headers.Add(header.Name, header.Value.ToString());
                             }
                         }
                     }

--- a/Source/EasyNetQ.Monitor.Tests/Checks/EasyNetQErrorQueueCheckTests.cs
+++ b/Source/EasyNetQ.Monitor.Tests/Checks/EasyNetQErrorQueueCheckTests.cs
@@ -14,7 +14,7 @@ namespace EasyNetQ.Monitor.Tests.Checks
     public class EasyNetQErrorQueueCheckTests : CheckTestBase
     {
         private ICheck easyNetQErrorQueueCheck;
-        readonly Vhost vhost = new Vhost { name = "my_vhost" };
+        readonly Vhost vhost = new Vhost { Name = "my_vhost" };
 
 
         protected override void DoSetUp()
@@ -32,7 +32,7 @@ namespace EasyNetQ.Monitor.Tests.Checks
 
             var queue = new Queue
             {
-                messages = 1
+                Messages = 1
             };
 
             ManagementClient.Stub(x => x.GetQueue("EasyNetQ_Default_Error_Queue", vhost)).Return(queue);
@@ -53,7 +53,7 @@ namespace EasyNetQ.Monitor.Tests.Checks
             
             var queue = new Queue
             {
-                messages = 0
+                Messages = 0
             };
 
             ManagementClient.Stub(x => x.GetQueue("EasyNetQ_Default_Error_Queue", vhost)).Return(queue);
@@ -66,7 +66,7 @@ namespace EasyNetQ.Monitor.Tests.Checks
         [Test]
         public void Should_alert_for_each_error_queue_in_each_vhost()
         {
-            var vhost2 = new Vhost {name = "my_other_vhost"};
+            var vhost2 = new Vhost {Name = "my_other_vhost"};
             ManagementClient.Stub(x => x.GetVHosts()).Return(new[]
             {
                 vhost,
@@ -75,7 +75,7 @@ namespace EasyNetQ.Monitor.Tests.Checks
 
             var queue = new Queue
             {
-                messages = 1
+                Messages = 1
             };
 
             ManagementClient.Stub(x => x.GetQueue("EasyNetQ_Default_Error_Queue", vhost)).Return(queue);

--- a/Source/EasyNetQ.Monitor.Tests/Checks/MaxChannelsCheckTests.cs
+++ b/Source/EasyNetQ.Monitor.Tests/Checks/MaxChannelsCheckTests.cs
@@ -22,9 +22,9 @@ namespace EasyNetQ.Monitor.Tests.Checks
         {
             ManagementClient.Stub(x => x.GetOverview()).Return(new Overview
             {
-                object_totals = new ObjectTotals
+                ObjectTotals = new ObjectTotals
                 {
-                    channels = 100
+                    Channels = 100
                 }
             });
 
@@ -39,9 +39,9 @@ namespace EasyNetQ.Monitor.Tests.Checks
         {
             ManagementClient.Stub(x => x.GetOverview()).Return(new Overview
             {
-                object_totals = new ObjectTotals
+                ObjectTotals = new ObjectTotals
                 {
-                    channels = 99
+                    Channels = 99
                 }
             });
 

--- a/Source/EasyNetQ.Monitor.Tests/Checks/MaxConnectionsCheckTests.cs
+++ b/Source/EasyNetQ.Monitor.Tests/Checks/MaxConnectionsCheckTests.cs
@@ -25,9 +25,9 @@ namespace EasyNetQ.Monitor.Tests.Checks
         {
             ManagementClient.Stub(x => x.GetOverview()).Return(new Overview
             {
-                object_totals = new ObjectTotals
+                ObjectTotals = new ObjectTotals
                 {
-                    connections = 100
+                    Connections = 100
                 }
             });
             var result = maxConnectionsCheck.RunCheck(ManagementClient);
@@ -41,9 +41,9 @@ namespace EasyNetQ.Monitor.Tests.Checks
         {
             ManagementClient.Stub(x => x.GetOverview()).Return(new Overview
             {
-                object_totals = new ObjectTotals
+                ObjectTotals = new ObjectTotals
                 {
-                    connections = 99
+                    Connections = 99
                 }
             });
             var result = maxConnectionsCheck.RunCheck(ManagementClient);

--- a/Source/EasyNetQ.Monitor.Tests/Checks/MaxQueuedMessagesCheckTest.cs
+++ b/Source/EasyNetQ.Monitor.Tests/Checks/MaxQueuedMessagesCheckTest.cs
@@ -22,9 +22,9 @@ namespace EasyNetQ.Monitor.Tests.Checks
         {
             ManagementClient.Stub(x => x.GetOverview()).Return(new Overview
             {
-                queue_totals = new QueueTotals
+                QueueTotals = new QueueTotals
                 {
-                    messages = 100
+                    Messages = 100
                 }
             });
 
@@ -39,9 +39,9 @@ namespace EasyNetQ.Monitor.Tests.Checks
         {
             ManagementClient.Stub(x => x.GetOverview()).Return(new Overview
             {
-                queue_totals = new QueueTotals
+                QueueTotals = new QueueTotals
                 {
-                    messages = 99
+                    Messages = 99
                 }
             });
 

--- a/Source/EasyNetQ.Monitor.Tests/Checks/MaxQueuedMessagesOnEasyQueueCheckTests.cs
+++ b/Source/EasyNetQ.Monitor.Tests/Checks/MaxQueuedMessagesOnEasyQueueCheckTests.cs
@@ -25,9 +25,9 @@ namespace EasyNetQ.Monitor.Tests.Checks
             {
                 new Queue
                 {
-                    name = "my_queue",
-                    vhost = "my_virtual_host",
-                    messages = 101
+                    Name = "my_queue",
+                    Vhost = "my_virtual_host",
+                    Messages = 101
                 }
             });
 
@@ -46,9 +46,9 @@ namespace EasyNetQ.Monitor.Tests.Checks
             {
                 new Queue
                 {
-                    name = "my_queue",
-                    vhost = "my_virtual_host",
-                    messages = 99
+                    Name = "my_queue",
+                    Vhost = "my_virtual_host",
+                    Messages = 99
                 }
             });
 

--- a/Source/EasyNetQ.Monitor/Checks/EasyNetQErrorQueueCheck.cs
+++ b/Source/EasyNetQ.Monitor/Checks/EasyNetQErrorQueueCheck.cs
@@ -15,8 +15,8 @@ namespace EasyNetQ.Monitor.Checks
             var vhostsWithErrors =
                 from vhost in managementClient.GetVHosts()
                 let errorQueue = GetErrorQueue(managementClient, vhost)
-                where errorQueue.messages > 0
-                select vhost.name;
+                where errorQueue.Messages > 0
+                select vhost.Name;
 
             var message = string.Format(errorMessage, managementClient.HostUrl, string.Join(", ", vhostsWithErrors));
 
@@ -33,7 +33,7 @@ namespace EasyNetQ.Monitor.Checks
             {
                 if (exception.StatusCode == HttpStatusCode.NotFound)
                 {
-                    return new Queue { messages = 0 };
+                    return new Queue { Messages = 0 };
                 }
                 throw;
             }

--- a/Source/EasyNetQ.Monitor/Checks/MaxChannelsCheck.cs
+++ b/Source/EasyNetQ.Monitor/Checks/MaxChannelsCheck.cs
@@ -15,10 +15,10 @@ namespace EasyNetQ.Monitor.Checks
         {
             var overview = managementClient.GetOverview();
 
-            var alert = overview.object_totals.channels >= alertChannelCount;
+            var alert = overview.ObjectTotals.Channels >= alertChannelCount;
 
             var message = string.Format("broker '{0}' channels have exceeded alert level {1}, now {2}",
-                managementClient.HostUrl, alertChannelCount, overview.object_totals.channels);
+                managementClient.HostUrl, alertChannelCount, overview.ObjectTotals.Channels);
 
             return new CheckResult(alert, message);
         }

--- a/Source/EasyNetQ.Monitor/Checks/MaxConnectionsCheck.cs
+++ b/Source/EasyNetQ.Monitor/Checks/MaxConnectionsCheck.cs
@@ -18,13 +18,13 @@ namespace EasyNetQ.Monitor.Checks
         public CheckResult RunCheck(IManagementClient managementClient)
         {
             var overview = managementClient.GetOverview();
-            var alert = overview.object_totals.connections >= alertConnectionCount;
+            var alert = overview.ObjectTotals.Connections >= alertConnectionCount;
             var message = alert
                 ? string.Format(
                     "broker {0} connections have exceeded alert level {1}. Now {2}", 
                     managementClient.HostUrl,
                     alertConnectionCount,
-                    overview.object_totals.connections)
+                    overview.ObjectTotals.Connections)
                 : "";
 
             return new CheckResult(alert, message);

--- a/Source/EasyNetQ.Monitor/Checks/MaxQueuedMessagesCheck.cs
+++ b/Source/EasyNetQ.Monitor/Checks/MaxQueuedMessagesCheck.cs
@@ -14,9 +14,9 @@ namespace EasyNetQ.Monitor.Checks
         public CheckResult RunCheck(IManagementClient managementClient)
         {
             var overview = managementClient.GetOverview();
-            var alert = overview.queue_totals.messages >= alertQueueCount;
+            var alert = overview.QueueTotals.Messages >= alertQueueCount;
             var message = string.Format("broker '{0}' queued messages exceed alert level {1}, now {2}",
-                managementClient.HostUrl, alertQueueCount, overview.queue_totals.messages);
+                managementClient.HostUrl, alertQueueCount, overview.QueueTotals.Messages);
 
             return new CheckResult(alert, message);
         }

--- a/Source/EasyNetQ.Monitor/Checks/MaxQueuedMessagesOnEasyQueueCheck.cs
+++ b/Source/EasyNetQ.Monitor/Checks/MaxQueuedMessagesOnEasyQueueCheck.cs
@@ -19,8 +19,8 @@ namespace EasyNetQ.Monitor.Checks
             var queues = managementClient.GetQueues();
             var alertQueues =
                 from queue in queues
-                where queue.messages >= alertIndividualQueueMessagesCount
-                select string.Format("{0} on {1} with {2} messages", queue.name, queue.vhost, queue.messages);
+                where queue.Messages >= alertIndividualQueueMessagesCount
+                select string.Format("{0} on {1} with {2} messages", queue.Name, queue.Vhost, queue.Messages);
 
             var message = string.Format(alertMessage, 
                 managementClient.HostUrl,


### PR DESCRIPTION
I added a contract resolver and updated the property names in the management project to use camel cased property names. I think this looks a lot cleaner than using underscores. 

I could get _most_ of the management api unit tests to pass, if you decide to merge this (which I'd totally understand if you don't because it's not that exciting and it's a breaking change), could you just check all the tests pass?
