### PR TITLE
Introduced Preconditions class

### DIFF
--- a/Source/EasyNetQ/AutoSubscriber.cs
+++ b/Source/EasyNetQ/AutoSubscriber.cs
@@ -39,11 +39,8 @@ namespace EasyNetQ
 
         public AutoSubscriber(IBus bus, string subscriptionIdPrefix)
         {
-            if (bus == null)
-                throw new ArgumentNullException("bus");
-
-            if(string.IsNullOrWhiteSpace(subscriptionIdPrefix))
-                throw new ArgumentNullException("subscriptionIdPrefix", "You need to specify a SubscriptionId prefix, which will be used as part of the checksum of all generated subscription ids.");
+            Preconditions.CheckNotNull(bus, "bus");
+            Preconditions.CheckNotBlank(subscriptionIdPrefix, "subscriptionIdPrefix", "You need to specify a SubscriptionId prefix, which will be used as part of the checksum of all generated subscription ids.");
 
             this.bus = bus;
             SubscriptionIdPrefix = subscriptionIdPrefix;
@@ -75,8 +72,7 @@ namespace EasyNetQ
         /// <param name="assemblies">The assembleis to scan for consumers.</param>
         public virtual void Subscribe(params Assembly[] assemblies)
         {
-            if (assemblies == null || !assemblies.Any())
-                throw new ArgumentException("No assemblies specified.", "assemblies");
+            Preconditions.CheckAny(assemblies, "assemblies", "No assemblies specified.");
 
             var genericBusSubscribeMethod = GetSubscribeMethodOfBus();
             var subscriptionInfos = GetSubscriptionInfos(assemblies.SelectMany(a => a.GetTypes()));

--- a/Source/EasyNetQ/BusExtensions.cs
+++ b/Source/EasyNetQ/BusExtensions.cs
@@ -15,10 +15,7 @@ namespace EasyNetQ
         /// <param name="message">The message to response with</param>
         public static void FuturePublish<T>(this IPublishChannel publishChannel, DateTime timeToRespond, T message)
         {
-            if (message == null)
-            {
-                throw new ArgumentNullException("message");
-            }
+            Preconditions.CheckNotNull(message, "message");
 
             var advancedBus = publishChannel.Bus.Advanced;
             var typeName = advancedBus.SerializeType(typeof(T));

--- a/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
+++ b/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
@@ -66,21 +66,16 @@ namespace EasyNetQ.ConnectionString
         /// <returns></returns>
         public static Action<TContaining, TProperty> CreateSetter<TContaining, TProperty>(Expression<Func<TContaining, TProperty>> getter)
         {
-            if (getter == null)
-                throw new ArgumentNullException("getter");
+            Preconditions.CheckNotNull(getter, "getter");
 
             var memberEx = getter.Body as MemberExpression;
 
-            if (memberEx == null)
-                throw new ArgumentException("Body is not a member-expression.");
+            Preconditions.CheckNotNull(memberEx, "getter", "Body is not a member-expression.");
 
             var property = memberEx.Member as PropertyInfo;
 
-            if (property == null)
-                throw new ArgumentException("Member is not a property.");
-
-            if (!property.CanWrite)
-                throw new ArgumentException("Property is not writable.");
+            Preconditions.CheckNotNull(property, "getter", "Member is not a property.");
+            Preconditions.CheckTrue(property.CanWrite, "getter", "Member is not a writeable property.");
 
             return (Action<TContaining, TProperty>)
                 Delegate.CreateDelegate(typeof(Action<TContaining, TProperty>),

--- a/Source/EasyNetQ/ConsumerInfo.cs
+++ b/Source/EasyNetQ/ConsumerInfo.cs
@@ -11,14 +11,9 @@ namespace EasyNetQ
 
         public ConsumerInfo(Type concreteType, Type interfaceType, Type messageType)
         {
-            if (concreteType == null)
-                throw new ArgumentNullException("concreteType");
-
-            if (interfaceType == null)
-                throw new ArgumentNullException("interfaceType");
-
-            if (messageType == null)
-                throw new ArgumentNullException("messageType");
+            Preconditions.CheckNotNull(concreteType, "concreteType");
+            Preconditions.CheckNotNull(interfaceType, "interfaceType");
+            Preconditions.CheckNotNull(messageType, "messageType");
 
             ConcreteType = concreteType;
             InterfaceType = interfaceType;

--- a/Source/EasyNetQ/DefaultConsumerErrorStrategy.cs
+++ b/Source/EasyNetQ/DefaultConsumerErrorStrategy.cs
@@ -36,10 +36,7 @@ namespace EasyNetQ
             IEasyNetQLogger logger,
             IConventions conventions)
         {
-            if (conventions == null)
-            {
-                throw new ArgumentNullException("conventions");
-            }
+            Preconditions.CheckNotNull(conventions, "conventions");
 
             this.connectionFactory = connectionFactory;
             this.serializer = serializer;

--- a/Source/EasyNetQ/EasyNetQ.csproj
+++ b/Source/EasyNetQ/EasyNetQ.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Topology\TopologyBuilder.cs" />
     <Compile Include="DefaultClusterHostSelectionStrategy.cs" />
     <Compile Include="TypeNameSerializer.cs" />
+    <Compile Include="Preconditions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Source/EasyNetQ/IConnectionFactory.cs
+++ b/Source/EasyNetQ/IConnectionFactory.cs
@@ -25,14 +25,9 @@ namespace EasyNetQ
         public ConnectionFactoryWrapper(IConnectionConfiguration connectionConfiguration, IClusterHostSelectionStrategy<ConnectionFactoryInfo> clusterHostSelectionStrategy)
         {
             this.clusterHostSelectionStrategy = clusterHostSelectionStrategy;
-            if(connectionConfiguration == null)
-            {
-                throw new ArgumentNullException("connectionConfiguration");
-            }
-            if (!connectionConfiguration.Hosts.Any())
-            {
-                throw new EasyNetQException("At least one host must be defined in connectionConfiguration");
-            }
+
+            Preconditions.CheckNotNull(connectionConfiguration, "connectionConfiguration");
+            Preconditions.CheckAny(connectionConfiguration.Hosts, "connectionConfiguration", "At least one host must be defined in connectionConfiguration");
 
             Configuration = connectionConfiguration;
 

--- a/Source/EasyNetQ/Preconditions.cs
+++ b/Source/EasyNetQ/Preconditions.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EasyNetQ
+{
+    /// <summary>
+    /// Collection of precondition methods for qualifying method arguments.
+    /// </summary>
+    internal static class Preconditions
+    {
+        /// <summary>
+        /// Ensures that <paramref name="value"/> is not null.
+        /// </summary>
+        /// <param name="value">
+        /// The value to check, must not be null.
+        /// </param>
+        /// <param name="name">
+        /// The name of the parameter the value is taken from, must not be
+        /// blank.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="value"/> is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="name"/> is blank.
+        /// </exception>
+        public static void CheckNotNull(object value, string name)
+        {
+            CheckNotNull(value, name, string.Format("{0} must not be blank", name));
+        }
+
+        /// <summary>
+        /// Ensures that <paramref name="value"/> is not null.
+        /// </summary>
+        /// <param name="value">
+        /// The value to check, must not be null.
+        /// </param>
+        /// <param name="name">
+        /// The name of the parameter the value is taken from, must not be
+        /// blank.
+        /// </param>
+        /// <param name="message">
+        /// The message to provide to the exception if <paramref name="value"/>
+        /// is null, must not be blank.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="value"/> is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="name"/> or <paramref name="message"/> are
+        /// blank.
+        /// </exception>
+        public static void CheckNotNull(object value, string name, string message)
+        {
+            CheckNotBlank(name, "name", "name must not be blank");
+            CheckNotBlank(message, "message", "message must not be blank");
+
+            if (value == null)
+            {
+                throw new ArgumentNullException(name, message);
+            }
+        }
+
+        /// <summary>
+        /// Ensures that <paramref name="value"/> is not blank.
+        /// </summary>
+        /// <param name="value">
+        /// The value to check, must not be blank.
+        /// </param>
+        /// <param name="name">
+        /// The name of the parameter the value is taken from, must not be
+        /// blank.
+        /// </param>
+        /// <param name="message">
+        /// The message to provide to the exception if <paramref name="value"/>
+        /// is blank, must not be blank.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="value"/>, <paramref name="name"/>, or
+        /// <paramref name="message"/> are blank.
+        /// </exception>
+        public static void CheckNotBlank(string value, string name, string message)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("name must not be blank", "name");
+            }
+
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                throw new ArgumentException("message must not be blank", "message");
+            }
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException(message, name);
+            }
+        }
+
+        /// <summary>
+        /// Ensures that <paramref name="value"/> is not blank.
+        /// </summary>
+        /// <param name="value">
+        /// The value to check, must not be blank.
+        /// </param>
+        /// <param name="name">
+        /// The name of the parameter the value is taken from, must not be
+        /// blank.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="value"/> or <paramref name="name"/> are
+        /// blank.
+        /// </exception>
+        public static void CheckNotBlank(string value, string name)
+        {
+            CheckNotBlank(value, name, string.Format("{0} must not be blank", name));
+        }
+
+        /// <summary>
+        /// Ensures that <paramref name="collection"/> contains at least one
+        /// item.
+        /// </summary>
+        /// <param name="collection">
+        /// The collection to check, must not be null or empty.
+        /// </param>
+        /// <param name="name">
+        /// The name of the parameter the collection is taken from, must not be
+        /// blank.
+        /// </param>
+        /// <param name="message">
+        /// The message to provide to the exception if <paramref name="collection"/>
+        /// is empty, must not be blank.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="collection"/> is empty, or if
+        /// <paramref name="value"/> or <paramref name="name"/> are blank.
+        /// </exception>
+        public static void CheckAny<T>(IEnumerable<T> collection, string name, string message)
+        {
+            CheckNotBlank(name, "name", "name must not be blank");
+            CheckNotBlank(message, "message", "message must not be blank");
+
+            if (collection == null || !collection.Any())
+            {
+                throw new ArgumentException(message, name);
+            }
+        }
+
+        /// <summary>
+        /// Ensures that <paramref name="value"/> is true.
+        /// </summary>
+        /// <param name="value">
+        /// The value to check, must be true.
+        /// </param>
+        /// <param name="name">
+        /// The name of the parameter the value is taken from, must not be
+        /// blank.
+        /// </param>
+        /// <param name="message">
+        /// The message to provide to the exception if <paramref name="collection"/>
+        /// is false, must not be blank.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="value"/> is false, or if <paramref name="name"/>
+        /// or <paramref name="message"/> are blank.
+        /// </exception>
+        public static void CheckTrue(bool value, string name, string message)
+        {
+            CheckNotBlank(name, "name", "name must not be blank");
+            CheckNotBlank(message, "message", "message must not be blank");
+
+            if (!value)
+            {
+                throw new ArgumentException(message, name);
+            }
+        }
+
+        /// <summary>
+        /// Ensures that <paramref name="value"/> is false.
+        /// </summary>
+        /// <param name="value">
+        /// The value to check, must be false.
+        /// </param>
+        /// <param name="name">
+        /// The name of the parameter the value is taken from, must not be
+        /// blank.
+        /// </param>
+        /// <param name="message">
+        /// The message to provide to the exception if <paramref name="collection"/>
+        /// is true, must not be blank.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="value"/> is true, or if <paramref name="name"/>
+        /// or <paramref name="message"/> are blank.
+        /// </exception>
+        public static void CheckFalse(bool value, string name, string message)
+        {
+            CheckNotBlank(name, "name", "name must not be blank");
+            CheckNotBlank(message, "message", "message must not be blank");
+
+            if (value)
+            {
+                throw new ArgumentException(message, name);
+            }
+        }
+    }
+}

--- a/Source/EasyNetQ/PublisherConfirms.cs
+++ b/Source/EasyNetQ/PublisherConfirms.cs
@@ -17,18 +17,9 @@ namespace EasyNetQ
 
         public void RegisterCallbacks(IModel channel, Action successCallback, Action failureCallback)
         {
-            if (channel == null)
-            {
-                throw new ArgumentNullException("channel");
-            }
-            if (successCallback == null)
-            {
-                throw new ArgumentNullException("successCallback");
-            }
-            if (failureCallback == null)
-            {
-                throw new ArgumentNullException("failureCallback");
-            }
+            Preconditions.CheckNotNull(channel, "channel");
+            Preconditions.CheckNotNull(successCallback, "successCallback");
+            Preconditions.CheckNotNull(failureCallback, "failureCallback");
 
             var sequenceNumber = channel.NextPublishSeqNo;
 
@@ -40,20 +31,14 @@ namespace EasyNetQ
 
         public void SuccessfulPublish(IModel channel, BasicAckEventArgs args)
         {
-            if (args == null)
-            {
-                throw new ArgumentNullException("args");
-            }
+            Preconditions.CheckNotNull(args, "args");
 
             ProcessArgsAndRun(args.Multiple, args.DeliveryTag, x => x.Success());
         }
 
         public void FailedPublish(IModel channel, BasicNackEventArgs args)
         {
-            if (args == null)
-            {
-                throw new ArgumentNullException("args");
-            }
+            Preconditions.CheckNotNull(args, "args");
 
             ProcessArgsAndRun(args.Multiple, args.DeliveryTag, x => x.Failure());
         }

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -32,38 +32,14 @@ namespace EasyNetQ
             Func<string> getCorrelationId, 
             IConventions conventions)
         {
-            if(connectionConfiguration == null)
-            {
-                throw new ArgumentNullException("connectionConfiguration");
-            }
-            if (connectionFactory == null)
-            {
-                throw new ArgumentNullException("connectionFactory");
-            }
-            if (serializeType == null)
-            {
-                throw new ArgumentNullException("serializeType");
-            }
-            if (serializer == null)
-            {
-                throw new ArgumentNullException("serializer");
-            }
-            if (consumerFactory == null)
-            {
-                throw new ArgumentNullException("consumerFactory");
-            }
-            if (logger == null)
-            {
-                throw new ArgumentNullException("logger");
-            }
-            if (getCorrelationId == null)
-            {
-                throw new ArgumentNullException("getCorrelationId");
-            }
-            if (conventions == null)
-            {
-                throw new ArgumentNullException("conventions");
-            }
+            Preconditions.CheckNotNull(connectionConfiguration, "connectionConfiguration");
+            Preconditions.CheckNotNull(connectionFactory, "connectionFactory");
+            Preconditions.CheckNotNull(serializeType, "serializeType");
+            Preconditions.CheckNotNull(serializer, "serializer");
+            Preconditions.CheckNotNull(consumerFactory, "consumerFactory");
+            Preconditions.CheckNotNull(logger, "logger");
+            Preconditions.CheckNotNull(getCorrelationId, "getCorrelationId");
+            Preconditions.CheckNotNull(conventions, "conventions");
 
             this.connectionConfiguration = connectionConfiguration;
             this.serializeType = serializeType;
@@ -116,14 +92,8 @@ namespace EasyNetQ
 
         public virtual void Subscribe<T>(IQueue queue, Func<IMessage<T>, MessageReceivedInfo, Task> onMessage)
         {
-            if(queue == null)
-            {
-                throw new ArgumentNullException("queue");
-            }
-            if(onMessage == null)
-            {
-                throw new ArgumentNullException("onMessage");
-            }
+            Preconditions.CheckNotNull(queue, "queue");
+            Preconditions.CheckNotNull(onMessage, "onMessage");
 
             Subscribe(queue, (body, properties, messageRecievedInfo) =>
             {
@@ -138,14 +108,9 @@ namespace EasyNetQ
 
         public virtual void Subscribe(IQueue queue, Func<Byte[], MessageProperties, MessageReceivedInfo, Task> onMessage)
         {
-            if (queue == null)
-            {
-                throw new ArgumentNullException("queue");
-            }
-            if (onMessage == null)
-            {
-                throw new ArgumentNullException("onMessage");
-            }
+            Preconditions.CheckNotNull(queue, "queue");
+            Preconditions.CheckNotNull(onMessage, "onMessage");
+
             if (disposed)
             {
                 throw new EasyNetQException("This bus has been disposed");

--- a/Source/EasyNetQ/RabbitAdvancedPublishChannel.cs
+++ b/Source/EasyNetQ/RabbitAdvancedPublishChannel.cs
@@ -15,10 +15,8 @@ namespace EasyNetQ
 
         public RabbitAdvancedPublishChannel(RabbitAdvancedBus advancedBus, Action<IChannelConfiguration> configure)
         {
-            if(advancedBus == null)
-            {
-                throw new ArgumentNullException("advancedBus");
-            }
+            Preconditions.CheckNotNull(advancedBus, "advancedBus");
+
             if (!advancedBus.Connection.IsConnected)
             {
                 throw new EasyNetQException("Cannot open channel for publishing, the broker is not connected");
@@ -58,22 +56,10 @@ namespace EasyNetQ
 
         public virtual void Publish<T>(IExchange exchange, string routingKey, IMessage<T> message, Action<IAdvancedPublishConfiguration> configure)
         {
-            if(exchange == null)
-            {
-                throw new ArgumentNullException("exchange");
-            }
-            if(routingKey == null)
-            {
-                throw new ArgumentNullException("routingKey");
-            }
-            if(message == null)
-            {
-                throw new ArgumentNullException("message");
-            }
-            if(configure == null)
-            {
-                throw new ArgumentNullException("configure");
-            }
+            Preconditions.CheckNotNull(exchange, "exchange");
+            Preconditions.CheckNotNull(routingKey, "routingKey");
+            Preconditions.CheckNotNull(message, "message");
+            Preconditions.CheckNotNull(configure, "configure");
 
             var typeName = advancedBus.SerializeType(typeof(T));
             var messageBody = advancedBus.Serializer.MessageToBytes(message.Body);
@@ -89,26 +75,12 @@ namespace EasyNetQ
 
         public virtual void Publish(IExchange exchange, string routingKey, MessageProperties properties, byte[] messageBody, Action<IAdvancedPublishConfiguration> configure)
         {
-            if (exchange == null)
-            {
-                throw new ArgumentNullException("exchange");
-            }
-            if (routingKey == null)
-            {
-                throw new ArgumentNullException("routingKey");
-            }
-            if(properties == null)
-            {
-                throw new ArgumentNullException("properties");
-            }
-            if(messageBody == null)
-            {
-                throw new ArgumentNullException("messageBody");
-            }
-            if(configure == null)
-            {
-                throw new ArgumentNullException("configure");
-            }
+            Preconditions.CheckNotNull(exchange, "exchange");
+            Preconditions.CheckNotNull(routingKey, "routingKey");
+            Preconditions.CheckNotNull(properties, "properties");
+            Preconditions.CheckNotNull(messageBody, "messageBody");
+            Preconditions.CheckNotNull(configure, "configure");
+
             if (disposed)
             {
                 throw new EasyNetQException("PublishChannel is already disposed");
@@ -117,6 +89,7 @@ namespace EasyNetQ
             {
                 throw new EasyNetQException("Publish failed. No rabbit server connected.");
             }
+
             try
             {
                 var configuration = new AdvancedPublishConfiguration();

--- a/Source/EasyNetQ/RabbitBus.cs
+++ b/Source/EasyNetQ/RabbitBus.cs
@@ -36,18 +36,9 @@ namespace EasyNetQ
             IConventions conventions,
             IAdvancedBus advancedBus)
         {
-            if (serializeType == null)
-            {
-                throw new ArgumentNullException("serializeType");
-            }
-            if (logger == null)
-            {
-                throw new ArgumentNullException("logger");
-            }
-            if (conventions == null)
-            {
-                throw new ArgumentNullException("conventions");
-            }
+            Preconditions.CheckNotNull(serializeType, "serializeType");
+            Preconditions.CheckNotNull(logger, "logger");
+            Preconditions.CheckNotNull(conventions, "conventions");
 
             this.serializeType = serializeType;
             this.logger = logger;
@@ -99,15 +90,8 @@ namespace EasyNetQ
 
         public virtual void SubscribeAsync<T>(string subscriptionId, Func<T, Task> onMessage, Action<ISubscriptionConfiguration<T>> configure)
         {
-            if(subscriptionId == null)
-            {
-                throw new ArgumentNullException("subscriptionId");
-            }
-
-            if (onMessage == null)
-            {
-                throw new ArgumentNullException("onMessage");
-            }
+            Preconditions.CheckNotNull(subscriptionId, "subscriptionId");
+            Preconditions.CheckNotNull(onMessage, "onMessage");
 
             var configuration = new SubscriptionConfiguration<T>();
             configure(configuration);
@@ -147,10 +131,7 @@ namespace EasyNetQ
 
         public virtual void Respond<TRequest, TResponse>(Func<TRequest, TResponse> responder, IDictionary<string, object> arguments)
         {
-            if (responder == null)
-            {
-                throw new ArgumentNullException("responder");
-            }
+            Preconditions.CheckNotNull(responder, "responder");
 
             Func<TRequest, Task<TResponse>> taskResponder =
                 request => Task<TResponse>.Factory.StartNew(_ => responder(request), null);
@@ -165,10 +146,7 @@ namespace EasyNetQ
 
         public virtual void RespondAsync<TRequest, TResponse>(Func<TRequest, Task<TResponse>> responder, IDictionary<string, object> arguments)
         {
-            if (responder == null)
-            {
-                throw new ArgumentNullException("responder");
-            }
+            Preconditions.CheckNotNull(responder, "responder");
 
             var requestTypeName = serializeType(typeof(TRequest));
 

--- a/Source/EasyNetQ/RabbitHutch.cs
+++ b/Source/EasyNetQ/RabbitHutch.cs
@@ -26,10 +26,7 @@ namespace EasyNetQ
         /// </returns>
         public static IBus CreateBus(string connectionString)
         {
-            if(connectionString == null)
-            {
-                throw new ArgumentNullException("connectionString");
-            }
+            Preconditions.CheckNotNull(connectionString, "connectionString");
 
             return CreateBus(connectionString, x => {});
         }
@@ -53,14 +50,8 @@ namespace EasyNetQ
         /// </returns>
         public static IBus CreateBus(string connectionString, Action<IServiceRegister> registerServices)
         {
-            if(connectionString == null)
-            {
-                throw new ArgumentNullException("connectionString");
-            }
-            if(registerServices == null)
-            {
-                throw new ArgumentNullException("registerServices");
-            }
+            Preconditions.CheckNotNull(connectionString, "connectionString");
+            Preconditions.CheckNotNull(registerServices, "registerServices");
 
             var connectionStringParser = new ConnectionStringParser();
 
@@ -106,26 +97,11 @@ namespace EasyNetQ
             ushort requestedHeartbeat, 
             Action<IServiceRegister> registerServices)
         {
-            if(hostName == null)
-            {
-                throw new ArgumentNullException("hostName");
-            }
-            if(virtualHost == null)
-            {
-                throw new ArgumentNullException("virtualHost");
-            }
-            if(username == null)
-            {
-                throw new ArgumentNullException("username");
-            }
-            if(password == null)
-            {
-                throw new ArgumentNullException("password");
-            }
-            if(registerServices == null)
-            {
-                throw new ArgumentNullException("registerServices");
-            }
+            Preconditions.CheckNotNull(hostName, "hostName");
+            Preconditions.CheckNotNull(virtualHost, "virtualHost");
+            Preconditions.CheckNotNull(username, "username");
+            Preconditions.CheckNotNull(password, "password");
+            Preconditions.CheckNotNull(registerServices, "registerServices");
 
             var connectionConfiguration = new ConnectionConfiguration
             {
@@ -156,14 +132,8 @@ namespace EasyNetQ
         /// <returns></returns>
         public static IBus CreateBus(IConnectionConfiguration connectionConfiguration, Action<IServiceRegister> registerServices)
         {
-            if(connectionConfiguration == null)
-            {
-                throw new ArgumentNullException("connectionConfiguration");
-            }
-            if(registerServices == null)
-            {
-                throw new ArgumentNullException("registerServices");
-            }
+            Preconditions.CheckNotNull(connectionConfiguration, "connectionConfiguration");
+            Preconditions.CheckNotNull(registerServices, "registerServices");
 
             Action<IServiceRegister> registerServices2 = x =>
             {

--- a/Source/EasyNetQ/RabbitPublishChannel.cs
+++ b/Source/EasyNetQ/RabbitPublishChannel.cs
@@ -31,10 +31,7 @@ namespace EasyNetQ
 
         public RabbitPublishChannel(RabbitBus bus, Action<IChannelConfiguration> configure, IConventions conventions)
         {
-            if (conventions == null)
-            {
-                throw new ArgumentNullException("conventions");
-            }
+            Preconditions.CheckNotNull(conventions, "conventions");
 
             this.bus = bus;
             this.conventions = conventions;
@@ -49,14 +46,8 @@ namespace EasyNetQ
 
         public virtual void Publish<T>(T message, Action<IPublishConfiguration<T>> configure)
         {
-            if(message == null)
-            {
-                throw new ArgumentNullException("message");
-            }
-            if(configure == null)
-            {
-                throw new ArgumentNullException("configure");
-            }
+            Preconditions.CheckNotNull(message, "message");
+            Preconditions.CheckNotNull(configure, "configure");
 
             var configuration = new PublishConfiguration<T>();
             configure(configuration);
@@ -97,14 +88,8 @@ namespace EasyNetQ
         virtual 
         public void Request<TRequest, TResponse>(TRequest request, Action<TResponse> onResponse, IDictionary<string, object> arguments)
         {
-            if (onResponse == null)
-            {
-                throw new ArgumentNullException("onResponse");
-            }
-            if (request == null)
-            {
-                throw new ArgumentNullException("request");
-            }
+            Preconditions.CheckNotNull(onResponse, "onResponse");
+            Preconditions.CheckNotNull(request, "request");
 
             var returnQueueName = SubscribeToResponse(onResponse, arguments);
             RequestPublish(request, returnQueueName);

--- a/Source/EasyNetQ/Sprache/Parse.cs
+++ b/Source/EasyNetQ/Sprache/Parse.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using EasyNetQ;
 
 namespace Sprache
 {
@@ -17,8 +18,8 @@ namespace Sprache
         /// <returns></returns>
         public static Parser<char> Char(Predicate<char> predicate, string description)
         {
-            if (predicate == null) throw new ArgumentNullException("predicate");
-            if (description == null) throw new ArgumentNullException("description");
+            Preconditions.CheckNotNull(predicate, "predicate");
+            Preconditions.CheckNotNull(description, "description");
 
             return i =>
             {
@@ -85,7 +86,7 @@ namespace Sprache
         /// <returns></returns>
         public static Parser<IEnumerable<char>> String(string s)
         {
-            if (s == null) throw new ArgumentNullException("s");
+            Preconditions.CheckNotNull(s, "s");
 
             return s
                 .Select(Char)
@@ -104,8 +105,8 @@ namespace Sprache
         /// <returns></returns>
         public static Parser<U> Then<T, U>(this Parser<T> first, Func<T, Parser<U>> second)
         {
-            if (first == null) throw new ArgumentNullException("first");
-            if (second == null) throw new ArgumentNullException("second");
+            Preconditions.CheckNotNull(first, "first");
+            Preconditions.CheckNotNull(second, "second");
 
             return i => first(i).IfSuccess(s => second(s.Result)(s.Remainder));
         }
@@ -119,7 +120,7 @@ namespace Sprache
         /// <remarks>Implemented imperatively to decrease stack usage.</remarks>
         public static Parser<IEnumerable<T>> Many<T>(this Parser<T> parser)
         {
-            if (parser == null) throw new ArgumentNullException("parser");
+            Preconditions.CheckNotNull(parser, "parser");
 
             return i =>
             {
@@ -150,7 +151,7 @@ namespace Sprache
         /// <remarks>Implemented imperatively to decrease stack usage.</remarks>
         public static Parser<IEnumerable<T>> XMany<T>(this Parser<T> parser)
         {
-            if (parser == null) throw new ArgumentNullException("parser");
+            Preconditions.CheckNotNull(parser, "parser");
 
             return parser.Many().Then(m => parser.Once().XOr(Return(m)));
         }
@@ -163,7 +164,7 @@ namespace Sprache
         /// <returns></returns>
         public static Parser<IEnumerable<T>> AtLeastOnce<T>(this Parser<T> parser)
         {
-            if (parser == null) throw new ArgumentNullException("parser");
+            Preconditions.CheckNotNull(parser, "parser");
 
             return parser.Once().Then(t1 => parser.Many().Select(ts => t1.Concat(ts)));
         }
@@ -176,7 +177,7 @@ namespace Sprache
         /// <returns></returns>
         public static Parser<T> End<T>(this Parser<T> parser)
         {
-            if (parser == null) throw new ArgumentNullException("parser");
+            Preconditions.CheckNotNull(parser, "parser");
 
             return i => parser(i).IfSuccess(s =>
                 s.Remainder.AtEnd ?
@@ -197,8 +198,8 @@ namespace Sprache
         /// <returns></returns>
         public static Parser<U> Select<T, U>(this Parser<T> parser, Func<T, U> convert)
         {
-            if (parser == null) throw new ArgumentNullException("parser");
-            if (convert == null) throw new ArgumentNullException("convert");
+            Preconditions.CheckNotNull(parser, "parser");
+            Preconditions.CheckNotNull(convert, "convert");
 
             return parser.Then(t => Return(convert(t)));
         }
@@ -211,7 +212,7 @@ namespace Sprache
         /// <returns></returns>
         public static Parser<T> Token<T>(this Parser<T> parser)
         {
-            if (parser == null) throw new ArgumentNullException("parser");
+            Preconditions.CheckNotNull(parser, "parser");
 
             return from leading in WhiteSpace.Many()
                    from item in parser
@@ -227,7 +228,7 @@ namespace Sprache
         /// <returns></returns>
         public static Parser<T> Ref<T>(Func<Parser<T>> reference)
         {
-            if (reference == null) throw new ArgumentNullException("reference");
+            Preconditions.CheckNotNull(reference, "reference");
 
             Parser<T> p = null;
 
@@ -267,8 +268,8 @@ namespace Sprache
         /// <returns></returns>
         public static Parser<T> Or<T>(this Parser<T> first, Parser<T> second)
         {
-            if (first == null) throw new ArgumentNullException("first");
-            if (second == null) throw new ArgumentNullException("second");
+            Preconditions.CheckNotNull(first, "first");
+            Preconditions.CheckNotNull(second, "second");
 
             return i =>
             {
@@ -297,8 +298,8 @@ namespace Sprache
         /// <returns></returns>
         public static Parser<T> Named<T>(this Parser<T> parser, string name)
         {
-            if (parser == null) throw new ArgumentNullException("parser");
-            if (name == null) throw new ArgumentNullException("name");
+            Preconditions.CheckNotNull(parser, "parser");
+            Preconditions.CheckNotNull(name, "name");
 
             return i => parser(i).IfFailure(f => f.FailedInput == i ?
                 new Failure<T>(f.FailedInput, () => f.Message, () => new[] { name }) :
@@ -315,8 +316,8 @@ namespace Sprache
         /// <returns></returns>
         public static Parser<T> XOr<T>(this Parser<T> first, Parser<T> second)
         {
-            if (first == null) throw new ArgumentNullException("first");
-            if (second == null) throw new ArgumentNullException("second");
+            Preconditions.CheckNotNull(first, "first");
+            Preconditions.CheckNotNull(second, "second");
 
             return i => {
                 var fr = first(i);
@@ -348,7 +349,7 @@ namespace Sprache
         /// <returns></returns>
         public static Parser<IEnumerable<T>> Once<T>(this Parser<T> parser)
         {
-            if (parser == null) throw new ArgumentNullException("parser");
+            Preconditions.CheckNotNull(parser, "parser");
 
             return parser.Select(r => (IEnumerable<T>)new[] { r });
         }
@@ -362,8 +363,8 @@ namespace Sprache
         /// <returns></returns>
         public static Parser<IEnumerable<T>> Concat<T>(this Parser<IEnumerable<T>> first, Parser<IEnumerable<T>> second)
         {
-            if (first == null) throw new ArgumentNullException("first");
-            if (second == null) throw new ArgumentNullException("second");
+            Preconditions.CheckNotNull(first, "first");
+            Preconditions.CheckNotNull(second, "second");
 
             return first.Then(f => second.Select(s => f.Concat(s)));
         }
@@ -389,7 +390,7 @@ namespace Sprache
         /// <returns></returns>
         public static Parser<U> Return<T, U>(this Parser<T> parser, U value)
         {
-            if (parser == null) throw new ArgumentNullException("parser");
+            Preconditions.CheckNotNull(parser, "parser");
             return parser.Select(t => value);
         }
 
@@ -403,8 +404,8 @@ namespace Sprache
         /// <returns></returns>
         public static Parser<T> Except<T, U>(this Parser<T> parser, Parser<U> except)
         {
-            if (parser == null) throw new ArgumentNullException("parser");
-            if (except == null) throw new ArgumentNullException("except");
+            Preconditions.CheckNotNull(parser, "parser");
+            Preconditions.CheckNotNull(except, "except");
 
             // Could be more like: except.Then(s => s.Fail("..")).XOr(parser)
             return i =>
@@ -439,8 +440,8 @@ namespace Sprache
         /// <returns></returns>
         public static Parser<T> Where<T>(this Parser<T> parser, Func<T, bool> predicate)
         {
-            if (parser == null) throw new ArgumentNullException("parser");
-            if (predicate == null) throw new ArgumentNullException("predicate");
+            Preconditions.CheckNotNull(parser, "parser");
+            Preconditions.CheckNotNull(predicate, "predicate");
 
             return i => parser(i).IfSuccess(s =>
                 predicate(s.Result) ? (IResult<T>)s : new Failure<T>(i,
@@ -463,9 +464,9 @@ namespace Sprache
             Func<T, Parser<U>> selector,
             Func<T, U, V> projector)
         {
-            if (parser == null) throw new ArgumentNullException("parser");
-            if (selector == null) throw new ArgumentNullException("selector");
-            if (projector == null) throw new ArgumentNullException("projector");
+            Preconditions.CheckNotNull(parser, "parser");
+            Preconditions.CheckNotNull(selector, "selector");
+            Preconditions.CheckNotNull(projector, "projector");
 
             return parser.Then(t => selector(t).Select(u => projector(t, u)));
         }
@@ -484,9 +485,9 @@ namespace Sprache
             Parser<T> operand,
             Func<TOp, T, T, T> apply)
         {
-            if (op == null) throw new ArgumentNullException("op");
-            if (operand == null) throw new ArgumentNullException("operand");
-            if (apply == null) throw new ArgumentNullException("apply");
+            Preconditions.CheckNotNull(op, "op");
+            Preconditions.CheckNotNull(operand, "operand");
+            Preconditions.CheckNotNull(apply, "apply");
             return operand.Then(first => ChainOperatorRest(first, op, operand, apply));
         }
 
@@ -496,9 +497,9 @@ namespace Sprache
             Parser<T> operand,
             Func<TOp, T, T, T> apply)
         {
-            if (op == null) throw new ArgumentNullException("op");
-            if (operand == null) throw new ArgumentNullException("operand");
-            if (apply == null) throw new ArgumentNullException("apply");
+            Preconditions.CheckNotNull(op, "op");
+            Preconditions.CheckNotNull(operand, "operand");
+            Preconditions.CheckNotNull(apply, "apply");
             return op.Then(opvalue =>
                     operand.Then(operandValue =>
                         ChainOperatorRest(apply(opvalue, firstOperand, operandValue), op, operand, apply)))
@@ -519,9 +520,9 @@ namespace Sprache
             Parser<T> operand,
             Func<TOp, T, T, T> apply)
         {
-            if (op == null) throw new ArgumentNullException("op");
-            if (operand == null) throw new ArgumentNullException("operand");
-            if (apply == null) throw new ArgumentNullException("apply");
+            Preconditions.CheckNotNull(op, "op");
+            Preconditions.CheckNotNull(operand, "operand");
+            Preconditions.CheckNotNull(apply, "apply");
             return operand.Then(first => ChainRightOperatorRest(first, op, operand, apply));
         }
 
@@ -531,9 +532,9 @@ namespace Sprache
             Parser<T> operand,
             Func<TOp, T, T, T> apply)
         {
-            if (op == null) throw new ArgumentNullException("op");
-            if (operand == null) throw new ArgumentNullException("operand");
-            if (apply == null) throw new ArgumentNullException("apply");
+            Preconditions.CheckNotNull(op, "op");
+            Preconditions.CheckNotNull(operand, "operand");
+            Preconditions.CheckNotNull(apply, "apply");
             return op.Then(opvalue =>
                     operand.Then(operandValue =>
                         ChainRightOperatorRest(operandValue, op, operand, apply)).Then(r =>

--- a/Source/EasyNetQ/Sprache/ParserOfT.cs
+++ b/Source/EasyNetQ/Sprache/ParserOfT.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using EasyNetQ;
 
 namespace Sprache
 {
@@ -11,16 +12,16 @@ namespace Sprache
     {
         public static IResult<T> TryParse<T>(this Parser<T> parser, string input)
         {
-            if (parser == null) throw new ArgumentNullException("parser");
-            if (input == null) throw new ArgumentNullException("input");
+            Preconditions.CheckNotNull(parser, "parser");
+            Preconditions.CheckNotNull(input, "input");
 
             return parser(new Input(input));
         }
 
         public static T Parse<T>(this Parser<T> parser, string input)
         {
-            if (parser == null) throw new ArgumentNullException("parser");
-            if (input == null) throw new ArgumentNullException("input");
+            Preconditions.CheckNotNull(parser, "parser");
+            Preconditions.CheckNotNull(input, "input");
 
             var result = parser.TryParse(input);
             

--- a/Source/EasyNetQ/Topology/Binding.cs
+++ b/Source/EasyNetQ/Topology/Binding.cs
@@ -7,22 +7,10 @@ namespace EasyNetQ.Topology
     {
         public Binding(IBindable bindable, IExchange exchange, params string[] routingKeys)
         {
-            if(bindable == null)
-            {
-                throw new ArgumentNullException("bindable");
-            }
-            if(exchange == null)
-            {
-                throw new ArgumentNullException("exchange");
-            }
-            if (routingKeys.Any(string.IsNullOrEmpty))
-            {
-                throw new ArgumentException("RoutingKey is null or empty");
-            }
-            if (routingKeys.Length == 0)
-            {
-                throw new ArgumentException("There must be at least one routingKey");
-            }
+            Preconditions.CheckNotNull(bindable, "bindable");
+            Preconditions.CheckNotNull(exchange, "exchange");
+            Preconditions.CheckAny(routingKeys, "routingKeys", "There must be at least one routingKey");
+            Preconditions.CheckFalse(routingKeys.Any(string.IsNullOrEmpty), "routingKeys", "RoutingKey is null or empty");
 
             Bindable = bindable;
             Exchange = exchange;
@@ -31,10 +19,7 @@ namespace EasyNetQ.Topology
 
         public void Visit(ITopologyVisitor visitor)
         {
-            if(visitor == null)
-            {
-                throw new ArgumentNullException("visitor");
-            }
+            Preconditions.CheckNotNull(visitor, "visitor");
 
             Exchange.Visit(visitor);
             visitor.CreateBinding(Bindable, Exchange, RoutingKeys);

--- a/Source/EasyNetQ/Topology/Exchange.cs
+++ b/Source/EasyNetQ/Topology/Exchange.cs
@@ -15,55 +15,37 @@ namespace EasyNetQ.Topology
 
         public static IExchange DeclareDirect(string exchangeName)
         {
-            if (string.IsNullOrEmpty(exchangeName))
-            {
-                throw new ArgumentException("name is null or empty");
-            }
+            Preconditions.CheckNotBlank(exchangeName, "exchangeName");
             return new Exchange(exchangeName, Topology.ExchangeType.Direct);
         }
 
         public static IExchange DeclareDirect(string exchangeName, bool autoDelete, IDictionary arguments)
         {
-            if (string.IsNullOrEmpty(exchangeName))
-            {
-                throw new ArgumentException("name is null or empty");
-            }
+            Preconditions.CheckNotBlank(exchangeName, "exchangeName");
             return new Exchange(exchangeName, Topology.ExchangeType.Direct, autoDelete, arguments);
         }
 
         public static IExchange DeclareTopic(string exchangeName)
         {
-            if (string.IsNullOrEmpty(exchangeName))
-            {
-                throw new ArgumentException("name is null or empty");
-            }
+            Preconditions.CheckNotBlank(exchangeName, "exchangeName");
             return new Exchange(exchangeName, Topology.ExchangeType.Topic);
         }
 
         public static IExchange DeclareTopic(string exchangeName, bool autoDelete, IDictionary arguments)
         {
-            if (string.IsNullOrEmpty(exchangeName))
-            {
-                throw new ArgumentException("name is null or empty");
-            }
+            Preconditions.CheckNotBlank(exchangeName, "exchangeName");
             return new Exchange(exchangeName, Topology.ExchangeType.Topic, autoDelete, arguments);
         }
 
         public static IExchange DeclareFanout(string exchangeName)
         {
-            if (string.IsNullOrEmpty(exchangeName))
-            {
-                throw new ArgumentException("name is null or empty");
-            }
+            Preconditions.CheckNotBlank(exchangeName, "exchangeName");
             return new Exchange(exchangeName, Topology.ExchangeType.Fanout);
         }
 
         public static IExchange DeclareFanout(string exchangeName, bool autoDelete, IDictionary arguments)
         {
-            if (string.IsNullOrEmpty(exchangeName))
-            {
-                throw new ArgumentException("name is null or empty");
-            }
+            Preconditions.CheckNotBlank(exchangeName, "exchangeName");
             return new Exchange(exchangeName, Topology.ExchangeType.Fanout, autoDelete, arguments);
         }
 
@@ -74,10 +56,7 @@ namespace EasyNetQ.Topology
 
         protected Exchange(string name, string exchangeType)
         {
-            if(name == null)
-            {
-                throw new ArgumentNullException("name");
-            }
+            Preconditions.CheckNotNull(name, "name");
 
             Name = name;
             ExchangeType = exchangeType;
@@ -85,10 +64,7 @@ namespace EasyNetQ.Topology
 
         protected Exchange(string name, string exchangeType, bool autoDelete, IDictionary arguments)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException("name");
-            }
+            Preconditions.CheckNotNull(name, "name");
 
             Name = name;
             ExchangeType = exchangeType;
@@ -98,10 +74,8 @@ namespace EasyNetQ.Topology
 
         public virtual void Visit(ITopologyVisitor visitor)
         {
-            if (visitor == null)
-            {
-                throw new ArgumentNullException("visitor");
-            }
+            Preconditions.CheckNotNull(visitor, "visitor");
+
             if (Name != string.Empty)
             {
                 visitor.CreateExchange(Name, ExchangeType, AutoDelete, Arguments);
@@ -114,18 +88,9 @@ namespace EasyNetQ.Topology
 
         public virtual void BindTo(IExchange exchange, params string[] routingKeys)
         {
-            if (exchange == null)
-            {
-                throw new ArgumentNullException("exchange");
-            }
-            if (routingKeys.Any(string.IsNullOrEmpty))
-            {
-                throw new ArgumentException("RoutingKey is null or empty");
-            }
-            if (routingKeys.Length == 0)
-            {
-                throw new ArgumentException("There must be at least one routingKey");
-            }
+            Preconditions.CheckNotNull(exchange, "exchange");
+            Preconditions.CheckAny(routingKeys, "routingKeys", "There must be at least one routingKey");
+            Preconditions.CheckFalse(routingKeys.Any(string.IsNullOrEmpty), "routingKeys", "RoutingKey is null or empty");
 
             var binding = new Binding(this, exchange, routingKeys);
             bindings.Add(binding);

--- a/Source/EasyNetQ/Topology/Queue.cs
+++ b/Source/EasyNetQ/Topology/Queue.cs
@@ -60,10 +60,8 @@ namespace EasyNetQ.Topology
         protected Queue(bool durable, bool exclusive, bool autoDelete, string name, IDictionary<string, object> arguements)
             : this(durable, exclusive, autoDelete, arguements)
         {
-            if(string.IsNullOrEmpty(name))
-            {
-                throw new ArgumentException("name is null or empty");
-            }
+            Preconditions.CheckNotBlank(name, "name");
+
             Name = name;
         }
 
@@ -87,21 +85,13 @@ namespace EasyNetQ.Topology
 
         public void BindTo(IExchange exchange, params string[] routingKeys)
         {
-            if(exchange == null)
-            {
-                throw new ArgumentNullException("exchange");
-            }
+            Preconditions.CheckNotNull(exchange, "exchange");
+            Preconditions.CheckAny(routingKeys, "routingKeys", "There must be at least one routingKey");
+            Preconditions.CheckFalse(routingKeys.Any(string.IsNullOrEmpty), "routingKeys", "RoutingKey is null or empty");
+
             if (exchange is DefaultExchange)
             {
                 throw new EasyNetQException("All queues are bound automatically to the default exchange, do bind manually.");
-            }
-            if (routingKeys.Any(string.IsNullOrEmpty))
-            {
-                throw new ArgumentException("RoutingKey is null or empty");
-            }
-            if (routingKeys.Length == 0)
-            {
-                throw new ArgumentException("There must be at least one routingKey");
             }
 
             var binding = new Binding(this, exchange, routingKeys);
@@ -110,10 +100,7 @@ namespace EasyNetQ.Topology
 
         public void Visit(ITopologyVisitor visitor)
         {
-            if(visitor == null)
-            {
-                throw new ArgumentNullException("visitor");
-            }
+            Preconditions.CheckNotNull(visitor, "visitor");
 
             if (Name == null)
             {

--- a/Source/EasyNetQ/Topology/TopologyBuilder.cs
+++ b/Source/EasyNetQ/Topology/TopologyBuilder.cs
@@ -12,30 +12,21 @@ namespace EasyNetQ.Topology
 
         public TopologyBuilder(IModel model)
         {
-            if(model == null)
-            {
-                throw new ArgumentNullException("model");
-            }
+            Preconditions.CheckNotNull(model, "model");
 
             this.model = model;
         }
 
         public void CreateExchange(string exchangeName, string exchangeType, bool autoDelete, IDictionary arguments)
         {
-            if(exchangeName == null)
-            {
-                throw new ArgumentNullException("exchangeName");
-            }
+            Preconditions.CheckNotNull(exchangeName, "exchangeName");
 
             model.ExchangeDeclare(exchangeName, exchangeType, true, autoDelete, arguments);
         }
 
         public void CreateQueue(string queueName, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object> arguments)
         {
-            if (string.IsNullOrEmpty(queueName))
-            {
-                throw new ArgumentException("queueName is null or empty");
-            }
+            Preconditions.CheckNotBlank(queueName, "queueName");
 
             model.QueueDeclare(queueName, durable, exclusive, autoDelete, (IDictionary)arguments);
         }
@@ -48,22 +39,10 @@ namespace EasyNetQ.Topology
 
         public void CreateBinding(IBindable bindable, IExchange exchange, string[] routingKeys)
         {
-            if(bindable == null)
-            {
-                throw new ArgumentNullException("bindable");
-            }
-            if(exchange == null)
-            {
-                throw new ArgumentNullException("exchange");
-            }
-            if (routingKeys.Any(string.IsNullOrEmpty))
-            {
-                throw new ArgumentException("RoutingKey is null or empty");
-            }
-            if (routingKeys.Length == 0)
-            {
-                throw new ArgumentException("There must be at least one routingKey");
-            }
+            Preconditions.CheckNotNull(bindable, "bindable");
+            Preconditions.CheckNotNull(exchange, "exchange");
+            Preconditions.CheckAny(routingKeys, "routingKeys", "There must be at least one routingKey");
+            Preconditions.CheckFalse(routingKeys.Any(string.IsNullOrEmpty), "routingKeys", "RoutingKey is null or empty");
 
             var queue = bindable as IQueue;
             if(queue != null)

--- a/Source/EasyNetQ/TypeNameSerializer.cs
+++ b/Source/EasyNetQ/TypeNameSerializer.cs
@@ -6,10 +6,7 @@ namespace EasyNetQ
     {
         public static string Serialize(Type type)
         {
-            if (type == null)
-            {
-                throw new ArgumentNullException("type");
-            }
+            Preconditions.CheckNotNull(type, "type");
             return type.FullName.Replace('.', '_') + ":" + type.Assembly.GetName().Name.Replace('.', '_');
         }
     }


### PR DESCRIPTION
I've been referring to the source of EasyNetQ a lot whilst working on a custom RabbitMQ client (there's some special cases I need to cover and I need it to compile to .NET 3.5) so I thought I'd try and give at least a little back.

I noticed a general pattern, that I also use, of checking method parameters for null to fail-fast with a more meaningful message. However, I usually use a `Preconditions` class along the lines of the one I've introduced here. I implemented it to throw the same kind of exception with the same message as existed before so it should be non-breaking (the tests still pass) but hopefully it's added some clarity to the methods utilising it.

To pull a single example out:

``` csharp
public static void FuturePublish<T>(this IPublishChannel publishChannel, DateTime timeToRespond, T message)
{
    // Before (4 lines)
    if (message == null)
    {
        throw new ArgumentNullException("message");
    }

    // After (1 line)
    Preconditions.CheckNotNull(message, "message");

    var advancedBus = publishChannel.Bus.Advanced;
    // etc
```
