### PR TITLE
Possible to add input arguments when creating bindings and queues

### DIFF
--- a/Source/EasyNetQ.Management.Client/EasyNetQ.Management.Client.csproj
+++ b/Source/EasyNetQ.Management.Client/EasyNetQ.Management.Client.csproj
@@ -68,7 +68,6 @@
     <Compile Include="Model\ExchangeInfo.cs" />
     <Compile Include="Model\ExchangeType.cs" />
     <Compile Include="Model\GetMessagesCriteria.cs" />
-    <Compile Include="Model\InputArgument.cs" />
     <Compile Include="Model\InputArguments.cs" />
     <Compile Include="Model\Listener.cs" />
     <Compile Include="Model\Message.cs" />

--- a/Source/EasyNetQ.Management.Client/Model/InputArgument.cs
+++ b/Source/EasyNetQ.Management.Client/Model/InputArgument.cs
@@ -1,6 +1,0 @@
-namespace EasyNetQ.Management.Client.Model
-{
-    public class InputArgument
-    {
-    }
-}

--- a/Source/EasyNetQ.Management.Client/Model/InputArguments.cs
+++ b/Source/EasyNetQ.Management.Client/Model/InputArguments.cs
@@ -2,5 +2,5 @@ using System.Collections.Generic;
 
 namespace EasyNetQ.Management.Client.Model
 {
-    public class InputArguments : List<InputArgument>{}
+    public class InputArguments : Dictionary<string, string>{}
 }


### PR DESCRIPTION
InputArguments where a list of InputArgument objects. InputArgument don't have any properties, why it wasn't possible to specify input arguments. I've changed InputArguments to extend Dictionary<string, string> like the existing Arguments class. The InputArgument class seems redundant after this change why I removed it.
