### PR TITLE
Rename routingkey/queue for request/response with conventions

### DIFF
--- a/Source/EasyNetQ/Conventions.cs
+++ b/Source/EasyNetQ/Conventions.cs
@@ -5,7 +5,8 @@ namespace EasyNetQ
 {
 	public delegate string ExchangeNameConvention(Type messageType);
 	public delegate string TopicNameConvention(Type messageType);
-	public delegate string QueueNameConvention(Type messageType, string subscriberId);
+    public delegate string QueueNameConvention(Type messageType, string subscriberId);
+    public delegate string RpcRoutingKeyNamingConvention(Type messageType);
 
     public delegate string ErrorQueueNameConvention();
     public delegate string ErrorExchangeNameConvention(string  originalRoutingKey);
@@ -13,10 +14,10 @@ namespace EasyNetQ
 
 	public interface IConventions
 	{
-
 		ExchangeNameConvention ExchangeNamingConvention { get; set; }
 		TopicNameConvention TopicNamingConvention { get; set; }
-		QueueNameConvention QueueNamingConvention { get; set; }
+        QueueNameConvention QueueNamingConvention { get; set; }
+        RpcRoutingKeyNamingConvention RpcRoutingKeyNamingConvention { get; set; }
 
         ErrorQueueNameConvention ErrorQueueNamingConvention { get; set; }
         ErrorExchangeNameConvention ErrorExchangeNamingConvention { get; set; }
@@ -36,6 +37,7 @@ namespace EasyNetQ
 						var typeName = TypeNameSerializer.Serialize(messageType);
 						return string.Format("{0}_{1}", typeName, subscriptionId);
 					};
+            RpcRoutingKeyNamingConvention = TypeNameSerializer.Serialize;
 
             ErrorQueueNamingConvention = () => "EasyNetQ_Default_Error_Queue";
             ErrorExchangeNamingConvention = (originalRoutingKey) => "ErrorExchange_" + originalRoutingKey;
@@ -44,7 +46,8 @@ namespace EasyNetQ
 
 		public ExchangeNameConvention ExchangeNamingConvention { get; set; }
 		public TopicNameConvention TopicNamingConvention { get; set; }
-		public QueueNameConvention QueueNamingConvention { get; set; }
+        public QueueNameConvention QueueNamingConvention { get; set; }
+        public RpcRoutingKeyNamingConvention RpcRoutingKeyNamingConvention { get; set; }
 
         public ErrorQueueNameConvention ErrorQueueNamingConvention { get; set; }
         public ErrorExchangeNameConvention ErrorExchangeNamingConvention { get; set; }

--- a/Source/EasyNetQ/RabbitBus.cs
+++ b/Source/EasyNetQ/RabbitBus.cs
@@ -148,11 +148,11 @@ namespace EasyNetQ
         {
             Preconditions.CheckNotNull(responder, "responder");
 
-            var requestTypeName = serializeType(typeof(TRequest));
+            var routingKey = conventions.RpcRoutingKeyNamingConvention(typeof (TRequest));
 
             var exchange = Exchange.DeclareDirect(conventions.RpcExchangeNamingConvention());
-            var queue = Queue.DeclareDurable(requestTypeName, arguments);
-            queue.BindTo(exchange, requestTypeName);
+            var queue = Queue.DeclareDurable(routingKey, arguments);
+            queue.BindTo(exchange, routingKey);
 
             advancedBus.Subscribe<TRequest>(queue, (requestMessage, messageRecievedInfo) =>
             {

--- a/Source/EasyNetQ/RabbitPublishChannel.cs
+++ b/Source/EasyNetQ/RabbitPublishChannel.cs
@@ -167,13 +167,13 @@ namespace EasyNetQ
 
         private void RequestPublish<TRequest>(TRequest request, string returnQueueName)
         {
-            var requestTypeName = bus.SerializeType(typeof(TRequest));
+            var routingKey = conventions.RpcRoutingKeyNamingConvention(typeof(TRequest));
             var exchange = Exchange.DeclareDirect(conventions.RpcExchangeNamingConvention());
 
             var requestMessage = new Message<TRequest>(request);
             requestMessage.Properties.ReplyTo = returnQueueName;
 
-            advancedPublishChannel.Publish(exchange, requestTypeName, requestMessage, configuration => {});
+            advancedPublishChannel.Publish(exchange, routingKey, requestMessage, configuration => { });
         }
 
         public void Dispose()


### PR DESCRIPTION
The conventions have been extended with a RpcRoutingKeyNamingConvention delegate.
This is used in the response/request scenario for renaming the routingkey/queue name.
If nothing is provided, the default is used: the typename serialization.
Conventions unit test is extended for the new delegate.
