### PR TITLE
Added support for num messages to command line args

### DIFF
--- a/Source/EasyNetQ.Hosepipe/ArgParser.cs
+++ b/Source/EasyNetQ.Hosepipe/ArgParser.cs
@@ -59,6 +59,24 @@ namespace EasyNetQ.Hosepipe
             return TryResult.Pass();
         }
 
+        public TryResult WithKey<T>(string key, Action<Argument> argumentAction) where T:IConvertible
+        {
+            if (!keys.ContainsKey(key)) return TryResult.Fail();
+
+            try 
+            {
+                Convert.ChangeType(keys[key].Value, typeof(T));
+            } 
+            catch (InvalidCastException)
+            {
+                return TryResult.Fail();
+            }
+
+            var argument = keys[key];
+            argumentAction(argument);
+            return TryResult.Pass();
+        }
+
         public TryResult At(int position, string command, Action argumentAction)
         {
             if (position < 0 || position >= arguments.Count) return TryResult.Fail();

--- a/Source/EasyNetQ.Hosepipe/Program.cs
+++ b/Source/EasyNetQ.Hosepipe/Program.cs
@@ -66,6 +66,8 @@ namespace EasyNetQ.Hosepipe
             arguments.WithKey("u", a => parameters.Username = a.Value);
             arguments.WithKey("p", a => parameters.Password = a.Value);
             arguments.WithKey("o", a => parameters.MessageFilePath = a.Value);
+            arguments.WithKey<int>("n", a => parameters.NumberOfMessagesToRetrieve = int.Parse(a.Value))
+                .FailWith(messsage("Invalid number of messages to retrieve"));
 
             try
             {


### PR DESCRIPTION
It wasn't obvious to me how to support arguments other than strings without making the Value property of Argument an object or IConvertible.  Hopefully this approach is reasonable and fits the Try/Pass pattern (not seen it before).

http://stackoverflow.com/questions/16458881/easynetq-hosepipe-limit
