### PR TITLE
Enable numerical values for arguments

### DIFF
--- a/Source/EasyNetQ.Management.Client/Model/InputArguments.cs
+++ b/Source/EasyNetQ.Management.Client/Model/InputArguments.cs
@@ -2,5 +2,5 @@ using System.Collections.Generic;
 
 namespace EasyNetQ.Management.Client.Model
 {
-    public class InputArguments : Dictionary<string, string>{}
+    public class InputArguments : Dictionary<string, object>{}
 }


### PR DESCRIPTION
Queue argument x-message-ttl requires a numerical value, but currently the value gets serialised as a string
