### PR TITLE
Allow ITopologyVisitor to be injected into IAdvancedBus and IAdvancedPublishChannel lowest level methods.

### DIFF
--- a/Source/EasyNetQ/IAdvancedBus.cs
+++ b/Source/EasyNetQ/IAdvancedBus.cs
@@ -31,6 +31,17 @@ namespace EasyNetQ
         void Subscribe(IQueue queue, Func<Byte[], MessageProperties, MessageReceivedInfo, Task> onMessage);
 
         /// <summary>
+        /// Subscribe to raw bytes from the queue.
+        /// </summary>
+        /// <param name="queue">The queue to subscribe to</param>
+        /// <param name="onMessage">
+        /// The message handler. Takes the message body, message properties and some information about the 
+        /// receive context. Returns a Task.
+        /// </param>
+        /// <param name="topologyVisitor">Topology visitor to apply to the queue></param>
+        void Subscribe(IQueue queue, Func<Byte[], MessageProperties, MessageReceivedInfo, Task> onMessage, ITopologyVisitor topologyVisitor);
+
+        /// <summary>
         /// Return a channel for publishing.
         /// </summary>
         /// <returns>IAdvancedPublishChannel</returns>

--- a/Source/EasyNetQ/IAdvancedPublishChannel.cs
+++ b/Source/EasyNetQ/IAdvancedPublishChannel.cs
@@ -27,6 +27,17 @@ namespace EasyNetQ
         void Publish(IExchange exchange, string routingKey, MessageProperties properties, byte[] messageBody, Action<IAdvancedPublishConfiguration> configure);
 
         /// <summary>
+        /// Publish raw bytes to the bus.
+        /// </summary>
+        /// <param name="exchange">The exchange to publish to</param>
+        /// <param name="routingKey">The routing key</param>
+        /// <param name="properties">The message properties</param>
+        /// <param name="messageBody">The message bytes to publish</param>
+        /// <param name="configure">Configure the publish</param>
+        /// <param name="topologyVisitor">Visitor to apply to the exchange</param>
+        void Publish(IExchange exchange, string routingKey, MessageProperties properties, byte[] messageBody, Action<IAdvancedPublishConfiguration> configure, ITopologyVisitor topologyVisitor);
+
+        /// <summary>
         /// Publish a message.
         /// </summary>
         /// <typeparam name="T">The message type</typeparam>

--- a/Source/EasyNetQ/RabbitAdvancedPublishChannel.cs
+++ b/Source/EasyNetQ/RabbitAdvancedPublishChannel.cs
@@ -73,7 +73,12 @@ namespace EasyNetQ
             Publish(exchange, routingKey, message.Properties, messageBody, configure);
         }
 
-        public virtual void Publish(IExchange exchange, string routingKey, MessageProperties properties, byte[] messageBody, Action<IAdvancedPublishConfiguration> configure)
+        public virtual void Publish(IExchange exchange, string routingKey, MessageProperties properties,
+            byte[] messageBody, Action<IAdvancedPublishConfiguration> configure)
+        {
+            Publish(exchange, routingKey, properties, messageBody, configure, new TopologyBuilder(channel));
+        }
+        public virtual void Publish(IExchange exchange, string routingKey, MessageProperties properties, byte[] messageBody, Action<IAdvancedPublishConfiguration> configure,ITopologyVisitor topologyVisitor)
         {
             Preconditions.CheckNotNull(exchange, "exchange");
             Preconditions.CheckNotNull(routingKey, "routingKey");
@@ -108,7 +113,7 @@ namespace EasyNetQ
                 var defaultProperties = channel.CreateBasicProperties();
                 properties.CopyTo(defaultProperties);
 
-                exchange.Visit(new TopologyBuilder(channel));
+                exchange.Visit(topologyVisitor);
 
                 channel.BasicPublish(
                     exchange.Name,      // exchange


### PR DESCRIPTION
This implements a partial workaround for issue #29. Refactored out the methods in IAdvancedBus and IAdvancedPublishChannel that apply the topology visitor to Queues and Exchanges to have an overload that accepts an ITopologyVisitor. In my consumer code where I want to suppress queue and exchange creation, I call these overloads with a visitor that does nothing with the queues and exchanges it visits.

I need to be able to not create the topology for the subscriber on publish in order to avoid RabbitMQ errors when the queue/exchange already exists with a different parameter than what I specify in EasyNetQ.
