### PR TITLE
Handle null responses from Admin API more better

### DIFF
--- a/Source/EasyNetQ.Management.Client.Tests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/ManagementClientTests.cs
@@ -39,7 +39,7 @@ namespace EasyNetQ.Management.Client.Tests
                 Console.Out.WriteLine("listener.IpAddress = {0}", listener.IpAddress);
             }
 
-            Console.Out.WriteLine("overview.Messages = {0}", overview.QueueTotals.Messages);
+            Console.Out.WriteLine("overview.Messages = {0}", overview.QueueTotals != null ? overview.QueueTotals.Messages : 0);
 
             foreach (var context in overview.Contexts)
             {
@@ -52,8 +52,8 @@ namespace EasyNetQ.Management.Client.Tests
         {
             var nodes = managementClient.GetNodes();
 
-            nodes.Count().ShouldEqual(1);
-            nodes.First().Name.ShouldEqual("rabbit@THOMAS");
+            nodes.Count().ShouldNotEqual(0);
+            nodes.First().Name.ShouldEqual("rabbit@" + Environment.MachineName);
         }
 
         [Test]

--- a/Source/EasyNetQ.Management.Client.Tests/TestExtensions.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/TestExtensions.cs
@@ -25,6 +25,13 @@ namespace EasyNetQ.Management.Client.Tests
             return actual;
         }
 
+        public static T ShouldNotEqual<T>(this T actual, object expected)
+        {
+            Assert.AreNotEqual(expected, actual);
+            return actual;
+        }
+
+
         public static T ShouldEqual<T>(this T actual, object expected, string message)
         {
             Assert.AreEqual(expected, actual, message);

--- a/Source/EasyNetQ.Management.Client/EasyNetQ.Management.Client.csproj
+++ b/Source/EasyNetQ.Management.Client/EasyNetQ.Management.Client.csproj
@@ -93,6 +93,7 @@
     <Compile Include="RabbitContractResolver.cs" />
     <Compile Include="Serialization\ClientPropertiesJsonConverter.cs" />
     <Compile Include="Serialization\PropertyConverter.cs" />
+    <Compile Include="Serialization\StringOrArrayConverter.cs" />
     <Compile Include="Serialization\UnixDateTimeConverter.cs" />
     <Compile Include="Serialization\UnixDateTimeHelper.cs" />
     <Compile Include="Serialization\UnixMsDateTimeConverter.cs" />

--- a/Source/EasyNetQ.Management.Client/ManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClient.cs
@@ -66,6 +66,8 @@ namespace EasyNetQ.Management.Client
             };
 
             settings.Converters.Add(new PropertyConverter());
+            settings.Converters.Add(new MessageStatsOrEmptyArrayConverter());
+            settings.Converters.Add(new QueueTotalsOrEmptyArrayConverter());
 
             LeaveDotsAndSlashesEscaped();
         }

--- a/Source/EasyNetQ.Management.Client/Model/Overview.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Overview.cs
@@ -9,7 +9,7 @@ namespace EasyNetQ.Management.Client.Model
         public List<ExchangeType> ExchangeTypes { get; set; }
         public string RabbitmqVersion { get; set; }
         public string ErlangVersion { get; set; }
-        public List<object> MessageStats { get; set; }
+        public MessageStats MessageStats { get; set; }
         public QueueTotals QueueTotals { get; set; }
         public ObjectTotals ObjectTotals { get; set; }
         public string Node { get; set; }

--- a/Source/EasyNetQ.Management.Client/Serialization/ObjectOrEmptyArrayConverter.cs
+++ b/Source/EasyNetQ.Management.Client/Serialization/ObjectOrEmptyArrayConverter.cs
@@ -1,0 +1,49 @@
+namespace EasyNetQ.Management.Client.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using Model;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    class MessageStatsOrEmptyArrayConverter : ObjectOrEmptyArrayConverter<MessageStats>
+    {
+        
+    }
+    class QueueTotalsOrEmptyArrayConverter : ObjectOrEmptyArrayConverter<List<object>>
+    {
+        
+    }
+    class ObjectOrEmptyArrayConverter<T> : JsonConverter where T:new()
+    {
+        // From http://stackoverflow.com/questions/17171737/how-to-deserialize-json-data-which-sometimes-is-an-empty-array-and-sometimes-a-s
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.StartArray)
+            {
+                reader.Read();
+                if (reader.TokenType != JsonToken.EndArray)
+                    throw new JsonReaderException("Empty array expected.");
+                return default(T);
+            }
+            var jObject = JObject.Load(reader);
+
+            // Create target object based on JObject
+            var target = new T();
+
+            // Populate the object properties
+            serializer.Populate(jObject.CreateReader(), target);
+            return target;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            serializer.Serialize(writer, value);
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(T);
+        }
+    }
+}


### PR DESCRIPTION
It seems that the RabbitMQ REST API returns an empty array in place of null for some objects. I noticed that when running GetOverview() against a brand new RabbitMQ cluster. If there had been no activity on the server before overview is requested, the queue_totals value is returned as [].

This change sets it up so that the empty array for a response object is interpreted as null. I noticed that this was happening for queue_totals and message_stats so I have converters for QueueTotals and MessageStats.
