### PR TITLE
testing if subscriptionAction.Channel.IsOpen when re-creating subscribers

### DIFF
--- a/Source/EasyNetQ/RabbitAdvancedPublishChannel.cs
+++ b/Source/EasyNetQ/RabbitAdvancedPublishChannel.cs
@@ -65,9 +65,9 @@ namespace EasyNetQ
             var messageBody = advancedBus.Serializer.MessageToBytes(message.Body);
 
             message.Properties.Type = typeName;
-            message.Properties.CorrelationId = 
+            message.Properties.CorrelationId =
                 string.IsNullOrEmpty(message.Properties.CorrelationId) ?
-                advancedBus.GetCorrelationId() : 
+                advancedBus.GetCorrelationId() :
                 message.Properties.CorrelationId;
 
             Publish(exchange, routingKey, message.Properties, messageBody, configure);
@@ -78,7 +78,7 @@ namespace EasyNetQ
         {
             Publish(exchange, routingKey, properties, messageBody, configure, new TopologyBuilder(channel));
         }
-        public virtual void Publish(IExchange exchange, string routingKey, MessageProperties properties, byte[] messageBody, Action<IAdvancedPublishConfiguration> configure,ITopologyVisitor topologyVisitor)
+        public virtual void Publish(IExchange exchange, string routingKey, MessageProperties properties, byte[] messageBody, Action<IAdvancedPublishConfiguration> configure, ITopologyVisitor topologyVisitor)
         {
             Preconditions.CheckNotNull(exchange, "exchange");
             Preconditions.CheckNotNull(routingKey, "routingKey");
@@ -121,7 +121,7 @@ namespace EasyNetQ
                     defaultProperties,  // basicProperties
                     messageBody);       // body
 
-                advancedBus.Logger.DebugWrite("Published to exchange: '{0}', routing key: '{1}', correlationId: '{2}'", 
+                advancedBus.Logger.DebugWrite("Published to exchange: '{0}', routing key: '{1}', correlationId: '{2}'",
                     exchange.Name, routingKey, defaultProperties.CorrelationId);
             }
             catch (OperationInterruptedException exception)
@@ -136,12 +136,12 @@ namespace EasyNetQ
 
         public virtual void Publish<T>(IExchange exchange, string routingKey, IMessage<T> message)
         {
-            Publish(exchange, routingKey, message, configuration => {});
+            Publish(exchange, routingKey, message, configuration => { });
         }
 
         public virtual void Publish(IExchange exchange, string routingKey, MessageProperties properties, byte[] messageBody)
         {
-            Publish(exchange, routingKey, properties, messageBody, configuration => {});
+            Publish(exchange, routingKey, properties, messageBody, configuration => { });
         }
     }
 }


### PR DESCRIPTION
topologyVisitor parameter cannot be re-used, even if it's not null,  without first checking that the channel to which it is bound is not closed - which happens when the consumer disconnects and reconnects unexpectedly.

The code would be clearer if  public virtual void Subscribe(IQueue queue, Func<Byte[], MessageProperties, MessageReceivedInfo, Task> onMessage, ITopologyVisitor topologyVisitor) didn't take in the  ITopologyVisitor topologyVisitor argument. I can't see why anyone would want to pass topologyVisitor in, or any usages.
