### PR TITLE
Fix test failing in build #106

### DIFF
--- a/Source/EasyNetQ.InMemoryClient/InMemoryModel.cs
+++ b/Source/EasyNetQ.InMemoryClient/InMemoryModel.cs
@@ -335,7 +335,7 @@ namespace EasyNetQ.InMemoryClient
 
         public bool IsOpen
         {
-            get { throw new NotImplementedException(); }
+            get { return true; }
         }
 
         public ulong NextPublishSeqNo


### PR DESCRIPTION
Should_be_able_to_resubscribe_in_case_queue_is_deleted_or_primary_node_is_down was failing because it was calling a stubbed out method on InMemoryModel that was throwing an exception that'd get silently swallowed because it was on a separate thread. Made IsOpen always return true.
