### PR TITLE
Fixed issue with queues consumers not being recreated after reconnecting.

### DIFF
--- a/Source/EasyNetQ.InMemoryClient/InMemoryModel.cs
+++ b/Source/EasyNetQ.InMemoryClient/InMemoryModel.cs
@@ -335,7 +335,7 @@ namespace EasyNetQ.InMemoryClient
 
         public bool IsOpen
         {
-            get { throw new NotImplementedException(); }
+            get { return true; }
         }
 
         public ulong NextPublishSeqNo


### PR DESCRIPTION
Fix for issue #100.

After connection is dropped and reconnected same channels cannot be used anymore. 

Checking for ..subscriptionAction.Channel.IsOpen == false.. isn't enough because it always returns true.  Even after connection is dropped. 
Actually not sure then it would be false at all. Maybe after calling close method on channel object.

To fix this introduced new parameter explicitly defining if it's new connection or same connection (In case of Consumer Cancel Notification).
