### PR TITLE
Replaced uint with int in queue parameters dictionary 

### DIFF
--- a/Source/EasyNetQ/IAdvancedBus.cs
+++ b/Source/EasyNetQ/IAdvancedBus.cs
@@ -52,19 +52,12 @@ namespace EasyNetQ
         /// <param name="passive">Throw an exception rather than create the queue if it doesn't exist</param>
         /// <param name="durable">Durable queues remain active when a server restarts.</param>
         /// <param name="exclusive">Exclusive queues may only be accessed by the current connection, 
-        /// and are deleted when that connection closes.</param>
+        ///     and are deleted when that connection closes.</param>
         /// <param name="autoDelete">If set, the queue is deleted when all consumers have finished using it.</param>
         /// <param name="perQueueTtl">How long a message published to a queue can live before it is discarded by the server.</param>
         /// <param name="expires">Determines how long a queue can remain unused before it is automatically deleted by the server.</param>
         /// <returns>The queue</returns>
-        IQueue QueueDeclare(
-            string name,
-            bool passive = false,
-            bool durable = true,
-            bool exclusive = false,
-            bool autoDelete = false,
-            uint perQueueTtl = uint.MaxValue,
-            uint expires = uint.MaxValue);
+        IQueue QueueDeclare(string name, bool passive = false, bool durable = true, bool exclusive = false, bool autoDelete = false, int perQueueTtl = int.MaxValue, int expires = int.MaxValue);
 
         /// <summary>
         /// Declare a transient server named queue. Note, this queue will only last for duration of the

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -123,8 +123,8 @@ namespace EasyNetQ
             bool durable = true, 
             bool exclusive = false,
             bool autoDelete = false, 
-            uint perQueueTtl = UInt32.MaxValue, 
-            uint expires = UInt32.MaxValue)
+            int perQueueTtl = int.MaxValue, 
+            int expires = int.MaxValue)
         {
             Preconditions.CheckNotNull(name, "name");
 
@@ -132,25 +132,18 @@ namespace EasyNetQ
             {
                 IDictionary<string, object> arguments = new Dictionary<string, object>();
                 if (passive)
-                {
                     model.QueueDeclarePassive(name);
-                }
                 else
                 {
-                    if (perQueueTtl != uint.MaxValue)
-                    {
+                    if (perQueueTtl != int.MaxValue)
                         arguments.Add("x-message-ttl", perQueueTtl);
-                    }
 
-                    if (expires != uint.MaxValue)
-                    {
+                    if (expires != int.MaxValue)
                         arguments.Add("x-expires", expires);
-                    }
 
-                    model.QueueDeclare(name, durable, exclusive, autoDelete, (IDictionary)arguments);
+                    model.QueueDeclare(name, durable, exclusive, autoDelete, (IDictionary) arguments);
 
-                    logger.DebugWrite("Declared Queue: '{0}' durable:{1}, exclusive:{2}, autoDelte:{3}, args:{4}",
-                        name, durable, exclusive, autoDelete, WriteArguments(arguments));
+                    logger.DebugWrite("Declared Queue: '{0}' durable:{1}, exclusive:{2}, autoDelte:{3}, args:{4}", name, durable, exclusive, autoDelete, WriteArguments(arguments));
                 }
 
                 return new Topology.Queue(name, exclusive);


### PR DESCRIPTION
uint is not working when casting from IDictionary<string, object> to IDictionary in the call to model.QueueDeclare(name, durable, exclusive, autoDelete, (IDictionary)arguments) on RabbitMQ.Client.
