### PR TITLE
Use Passive while declaring exchange

### DIFF
--- a/Source/EasyNetQ.Tests/Integration/AdvancedApiExamples.cs
+++ b/Source/EasyNetQ.Tests/Integration/AdvancedApiExamples.cs
@@ -35,6 +35,15 @@ namespace EasyNetQ.Tests.Integration
 
         }
 
+        [Test,Explicit]
+        public void DeclareTopologyAndCheckPassive()
+        {
+            var queue = advancedBus.QueueDeclare("my_queue");
+            var exchange = advancedBus.ExchangeDeclare("my_exchange", ExchangeType.Direct);
+            advancedBus.Bind(exchange, queue, "routing_key");
+            advancedBus.ExchangeDeclare("my_exchange", ExchangeType.Direct, passive: true);
+        }
+
         [Test, Explicit]
         public void DeclareWithTtlAndExpire()
         {

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -214,7 +214,10 @@ namespace EasyNetQ
 
             using (var model = connection.CreateModel())
             {
-                model.ExchangeDeclare(name, type, durable, autoDelete, null);
+                if (passive)
+                    model.ExchangeDeclarePassive(name);
+                else
+	                model.ExchangeDeclare(name, type, durable, autoDelete, null);
                 logger.DebugWrite("Declared Exchange: {0} type:{1}, durable:{2}, autoDelete:{3}",
                     name, type, durable, autoDelete);
                 return new Exchange(name);


### PR DESCRIPTION
Boolean value, Passive is currently unused while declaring exchange in
RabbitAdvancedBus. Changed this method to use it and added a test cover
the scenario.
