### PR TITLE
Remove misleading message from InternalConsumer when handling basic.cancel

### DIFF
--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -125,7 +125,7 @@ namespace EasyNetQ.Consumer
         {
             Cancel();
             logger.InfoWrite("BasicCancel(Consumer Cancel Notification from broker) event received. " +
-                             "Recreating queue and queue listener. Consumer tag: " + consumerTag);
+                             "Consumer tag: " + consumerTag);
         }
 
         public void HandleModelShutdown(IModel model, ShutdownEventArgs reason)


### PR DESCRIPTION
This appears to be from before TransientConsumer and others existed and no
longer applies.

I could be missing something, but I'm certainly not seeing or expecting the
behaviour described by the log message in the case of an exclusive queue
that I have deleted.
