### PR TITLE
Include XML documentation in NuGet package

### DIFF
--- a/Build/EasyNetQ.proj
+++ b/Build/EasyNetQ.proj
@@ -50,6 +50,7 @@
         <Delete Files="@(FilesToDelete)" />
     
         <Copy SourceFiles="$(OutputDir)\EasyNetQ.dll" DestinationFolder="$(Package)\EasyNetQ\lib\net40" />
+        <Copy SourceFiles="$(OutputDir)\EasyNetQ.xml" DestinationFolder="$(Package)\EasyNetQ\lib\net40" />
         
         <GetAssemblyIdentity AssemblyFiles="$(OutputDir)\EasyNetQ.dll">
             <Output TaskParameter="Assemblies" ItemName="AsmInfo" />

--- a/Source/EasyNetQ/EasyNetQ.csproj
+++ b/Source/EasyNetQ/EasyNetQ.csproj
@@ -30,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\EasyNetQ.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">


### PR DESCRIPTION
This documentation is only built for release due to warnings generated due
to missing documentation for some publicly visible types.
