### PR TITLE
added 2 possible appSetting options to ScheduleRepositoryConfiguration:

### DIFF
--- a/Source/EasyNetQ.Scheduler/ScheduleRepositoryConfiguration.cs
+++ b/Source/EasyNetQ.Scheduler/ScheduleRepositoryConfiguration.cs
@@ -5,8 +5,12 @@ namespace EasyNetQ.Scheduler
     public class ScheduleRepositoryConfiguration : ConfigurationBase
     {
         private const string connectionStringKey = "scheduleDb";
+        private const string connectionStringNameKey = "scheduleDbConnectionStringName";
+        private const string schemaNameKey = "SchemaName";
 
+        public string SchemaName { get; set; }
         public string ConnectionString { get; set; }
+        public string ConnectionStringName { get; set; }
         public int PurgeBatchSize { get; set; }
         public int MaximumScheduleMessagesToReturn { get; set; }
 
@@ -17,12 +21,14 @@ namespace EasyNetQ.Scheduler
 
         public static ScheduleRepositoryConfiguration FromConfigFile()
         {
+            var connectionStringName = ConfigurationManager.AppSettings[connectionStringNameKey] ?? connectionStringKey;
             return new ScheduleRepositoryConfiguration
             {
-                ConnectionString = ConfigurationManager.ConnectionStrings[connectionStringKey].ConnectionString,
+                ConnectionString = ConfigurationManager.ConnectionStrings[connectionStringName].ConnectionString,
                 PurgeBatchSize = GetIntAppSetting("PurgeBatchSize"),
                 PurgeDelayDays = GetIntAppSetting("PurgeDelayDays"),
-                MaximumScheduleMessagesToReturn = GetIntAppSetting("MaximumScheduleMessagesToReturn")
+                MaximumScheduleMessagesToReturn = GetIntAppSetting("MaximumScheduleMessagesToReturn"),
+                SchemaName = ConfigurationManager.AppSettings[schemaNameKey]
             };
         }
     }


### PR DESCRIPTION
- 'scheduleDbConnectionStringName' allows you to specify the name of a connectionstring in the appSettings section rather than needing a fixed connection string name
- 'SchemaName' allows you to specify the schema of the tables and stored procedures(if you changed it in the DB scripts)
  - fixed typo's in variable/parameter names
