### PR TITLE
exposed argument dictionary when Declaring an Exchange on Advanced Bus

### DIFF
--- a/Source/EasyNetQ.Tests/ExchangeQueueBindingTests.cs
+++ b/Source/EasyNetQ.Tests/ExchangeQueueBindingTests.cs
@@ -1,6 +1,7 @@
 ﻿// ReSharper disable InconsistentNaming
 
 using System.Collections;
+using System.Collections.Specialized;
 using EasyNetQ.Tests.Mocking;
 using EasyNetQ.Topology;
 using NUnit.Framework;
@@ -82,6 +83,7 @@ namespace EasyNetQ.Tests
         private MockBuilder mockBuilder;
         private IAdvancedBus advancedBus;
         private IExchange exchange;
+        private IDictionary arguments= new ListDictionary(){{"Key","Value"}};
 
         [SetUp]
         public void SetUp()
@@ -89,7 +91,7 @@ namespace EasyNetQ.Tests
             mockBuilder = new MockBuilder();
             advancedBus = mockBuilder.Bus.Advanced;
 
-            exchange = advancedBus.ExchangeDeclare("my_exchange", ExchangeType.Direct, false, false, true, true);
+            exchange = advancedBus.ExchangeDeclare("my_exchange", ExchangeType.Direct, false, false, true, true, arguments);
         }
 
         [Test]
@@ -108,7 +110,7 @@ namespace EasyNetQ.Tests
                     Arg<string>.Is.Equal("direct"),
                     Arg<bool>.Is.Equal(false),
                     Arg<bool>.Is.Equal(true),
-                    Arg<IDictionary>.Is.Anything));
+                    Arg<IDictionary>.Is.Equal(arguments)));
         }
     }
 
@@ -125,7 +127,7 @@ namespace EasyNetQ.Tests
             mockBuilder = new MockBuilder();
             advancedBus = mockBuilder.Bus.Advanced;
 
-            exchange = advancedBus.ExchangeDeclare("my_exchange", ExchangeType.Direct, passive:true);
+            exchange = advancedBus.ExchangeDeclare("my_exchange", ExchangeType.Direct, passive: true);
         }
 
         [Test]

--- a/Source/EasyNetQ/IAdvancedBus.cs
+++ b/Source/EasyNetQ/IAdvancedBus.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Threading.Tasks;
 using EasyNetQ.Consumer;
 using EasyNetQ.Topology;
@@ -206,15 +207,10 @@ namespace EasyNetQ
         /// <param name="durable">Durable exchanges remain active when a server restarts.</param>
         /// <param name="autoDelete">If set, the exchange is deleted when all queues have finished using it.</param>
         /// <param name="internal">If set, the exchange may not be used directly by publishers, 
-        /// but only when bound to other exchanges.</param>
+        ///     but only when bound to other exchanges.</param>
+        /// <param name="arguments">If set, extra parameters for the exchange</param>
         /// <returns>The exchange</returns>
-        IExchange ExchangeDeclare(
-            string name, 
-            string type, 
-            bool passive = false, 
-            bool durable = true, 
-            bool autoDelete = false, 
-            bool @internal = false);
+        IExchange ExchangeDeclare(string name, string type, bool passive = false, bool durable = true, bool autoDelete = false, bool @internal = false, IDictionary arguments=null);
 
         /// <summary>
         /// Delete an exchange

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -287,13 +287,7 @@ namespace EasyNetQ
             logger.DebugWrite("Purged Queue: {0}", queue.Name);
         }
 
-        public virtual IExchange ExchangeDeclare(
-            string name, 
-            string type, 
-            bool passive = false, 
-            bool durable = true, 
-            bool autoDelete = false,
-            bool @internal = false)
+        public virtual IExchange ExchangeDeclare(string name, string type, bool passive = false, bool durable = true, bool autoDelete = false, bool @internal = false, IDictionary arguments = null)
         {
             Preconditions.CheckNotNull(name, "name");
             Preconditions.CheckShortString(type, "type");
@@ -304,7 +298,7 @@ namespace EasyNetQ
             }
             else
             {
-                clientCommandDispatcher.Invoke(x => x.ExchangeDeclare(name, type, durable, autoDelete, null)).Wait();
+                clientCommandDispatcher.Invoke(x => x.ExchangeDeclare(name, type, durable, autoDelete, arguments)).Wait();
                 logger.DebugWrite("Declared Exchange: {0} type:{1}, durable:{2}, autoDelete:{3}",
                     name, type, durable, autoDelete);
             }


### PR DESCRIPTION
Mike,

I have really enjoyed using RabbitMQ with EasyNetQ over the last few months. When declaring exchanges, I would like to pass extra arguments to RabbitMQ. For awhile I have been about to this by extending RabbitAdvancedBus but with some recent changes it is harder to extend. So, I was wondering if you would add an optional arguments parameter to ExchangeDelare on RabbitAdvancedBus.

Thanks!

-Matt
