### PR TITLE
Add ForTopic Attribute which allows the specification of topics for

### DIFF
--- a/Source/EasyNetQ/AutoSubscribe/ForTopicAttribute.cs
+++ b/Source/EasyNetQ/AutoSubscribe/ForTopicAttribute.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace EasyNetQ.AutoSubscribe
+{
+    [Serializable]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class ForTopicAttribute : Attribute
+    {
+        public ForTopicAttribute(string topic)
+        {
+            Topic = topic;
+        }
+
+        public string Topic { get; set; }
+    }
+}

--- a/Source/EasyNetQ/AutoSubscribe/IConsume.cs
+++ b/Source/EasyNetQ/AutoSubscribe/IConsume.cs
@@ -1,7 +1,12 @@
+using System;
+using EasyNetQ.FluentConfiguration;
+
 namespace EasyNetQ.AutoSubscribe
 {
     public interface IConsume<in T> where T : class
     {
         void Consume(T message);
     }
+
+    
 }

--- a/Source/EasyNetQ/EasyNetQ.csproj
+++ b/Source/EasyNetQ/EasyNetQ.csproj
@@ -52,6 +52,7 @@
     <Compile Include="AmqpExceptions\AmpqExceptionGrammar.cs" />
     <Compile Include="AmqpExceptions\AmqpException.cs" />
     <Compile Include="AutoSubscribe\AutoSubscriber.cs" />
+    <Compile Include="AutoSubscribe\ForTopicAttribute.cs" />
     <Compile Include="AutoSubscribe\IConsumeAsync.cs" />
     <Compile Include="BusExtensions.cs" />
     <Compile Include="ComponentRegistration.cs" />

--- a/Source/packages/NUnit.2.6.2/NUnit.2.6.2.nuspec
+++ b/Source/packages/NUnit.2.6.2/NUnit.2.6.2.nuspec
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>NUnit</id>
+    <version>2.6.2</version>
+    <title>NUnit</title>
+    <authors>Charlie Poole</authors>
+    <owners>Charlie Poole</owners>
+    <licenseUrl>http://nunit.org/nuget/license.html</licenseUrl>
+    <projectUrl>http://nunit.org/</projectUrl>
+    <iconUrl>http://nunit.org/nuget/nunit_32x32.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>NUnit features a fluent assert syntax, parameterized, generic and theory tests and is user-extensible. A number of runners, both from the NUnit project and by third parties, are able to execute NUnit tests.
+
+Version 2.6 is the seventh major release of this well-known and well-tested programming tool.
+
+This package includes only the framework assembly. You will need to install the NUnit.Runners package unless you are using a third-party runner.</description>
+    <summary>NUnit is a unit-testing framework for all .Net languages with a strong TDD focus.</summary>
+    <releaseNotes>Version 2.6 is the seventh major release of NUnit.
+
+Unlike earlier versions, this package includes only the framework assembly. You will need to install the NUnit.Runners package unless you are using a third-party runner.
+
+The nunit.mocks assembly is now provided by the NUnit.Mocks package. The pnunit.framework assembly is provided by the pNUnit package.</releaseNotes>
+    <language>en-US</language>
+    <tags>test testing tdd framework fluent assert theory plugin addin</tags>
+  </metadata>
+</package>

--- a/Source/packages/Newtonsoft.Json.4.5.11/Newtonsoft.Json.4.5.11.nuspec
+++ b/Source/packages/Newtonsoft.Json.4.5.11/Newtonsoft.Json.4.5.11.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Newtonsoft.Json</id>
+    <version>4.5.11</version>
+    <title>Json.NET</title>
+    <authors>James Newton-King</authors>
+    <owners>James Newton-King</owners>
+    <licenseUrl>http://json.codeplex.com/license</licenseUrl>
+    <projectUrl>http://james.newtonking.com/projects/json-net.aspx</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Json.NET is a popular high-performance JSON framework for .NET</description>
+    <language>en-US</language>
+    <tags>json</tags>
+  </metadata>
+</package>

--- a/Source/packages/Sprache.1.10.0.12/Sprache.1.10.0.12.nuspec
+++ b/Source/packages/Sprache.1.10.0.12/Sprache.1.10.0.12.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>Sprache</id>
+    <version>1.10.0.12</version>
+    <title>Sprache</title>
+    <authors>Nicholas Blumhardt</authors>
+    <owners>Nicholas Blumhardt</owners>
+    <licenseUrl>https://github.com/sprache/Sprache/blob/master/licence.txt</licenseUrl>
+    <projectUrl>https://github.com/sprache/Sprache</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Sprache is a simple, lightweight library for constructing parsers directly in C# code.</description>
+    <releaseNotes />
+    <copyright>Copyright Nicholas Blumhardt 2012</copyright>
+    <tags>Parser Parsers Monad</tags>
+  </metadata>
+</package>

--- a/Source/packages/TopShelf.3.1.0/Topshelf.3.1.0.nuspec
+++ b/Source/packages/TopShelf.3.1.0/Topshelf.3.1.0.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Topshelf</id>
+    <version>3.1.0</version>
+    <title>Topshelf</title>
+    <authors>Chris Patterson,  Dru Sellers,  Travis Smith</authors>
+    <owners>Chris Patterson,  Dru Sellers,  Travis Smith</owners>
+    <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <projectUrl>http://github.com/Topshelf/Topshelf</projectUrl>
+    <iconUrl>http://topshelf-project.com/wp-content/themes/pandora/slide.1.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Topshelf is an open source project for hosting services without friction. By referencing Topshelf, your console application *becomes* a service installer with a comprehensive set of command-line options for installing, configuring, and running your application as a service.</description>
+    <summary>Topshelf, Friction-free Windows Services</summary>
+    <releaseNotes />
+    <copyright />
+    <language>en-US</language>
+  </metadata>
+</package>


### PR DESCRIPTION
Hi

It seems a shame to have topic exchanges but not allow the specification of topics on auto subscribed classes, which is my preferred approach to consuming messages. Have added attribute which you can apply to consume method which adds a topic. Have allowed duplicates for the attribute so that more then on topic an be subscribed though have not unit tested this. 

Cheers
John
