### PR TITLE
Fix #138 - removed default date from scheduler stored procedures

### DIFF
--- a/DatabaseScripts/EasyNetQ.Scheduler/uspMarkWorkItemForPurge.sql
+++ b/DatabaseScripts/EasyNetQ.Scheduler/uspMarkWorkItemForPurge.sql
@@ -18,9 +18,6 @@ CREATE PROCEDURE [dbo].[uspMarkWorkItemForPurge]
 
 AS
 
--- Set default purgeDate to Now
-IF @purgeDate is NULL SET @purgeDate=getdate()
-
 -- Performs the UPDATE and OUTPUTs the INSERTED. fields to the calling app
 UPDATE WorkItemStatus
 SET PurgeDate = @purgeDate

--- a/DatabaseScripts/EasyNetQ.Scheduler/uspWorkItemsSelfPurge.sql
+++ b/DatabaseScripts/EasyNetQ.Scheduler/uspWorkItemsSelfPurge.sql
@@ -17,8 +17,6 @@ CREATE Procedure [dbo].[uspWorkItemsSelfPurge] @rows TinyINT = 5, @purgeDate Dat
 
 AS
 
-IF @purgeDate is NULL SET @purgeDate=getdate()
-
 -- Only execute if there is work to do and continue 
 -- until all records with a PurgeDate <= now are deleted
 WHILE EXISTS(SELECT * FROM WorkItemStatus WHERE PurgeDate <= @purgeDate) 


### PR DESCRIPTION
This commit fixes the issue where the scheduler service specifies UTC time as the default for "now()" while the SQL server is running in a different time zone.  If the SQL server is running in a different time zone, then the discrepancy between "getdate()" on the server and "DateTime.UtcNow" in the scheduler services will lead to strange behavior.

I guess when you live in GMT you don't struggle with such things. ;-)
