### PR TITLE
RabbitMQ.Client version 3.2.4

### DIFF
--- a/Package/EasyNetQ/EasyNetQ.nuspec
+++ b/Package/EasyNetQ/EasyNetQ.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>EasyNetQ</id>
     <!-- Version gets updated from EasyNetQ.dll version number during the build's packaging process -->
-    <version>0.26.7.0</version>
+    <version>0.28.3.0</version>
     <title>EasyNetQ</title>
     <authors>Mike Hadlow, Chris Edwards, A Hazelwood</authors>
     <owners>Mike Hadlow</owners>
@@ -17,7 +17,7 @@
     <copyright>Copyright Mike Hadlow 2012</copyright>
     <tags>RabbitMQ Messaging AMQP</tags>
     <dependencies>
-      <dependency id="RabbitMQ.Client" version="[3.2.1.0]" />
+      <dependency id="RabbitMQ.Client" version="[3.2.4.0]" />
       <dependency id="Newtonsoft.Json" version="4.5" />
     </dependencies>
   </metadata>

--- a/Source/EasyNetQ.Hosepipe.Tests/EasyNetQ.Hosepipe.Tests.csproj
+++ b/Source/EasyNetQ.Hosepipe.Tests/EasyNetQ.Hosepipe.Tests.csproj
@@ -39,9 +39,9 @@
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.2.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+    <Reference Include="RabbitMQ.Client, Version=3.2.4.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RabbitMQ.Client.3.2.1\lib\net30\RabbitMQ.Client.dll</HintPath>
+      <HintPath>..\packages\RabbitMQ.Client.3.2.4\lib\net30\RabbitMQ.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Source/EasyNetQ.Hosepipe.Tests/packages.config
+++ b/Source/EasyNetQ.Hosepipe.Tests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
   <package id="NUnit" version="2.6.2" targetFramework="net40" />
-  <package id="RabbitMQ.Client" version="3.2.1" targetFramework="net40" />
+  <package id="RabbitMQ.Client" version="3.2.4" targetFramework="net40" />
 </packages>

--- a/Source/EasyNetQ.Hosepipe/EasyNetQ.Hosepipe.csproj
+++ b/Source/EasyNetQ.Hosepipe/EasyNetQ.Hosepipe.csproj
@@ -38,9 +38,9 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.2.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+    <Reference Include="RabbitMQ.Client, Version=3.2.4.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RabbitMQ.Client.3.2.1\lib\net30\RabbitMQ.Client.dll</HintPath>
+      <HintPath>..\packages\RabbitMQ.Client.3.2.4\lib\net30\RabbitMQ.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Source/EasyNetQ.Hosepipe/packages.config
+++ b/Source/EasyNetQ.Hosepipe/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40-Client" />
-  <package id="RabbitMQ.Client" version="3.2.1" targetFramework="net40-Client" />
+  <package id="RabbitMQ.Client" version="3.2.4" targetFramework="net40-Client" />
 </packages>

--- a/Source/EasyNetQ.LogReader/EasyNetQ.LogReader.csproj
+++ b/Source/EasyNetQ.LogReader/EasyNetQ.LogReader.csproj
@@ -41,9 +41,9 @@
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.2.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+    <Reference Include="RabbitMQ.Client, Version=3.2.4.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RabbitMQ.Client.3.2.1\lib\net30\RabbitMQ.Client.dll</HintPath>
+      <HintPath>..\packages\RabbitMQ.Client.3.2.4\lib\net30\RabbitMQ.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Source/EasyNetQ.LogReader/packages.config
+++ b/Source/EasyNetQ.LogReader/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40-Client" />
-  <package id="RabbitMQ.Client" version="3.2.1" targetFramework="net40-Client" />
+  <package id="RabbitMQ.Client" version="3.2.4" targetFramework="net40-Client" />
 </packages>

--- a/Source/EasyNetQ.Tests.Performance.Consumer/EasyNetQ.Tests.Performance.Consumer.csproj
+++ b/Source/EasyNetQ.Tests.Performance.Consumer/EasyNetQ.Tests.Performance.Consumer.csproj
@@ -35,9 +35,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RabbitMQ.Client, Version=3.2.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+    <Reference Include="RabbitMQ.Client, Version=3.2.4.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RabbitMQ.Client.3.2.1\lib\net30\RabbitMQ.Client.dll</HintPath>
+      <HintPath>..\packages\RabbitMQ.Client.3.2.4\lib\net30\RabbitMQ.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Source/EasyNetQ.Tests.Performance.Consumer/packages.config
+++ b/Source/EasyNetQ.Tests.Performance.Consumer/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RabbitMQ.Client" version="3.2.1" targetFramework="net40-Client" />
+  <package id="RabbitMQ.Client" version="3.2.4" targetFramework="net40-Client" />
 </packages>

--- a/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
+++ b/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
@@ -63,9 +63,9 @@
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.2.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+    <Reference Include="RabbitMQ.Client, Version=3.2.4.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RabbitMQ.Client.3.2.1\lib\net30\RabbitMQ.Client.dll</HintPath>
+      <HintPath>..\packages\RabbitMQ.Client.3.2.4\lib\net30\RabbitMQ.Client.dll</HintPath>
     </Reference>
     <Reference Include="Rhino.Mocks">
       <HintPath>..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>

--- a/Source/EasyNetQ.Tests/packages.config
+++ b/Source/EasyNetQ.Tests/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
   <package id="NUnit" version="2.6.2" targetFramework="net40" />
-  <package id="RabbitMQ.Client" version="3.2.1" targetFramework="net40" />
+  <package id="RabbitMQ.Client" version="3.2.4" targetFramework="net40" />
   <package id="RhinoMocks" version="3.6.1" />
 </packages>

--- a/Source/EasyNetQ.Trace/EasyNetQ.Trace.csproj
+++ b/Source/EasyNetQ.Trace/EasyNetQ.Trace.csproj
@@ -37,9 +37,9 @@
     <Reference Include="CommandLine">
       <HintPath>..\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.2.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+    <Reference Include="RabbitMQ.Client, Version=3.2.4.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RabbitMQ.Client.3.2.1\lib\net30\RabbitMQ.Client.dll</HintPath>
+      <HintPath>..\packages\RabbitMQ.Client.3.2.4\lib\net30\RabbitMQ.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Source/EasyNetQ.Trace/packages.config
+++ b/Source/EasyNetQ.Trace/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommandLineParser" version="1.9.71" targetFramework="net45" />
-  <package id="RabbitMQ.Client" version="3.2.1" targetFramework="net45" />
+  <package id="RabbitMQ.Client" version="3.2.4" targetFramework="net45" />
 </packages>

--- a/Source/EasyNetQ/EasyNetQ.csproj
+++ b/Source/EasyNetQ/EasyNetQ.csproj
@@ -39,9 +39,9 @@
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.2.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+    <Reference Include="RabbitMQ.Client, Version=3.2.4.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RabbitMQ.Client.3.2.1\lib\net30\RabbitMQ.Client.dll</HintPath>
+      <HintPath>..\packages\RabbitMQ.Client.3.2.4\lib\net30\RabbitMQ.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/Source/EasyNetQ/packages.config
+++ b/Source/EasyNetQ/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40-Client" />
-  <package id="RabbitMQ.Client" version="3.2.1" targetFramework="net40-Client" />
+  <package id="RabbitMQ.Client" version="3.2.4" targetFramework="net40-Client" />
 </packages>

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.28.2.0")]
+[assembly: AssemblyVersion("0.28.3.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.28.3.0 RabbitMQ.Client version 3.2.4
 // 0.28.1.0 Made Send method respect the PersistentMessages configuration option
 // 0.28.0.0 Consumer priority
 // 0.27.5.0 Fixed PersistentChannel issue where model invalid after exception thrown. Bug fix.

--- a/hall_of_fame.md
+++ b/hall_of_fame.md
@@ -53,3 +53,4 @@ No particular order. Don't forget to add your name with your pull request.
 * Sebastien Lambla
 * Karl Nilsson
 * Mike Hadlow
+* Andrey Katamanov


### PR DESCRIPTION
The current release of the RabbitMQ .NET/C# AMQP library is 3.2.4. :angel:
