### PR TITLE
fixes #178 StructureMapAdapter type registration check flaw

### DIFF
--- a/Source/EasyNetQ.DI.StructureMap/StructureMapAdapter.cs
+++ b/Source/EasyNetQ.DI.StructureMap/StructureMapAdapter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.Reflection;
-using StructureMap;
+using System.Linq;
 
 namespace EasyNetQ.DI
 {
@@ -40,25 +39,7 @@ namespace EasyNetQ.DI
 
         private bool ServiceRegistered<T>()
         {
-            var instance = structureMapContainer.TryGetInstance(typeof(T));
-            var d = instance as Delegate;
-            if (d != null)
-            {
-                try
-                {
-                    d.DynamicInvoke();
-                }
-                catch (TargetInvocationException ex)
-                {
-                    var inner = ex.InnerException as StructureMapException;
-                    if (inner == null)
-                        throw;
-                    if (inner.ErrorCode == 202)
-                        return false;
-                    throw;
-                }
-            }
-            return instance != null;
+            return structureMapContainer.Model.AllInstances.Any(x=>x.PluginType == typeof(T));           
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
+++ b/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="NinjectAdapterTests.cs" />
     <Compile Include="StructureMapAdapterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StructureMapAdapterWithRegistryTests.cs" />
     <Compile Include="WindsorAdapterTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/EasyNetQ.DI.Tests/StructureMapAdapterTests.cs
+++ b/Source/EasyNetQ.DI.Tests/StructureMapAdapterTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using EasyNetQ.Consumer;
 using EasyNetQ.Tests.Mocking;
 using NUnit.Framework;
 using StructureMap;

--- a/Source/EasyNetQ.DI.Tests/StructureMapAdapterWithRegistryTests.cs
+++ b/Source/EasyNetQ.DI.Tests/StructureMapAdapterWithRegistryTests.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using NUnit.Framework;
+using StructureMap;
+using StructureMap.Configuration.DSL;
+
+namespace EasyNetQ.DI.Tests
+{
+    /// <summary>
+    /// EasyNetQ expects that the DI container will follow a first-to-register-wins
+    /// policy. The internal DefaultServiceProvider works this way, as does Windsor.
+    /// However, Ninject doesn't allow more than one registration of a service, it 
+    /// throws an exception. StructureMap has a last-to-register-wins policy 
+    /// by default which has been overrided in the Adapter implementation.
+    /// </summary>
+    [TestFixture]
+    [Explicit("Starts a connection to localhost")]
+    public class StructureMapAdapterWithRegistryTests
+    {
+        private StructureMap.IContainer container;
+        private IContainer easynetQContainer;
+        private IBus bus;
+
+        [SetUp]
+        public void SetUp()
+        {
+            container = new Container(cfg =>
+                {
+                    cfg.AddRegistry<MessagingRegistry>();
+                });
+
+            container.RegisterAsEasyNetQContainerFactory();
+
+            bus = RabbitHutch.CreateBus("host=localhost");
+        
+            easynetQContainer = bus.Advanced.Container;
+        }
+
+        [Test]
+        public void Should_create_bus_with_structure_map_adapter()
+        {
+            Assert.IsNotNull(bus);
+        }
+
+        [Test]
+        public void Should_construct_registered_conventions()
+        {
+            Assert.Greater(MyConventions.ConventionsCallCount, 0);
+        }
+
+        [Test]
+        public void Should_use_registered_logger()
+        {
+            Assert.Greater(MyLogger.ConstructorCallCount, 0);
+        }
+
+        public class MessagingRegistry : Registry
+        {
+            public MessagingRegistry()
+            {
+                For<IEasyNetQLogger>().Singleton().Use<MyLogger>();
+                For<IConventions>().Singleton().Use<MyConventions>();
+            }
+        }
+
+        public class MyLogger : IEasyNetQLogger
+        {
+            public MyLogger()
+            {
+                ConstructorCallCount++;
+            }
+
+            public void DebugWrite(string format, params object[] args)
+            {                
+            }
+
+            public void InfoWrite(string format, params object[] args)
+            {
+            }
+
+            public void ErrorWrite(string format, params object[] args)
+            {
+            }
+
+            public void ErrorWrite(Exception exception)
+            {
+            }
+
+            public static int ConstructorCallCount { get; private set; }
+        }
+
+        public class MyConventions : IConventions
+        {
+            private readonly ITypeNameSerializer _typeNameSerializer;
+
+            public MyConventions(ITypeNameSerializer typeNameSerializer)
+            {
+                _typeNameSerializer = typeNameSerializer;
+                ExchangeNamingConvention = type => { return string.Format("exchange{0}_", type.Name.Replace(".", "_")); };
+                ConventionsCallCount++;
+            }
+
+            public ExchangeNameConvention ExchangeNamingConvention { get; set; }
+            public TopicNameConvention TopicNamingConvention { get; set; }
+            public QueueNameConvention QueueNamingConvention { get; set; }
+            public RpcRoutingKeyNamingConvention RpcRoutingKeyNamingConvention { get; set; }
+            public ErrorQueueNameConvention ErrorQueueNamingConvention { get; set; }
+            public ErrorExchangeNameConvention ErrorExchangeNamingConvention { get; set; }
+            public RpcExchangeNameConvention RpcExchangeNamingConvention { get; set; }
+            public RpcReturnQueueNamingConvention RpcReturnQueueNamingConvention { get; set; }
+            public ConsumerTagConvention ConsumerTagConvention { get; set; }
+
+            public static int ConventionsCallCount { get; private set; }
+        }
+    }
+}


### PR DESCRIPTION
Had a "duh" moment and realized there is a much easier way to check for previous component registrations for a StructureMap container. This also fixes issues with component registration crashing all dependencies for a component have not been previously registered.
