### PR TITLE
Support for queue name that contains plus char (+) when using Management Client

### DIFF
--- a/Source/EasyNetQ.Management.Client.Tests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/ManagementClientTests.cs
@@ -217,6 +217,7 @@ namespace EasyNetQ.Management.Client.Tests
         }
 
         private const string testQueue = "management_api_test_queue";
+        private const string testQueueWithPlusChar = "management_api_test_queue+plus+test";
 
         [Test]
         public void Should_get_queues()
@@ -238,12 +239,29 @@ namespace EasyNetQ.Management.Client.Tests
         }
 
         [Test]
+        public void Should_be_able_to_get_a_queue_by_name_with_plus_char()
+        {
+            var vhost = new Vhost { Name = "/" };
+            var queue = managementClient.GetQueue(testQueueWithPlusChar, vhost);
+            queue.Name.ShouldEqual(testQueueWithPlusChar);
+        }
+
+        [Test]
         public void Should_be_able_to_create_a_queue()
         {
             var vhost = managementClient.GetVhost("/");
             var queueInfo = new QueueInfo(testQueue);
             var queue = managementClient.CreateQueue(queueInfo, vhost);
             queue.Name.ShouldEqual(testQueue);
+        }
+
+        [Test]
+        public void Should_be_able_to_create_a_queue_with_plus_char_in_the_name()
+        {
+            var vhost = managementClient.GetVhost("/");
+            var queueInfo = new QueueInfo(testQueueWithPlusChar);
+            var queue = managementClient.CreateQueue(queueInfo, vhost);
+            queue.Name.ShouldEqual(testQueueWithPlusChar);
         }
 
         [Test]

--- a/Source/EasyNetQ.Management.Client/ManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClient.cs
@@ -131,7 +131,7 @@ namespace EasyNetQ.Management.Client
         public Queue GetQueue(string queueName, Vhost vhost)
         {
             return Get<Queue>(string.Format("queues/{0}/{1}",
-                SanitiseVhostName(vhost.Name), queueName));
+                SanitiseVhostName(vhost.Name), SanitiseQueueName(queueName)));
         }
 
         public Exchange CreateExchange(ExchangeInfo exchangeInfo, Vhost vhost)
@@ -212,7 +212,7 @@ namespace EasyNetQ.Management.Client
                 throw new ArgumentNullException("vhost");
             }
 
-            Put(string.Format("queues/{0}/{1}", SanitiseVhostName(vhost.Name), queueInfo.GetName()), queueInfo);
+            Put(string.Format("queues/{0}/{1}", SanitiseVhostName(vhost.Name), SanitiseQueueName(queueInfo.GetName())), queueInfo);
 
             return GetQueue(queueInfo.GetName(), vhost);
         }
@@ -224,7 +224,7 @@ namespace EasyNetQ.Management.Client
                 throw new ArgumentNullException("queue");
             }
 
-            Delete(string.Format("queues/{0}/{1}", SanitiseVhostName(queue.Vhost), queue.Name));
+            Delete(string.Format("queues/{0}/{1}", SanitiseVhostName(queue.Vhost), SanitiseQueueName(queue.Name)));
         }
 
         public IEnumerable<Binding> GetBindingsForQueue(Queue queue)
@@ -235,7 +235,7 @@ namespace EasyNetQ.Management.Client
             }
 
             return Get<IEnumerable<Binding>>(
-                string.Format("queues/{0}/{1}/bindings", SanitiseVhostName(queue.Vhost), queue.Name));
+                string.Format("queues/{0}/{1}/bindings", SanitiseVhostName(queue.Vhost), SanitiseQueueName(queue.Name)));
         }
 
         public void Purge(Queue queue)
@@ -245,7 +245,7 @@ namespace EasyNetQ.Management.Client
                 throw new ArgumentNullException("queue");
             }
 
-            Delete(string.Format("queues/{0}/{1}/contents", SanitiseVhostName(queue.Vhost), queue.Name));
+            Delete(string.Format("queues/{0}/{1}/contents", SanitiseVhostName(queue.Vhost), SanitiseQueueName(queue.Name)));
         }
 
         public IEnumerable<Message> GetMessagesFromQueue(Queue queue, GetMessagesCriteria criteria)
@@ -256,7 +256,7 @@ namespace EasyNetQ.Management.Client
             }
 
             return Post<GetMessagesCriteria, IEnumerable<Message>>(
-                string.Format("queues/{0}/{1}/get", SanitiseVhostName(queue.Vhost), queue.Name),
+                string.Format("queues/{0}/{1}/get", SanitiseVhostName(queue.Vhost), SanitiseQueueName(queue.Name)),
                 criteria);
         }
 
@@ -281,7 +281,7 @@ namespace EasyNetQ.Management.Client
             }
 
             Post<BindingInfo, object>(
-                string.Format("bindings/{0}/e/{1}/q/{2}", SanitiseVhostName(queue.Vhost), exchange.Name, queue.Name),
+                string.Format("bindings/{0}/e/{1}/q/{2}", SanitiseVhostName(queue.Vhost), exchange.Name, SanitiseQueueName(queue.Name)),
                 bindingInfo);
         }
 
@@ -318,7 +318,7 @@ namespace EasyNetQ.Management.Client
 
             return Get<IEnumerable<Binding>>(
                 string.Format("bindings/{0}/e/{1}/q/{2}", SanitiseVhostName(queue.Vhost),
-                    exchange.Name, queue.Name));
+                    exchange.Name, SanitiseQueueName(queue.Name)));
         }
 
         public void DeleteBinding(Binding binding)
@@ -617,6 +617,11 @@ namespace EasyNetQ.Management.Client
         private string SanitiseVhostName(string vhostName)
         {
             return vhostName.Replace("/", "%2f");
+        }
+
+        private string SanitiseQueueName(string queueName)
+        {
+            return queueName.Replace("+", "%2B");
         }
 
         private string RecodeBindingPropertiesKey(string propertiesKey)

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.28.3.0")]
+[assembly: AssemblyVersion("0.28.4.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.28.4.0 Support for queue name that contains plus char (+) when using Management Client.
 // 0.28.3.0 RabbitMQ.Client version 3.2.4
 // 0.28.1.0 Made Send method respect the PersistentMessages configuration option
 // 0.28.0.0 Consumer priority


### PR DESCRIPTION
Now management client supports queue name that contains + (plus char), fixing the issue https://github.com/mikehadlow/EasyNetQ/issues/181
