### PR TITLE
fixed typo in autodelete logging, use await syntax in AutofacMessageDispatcher

### DIFF
--- a/Source/EasyNetQ.DI.Autofac/AutofacMessageDispatcher.cs
+++ b/Source/EasyNetQ.DI.Autofac/AutofacMessageDispatcher.cs
@@ -21,15 +21,12 @@ namespace EasyNetQ.DI
                 scope.Resolve<TConsumer>().Consume(message);
         }
 
-        public Task DispatchAsync<TMessage, TConsumer>(TMessage message)
+        public async Task DispatchAsync<TMessage, TConsumer>(TMessage message)
             where TMessage : class
             where TConsumer : IConsumeAsync<TMessage>
         {
-            var scope = component.BeginLifetimeScope("async-message");
-            var consumer = scope.Resolve<TConsumer>();
-            return consumer
-                .Consume(message)
-                .ContinueWith(task => scope.Dispose());
+            using (var scope = component.BeginLifetimeScope("async-message"))
+                await scope.Resolve<TConsumer>().Consume(message);
         }
     }
 }

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -258,7 +258,7 @@ namespace EasyNetQ
                     x => x.QueueDeclare(name, durable, exclusive, autoDelete, arguments)
                     ).Wait();
 
-                logger.DebugWrite("Declared Queue: '{0}' durable:{1}, exclusive:{2}, autoDelte:{3}, args:{4}",
+                logger.DebugWrite("Declared Queue: '{0}' durable:{1}, exclusive:{2}, autoDelete:{3}, args:{4}",
                     name, durable, exclusive, autoDelete, WriteArguments(arguments));
             }
 


### PR DESCRIPTION
Currently DI.Autofac is already on 4.5, but if you want to keep the code base compatible with 4.0, ignore this pull.
