### PR TITLE
AutoSubscriber should omit abstract classes or generic classes implement...

### DIFF
--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing.cs
@@ -124,6 +124,16 @@ namespace EasyNetQ.Tests.AutoSubscriberTests
             }
         }
 
+        //Discovered by reflection over test assembly, do not remove.
+        private abstract class MyGenericAbstractConsumer<TMessage> : IConsume<TMessage>
+          where TMessage : class
+        {
+            public virtual void Consume(TMessage message)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
         private class MessageA
         {
             public string Text { get; set; }

--- a/Source/EasyNetQ/AutoSubscribe/AutoSubscriber.cs
+++ b/Source/EasyNetQ/AutoSubscribe/AutoSubscriber.cs
@@ -190,10 +190,10 @@ namespace EasyNetQ.AutoSubscribe
 
         protected virtual IEnumerable<KeyValuePair<Type, AutoSubscriberConsumerInfo[]>> GetSubscriptionInfos(IEnumerable<Type> types,Type interfaceType)
         {
-            foreach (var concreteType in types.Where(t => t.IsClass))
+            foreach (var concreteType in types.Where(t => t.IsClass && !t.IsAbstract))
             {
                 var subscriptionInfos = concreteType.GetInterfaces()
-                    .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == interfaceType)
+                    .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == interfaceType && !i.GetGenericArguments()[0].IsGenericParameter)
                     .Select(i => new AutoSubscriberConsumerInfo(concreteType, i, i.GetGenericArguments()[0]))
                     .ToArray();
 


### PR DESCRIPTION
...ing IConsume<TMessage> interface where TMessage is a generic type parameter of the class.
