### PR TITLE
Scheduler based on mongo

### DIFF
--- a/Source/EasyNetQ.Scheduler.Mongo.Core/EasyNetQ.Scheduler.Mongo.Core.csproj
+++ b/Source/EasyNetQ.Scheduler.Mongo.Core/EasyNetQ.Scheduler.Mongo.Core.csproj
@@ -1,0 +1,82 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>EasyNetQ.Scheduler.Mongo.Core</RootNamespace>
+    <AssemblyName>EasyNetQ.Scheduler.Mongo.Core</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="MongoDB.Bson">
+      <HintPath>..\packages\mongocsharpdriver.1.9.0\lib\net35\MongoDB.Bson.dll</HintPath>
+    </Reference>
+    <Reference Include="MongoDB.Driver">
+      <HintPath>..\packages\mongocsharpdriver.1.9.0\lib\net35\MongoDB.Driver.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ScheduleRepository.cs" />
+    <Compile Include="IScheduleRepositoryConfiguration.cs" />
+    <Compile Include="SchedulerService.cs" />
+    <Compile Include="ISchedulerServiceConfiguration.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Schedule.cs" />
+    <Compile Include="ScheduleState.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\EasyNetQ\EasyNetQ.csproj">
+      <Project>{b8def709-5168-48f1-b8d3-ad44e4a4a22b}</Project>
+      <Name>EasyNetQ</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Source/EasyNetQ.Scheduler.Mongo.Core/IScheduleRepositoryConfiguration.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo.Core/IScheduleRepositoryConfiguration.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace EasyNetQ.Scheduler.Mongo.Core
+{
+    public interface IScheduleRepositoryConfiguration
+    {
+        string ConnectionString { get; }
+        string DatabaseName { get; }
+        string CollectionName { get; }
+        TimeSpan DeleteTimeout { get; }
+        TimeSpan PublishTimeout { get; }
+    }
+}

--- a/Source/EasyNetQ.Scheduler.Mongo.Core/ISchedulerServiceConfiguration.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo.Core/ISchedulerServiceConfiguration.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace EasyNetQ.Scheduler.Mongo.Core
+{
+    public interface ISchedulerServiceConfiguration
+    {
+        string SubscriptionId { get; }
+        TimeSpan PublishInterval { get; }
+        TimeSpan HandleTimeoutInterval { get; }
+        int PublishMaxSchedules { get; }
+    }
+}

--- a/Source/EasyNetQ.Scheduler.Mongo.Core/Properties/AssemblyInfo.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("EasyNetQ.Scheduler.Mongo.Core")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("EasyNetQ.Scheduler.Mongo.Core")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("cbaa88d8-aa30-4d48-b56c-9df1a23792cc")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/EasyNetQ.Scheduler.Mongo.Core/Schedule.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo.Core/Schedule.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace EasyNetQ.Scheduler.Mongo.Core
+{
+    public class Schedule
+    {
+        public Guid Id { get; set; }
+
+        public DateTime WakeTime { get; set; }
+
+        public string BindingKey { get; set; }
+
+        [BsonIgnoreIfNull]
+        public string CancellationKey { get; set; }
+
+        public byte[] InnerMessage { get; set; }
+
+        public ScheduleState State { get; set; }
+
+        [BsonIgnoreIfNull]
+        public DateTime? PublishingTime { get; set; }
+
+        [BsonIgnoreIfNull]
+        public DateTime? PublishedTime { get; set; }
+    }
+}

--- a/Source/EasyNetQ.Scheduler.Mongo.Core/ScheduleRepository.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo.Core/ScheduleRepository.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using MongoDB.Driver;
+using MongoDB.Driver.Builders;
+
+namespace EasyNetQ.Scheduler.Mongo.Core
+{
+    public interface IScheduleRepository
+    {
+        void Store(Schedule schedule);
+        void Cancel(string cancelation);
+        Schedule GetPending();
+        void MarkAsPublished(Guid id);
+        void HandleTimeout();
+    }
+
+    public class ScheduleRepository : IScheduleRepository
+    {
+        private readonly IScheduleRepositoryConfiguration configuration;
+        private readonly Func<DateTime> getNow;
+        private readonly Lazy<MongoCollection<Schedule>> lazyCollection;
+        private readonly Lazy<MongoServer> lazyServer;
+
+        public ScheduleRepository(IScheduleRepositoryConfiguration configuration, Func<DateTime> getNow)
+        {
+            this.configuration = configuration;
+            this.getNow = getNow;
+            lazyServer = new Lazy<MongoServer>(Connect);
+            lazyCollection = new Lazy<MongoCollection<Schedule>>(CreateAndIndex);
+        }
+
+        private MongoServer Server
+        {
+            get { return lazyServer.Value; }
+        }
+
+        private MongoCollection<Schedule> Collection
+        {
+            get { return lazyCollection.Value; }
+        }
+
+        public void Store(Schedule schedule)
+        {
+            Collection.Insert(schedule);
+        }
+
+        public void Cancel(string cancelation)
+        {
+            Collection.Remove(Query<Schedule>.EQ(x => x.CancellationKey, cancelation));
+        }
+
+        public Schedule GetPending()
+        {
+            var now = getNow();
+            var query = Query.And(
+                Query<Schedule>.EQ(x => x.State, ScheduleState.Pending),
+                Query<Schedule>.LTE(x => x.WakeTime, now));
+            var update = Update.Combine(Update<Schedule>.Set(x => x.State, ScheduleState.Publishing),
+                                        Update<Schedule>.Set(x => x.PublishingTime, now));
+            var findAndModifyResult = Collection.FindAndModify(new FindAndModifyArgs
+                {
+                    Query = query,
+                    SortBy = SortBy<Schedule>.Ascending(x => x.WakeTime),
+                    Update = update,
+                    VersionReturned = FindAndModifyDocumentVersion.Modified,
+                });
+            return findAndModifyResult.GetModifiedDocumentAs<Schedule>();
+        }
+
+        public void MarkAsPublished(Guid id)
+        {
+            var now = getNow();
+            var query = Query.And(Query<Schedule>.EQ(x => x.Id, id));
+            var update = Update.Combine(Update<Schedule>.Set(x => x.State, ScheduleState.Published),
+                                        Update<Schedule>.Set(x => x.PublishedTime, now),
+                                        Update<Schedule>.Unset(x => x.PublishingTime)
+                );
+            Collection.Update(query, update);
+        }
+
+        public void HandleTimeout()
+        {
+            var publishingTimeTimeout = getNow() - configuration.PublishTimeout;
+            var query = Query.And(Query<Schedule>.EQ(x => x.State, ScheduleState.Publishing), Query<Schedule>.LTE(x => x.PublishingTime, publishingTimeTimeout));
+            var update = Update.Combine(Update<Schedule>.Set(x => x.State, ScheduleState.Pending), Update<Schedule>.Unset(x => x.PublishingTime));
+            Collection.Update(query, update, UpdateFlags.Multi);
+        }
+
+        private MongoCollection<Schedule> CreateAndIndex()
+        {
+            var collection = Server.GetDatabase(configuration.DatabaseName).GetCollection<Schedule>(configuration.CollectionName);
+            collection.CreateIndex(IndexKeys<Schedule>.Ascending(x => x.CancellationKey), IndexOptions.SetSparse(true));
+            collection.CreateIndex(IndexKeys<Schedule>.Ascending(x => x.State, x => x.WakeTime));
+            collection.CreateIndex(IndexKeys<Schedule>.Ascending(x => x.PublishedTime), IndexOptions.SetTimeToLive(configuration.DeleteTimeout).SetSparse(true));
+            return collection;
+        }
+
+        private MongoServer Connect()
+        {
+            return new MongoClient(configuration.ConnectionString).GetServer();
+        }
+    }
+}

--- a/Source/EasyNetQ.Scheduler.Mongo.Core/ScheduleState.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo.Core/ScheduleState.cs
@@ -1,0 +1,10 @@
+﻿namespace EasyNetQ.Scheduler.Mongo.Core
+{
+    public enum ScheduleState
+    {
+        Unknown = 0,
+        Pending = 1,
+        Publishing = 2,
+        Published = 3
+    }
+}

--- a/Source/EasyNetQ.Scheduler.Mongo.Core/SchedulerService.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo.Core/SchedulerService.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Threading;
+using EasyNetQ.SystemMessages;
+using EasyNetQ.Topology;
+
+namespace EasyNetQ.Scheduler.Mongo.Core
+{
+    public interface ISchedulerService
+    {
+        void Start();
+        void Stop();
+    }
+
+    public class SchedulerService : ISchedulerService
+    {
+        private readonly IBus bus;
+        private readonly ISchedulerServiceConfiguration configuration;
+        private readonly IEasyNetQLogger log;
+        private readonly IScheduleRepository scheduleRepository;
+        private Timer handleTimeoutTimer;
+        private Timer publishTimer;
+
+        public SchedulerService(IBus bus, IEasyNetQLogger log, IScheduleRepository scheduleRepository, ISchedulerServiceConfiguration configuration)
+        {
+            this.bus = bus;
+            this.log = log;
+            this.scheduleRepository = scheduleRepository;
+            this.configuration = configuration;
+        }
+
+        public void Start()
+        {
+            log.DebugWrite("Starting SchedulerService");
+            bus.Subscribe<ScheduleMe>(configuration.SubscriptionId, OnMessage);
+            bus.Subscribe<UnscheduleMe>(configuration.SubscriptionId, OnMessage);
+            publishTimer = new Timer(OnPublishTimerTick, null, TimeSpan.Zero, configuration.PublishInterval);
+            handleTimeoutTimer = new Timer(OnHandleTimeoutTimerTick, null, TimeSpan.Zero, configuration.HandleTimeoutInterval);
+        }
+
+        public void Stop()
+        {
+            log.DebugWrite("Stopping SchedulerService");
+            if (publishTimer != null)
+            {
+                publishTimer.Dispose();
+            }
+            if (handleTimeoutTimer != null)
+            {
+                handleTimeoutTimer.Dispose();
+            }
+            if (bus != null)
+            {
+                bus.Dispose();
+            }
+        }
+
+        public void OnHandleTimeoutTimerTick(object state)
+        {
+            log.DebugWrite("Handling failed messages");
+            scheduleRepository.HandleTimeout();
+        }
+
+        public void OnPublishTimerTick(object state)
+        {
+            if (!bus.IsConnected) return;
+            try
+            {
+                var published = 0;
+                while (published < configuration.PublishMaxSchedules)
+                {
+                    var schedule = scheduleRepository.GetPending();
+                    if (schedule == null)
+                        return;
+                    log.DebugWrite(string.Format("Publishing Scheduled Message with Routing Key: '{0}'", schedule.BindingKey));
+                    var exchange = bus.Advanced.ExchangeDeclare(schedule.BindingKey, ExchangeType.Topic);
+                    bus.Advanced.Publish(
+                        exchange,
+                        schedule.BindingKey,
+                        false,
+                        false,
+                        new MessageProperties {Type = schedule.BindingKey},
+                        schedule.InnerMessage);
+                    scheduleRepository.MarkAsPublished(schedule.Id);
+                    ++published;
+                }
+            }
+            catch (Exception exception)
+            {
+                log.ErrorWrite("Error in schedule pol\r\n{0}", exception);
+            }
+        }
+
+        private void OnMessage(UnscheduleMe message)
+        {
+            log.DebugWrite("Got Unschedule Message");
+            scheduleRepository.Cancel(message.CancellationKey);
+        }
+
+        private void OnMessage(ScheduleMe message)
+        {
+            log.DebugWrite("Got Schedule Message");
+            scheduleRepository.Store(new Schedule
+                {
+                    Id = Guid.NewGuid(),
+                    CancellationKey = message.CancellationKey,
+                    BindingKey = message.BindingKey,
+                    InnerMessage = message.InnerMessage,
+                    State = ScheduleState.Pending,
+                    WakeTime = message.WakeTime
+                });
+        }
+    }
+}

--- a/Source/EasyNetQ.Scheduler.Mongo.Core/packages.config
+++ b/Source/EasyNetQ.Scheduler.Mongo.Core/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="mongocsharpdriver" version="1.9.0" targetFramework="net45" />
+</packages>

--- a/Source/EasyNetQ.Scheduler.Mongo.Tests/EasyNetQ.Scheduler.Mongo.Tests.csproj
+++ b/Source/EasyNetQ.Scheduler.Mongo.Tests/EasyNetQ.Scheduler.Mongo.Tests.csproj
@@ -1,0 +1,88 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4E7F926F-D939-4962-A7EF-112DE41B4236}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>EasyNetQ.Scheduler.Mongo.Tests</RootNamespace>
+    <AssemblyName>EasyNetQ.Scheduler.Mongo.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Rhino.Mocks">
+      <HintPath>..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MockScheduleRepository.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ScheduleRepositoryTests.cs" />
+    <Compile Include="SchedulerServiceTests.cs" />
+    <Compile Include="TestExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\EasyNetQ.Scheduler.Mongo.Core\EasyNetQ.Scheduler.Mongo.Core.csproj">
+      <Project>{f444e58f-da2a-47e8-8246-c4bdd9a192b2}</Project>
+      <Name>EasyNetQ.Scheduler.Mongo.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\EasyNetQ.Scheduler.Mongo\EasyNetQ.Scheduler.Mongo.csproj">
+      <Project>{afd272b4-4a2b-43d4-81ed-666f8918fd01}</Project>
+      <Name>EasyNetQ.Scheduler.Mongo</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\EasyNetQ\EasyNetQ.csproj">
+      <Project>{b8def709-5168-48f1-b8d3-ad44e4a4a22b}</Project>
+      <Name>EasyNetQ</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Source/EasyNetQ.Scheduler.Mongo.Tests/MockScheduleRepository.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo.Tests/MockScheduleRepository.cs
@@ -1,0 +1,33 @@
+using System;
+using EasyNetQ.Scheduler.Mongo.Core;
+
+namespace EasyNetQ.Scheduler.Mongo.Tests
+{
+    public class MockScheduleRepository : IScheduleRepository
+    {
+        public Func<Schedule> GetPendingDelegate { get; set; } 
+
+        public void Store(Schedule scheduleMe)
+        {
+        }
+
+        public void Cancel(string cancelation)
+        {
+        }
+
+        public Schedule GetPending()
+        {
+            return (GetPendingDelegate != null)
+                       ? GetPendingDelegate()
+                       : null;
+        }
+
+        public void MarkAsPublished(Guid id)
+        {
+        }
+
+        public void HandleTimeout()
+        {
+        }
+    }
+}

--- a/Source/EasyNetQ.Scheduler.Mongo.Tests/Properties/AssemblyInfo.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("EasyNetQ.Scheduler.Mongo.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("EasyNetQ.Scheduler.Mongo.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b97e26a5-a52e-4d98-836c-3d15cc5febc3")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/EasyNetQ.Scheduler.Mongo.Tests/ScheduleRepositoryTests.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo.Tests/ScheduleRepositoryTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Text;
+using EasyNetQ.Scheduler.Mongo.Core;
+using NUnit.Framework;
+
+namespace EasyNetQ.Scheduler.Mongo.Tests
+{
+    [TestFixture]
+    [Explicit("Required a database")]
+    public class ScheduleRepositoryTests
+    {
+        private ScheduleRepository scheduleRepository;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var configuration = new ScheduleRepositoryConfiguration
+                {
+                    ConnectionString = "mongodb://localhost:27017/?w=1&amp;readPreference=primary&amp;uuidRepresentation=csharpLegacy",
+                    CollectionName = "Schedules",
+                    DatabaseName = "EasyNetQ",
+                    DeleteTimeout = TimeSpan.FromMinutes(5),
+                    PublishTimeout = TimeSpan.FromSeconds(60),
+                };
+            scheduleRepository = new ScheduleRepository(configuration, () => DateTime.UtcNow);
+        }
+
+        [Test]
+        [Explicit("Required a database")]
+        public void Should_be_able_to_store_a_schedule()
+        {
+            scheduleRepository.Store(new Schedule
+                {
+                    BindingKey = "abc",
+                    CancellationKey = "bcd",
+                    WakeTime = new DateTime(2011, 5, 18),
+                    InnerMessage = Encoding.UTF8.GetBytes("Hello World!"),
+                    Id = Guid.Empty,
+                    State = ScheduleState.Pending,
+                });
+        }
+
+        [Test]
+        [Explicit("Required a database")]
+        public void Should_be_able_to_cancel_a_schedule()
+        {
+            scheduleRepository.Cancel("bcd");
+        }
+
+        [Test]
+        [Explicit("Required a database")]
+        public void Should_be_able_to_get_messages()
+        {
+            while (true)
+            {
+                var schedule = scheduleRepository.GetPending();
+                if(schedule == null)
+                    break;
+                Console.WriteLine("{0}, {1}, {2}",
+                                  schedule.BindingKey,
+                                  schedule.WakeTime,
+                                  Encoding.UTF8.GetString(schedule.InnerMessage));
+            }
+        }
+
+        [Test]
+        [Explicit("Required a database")]
+        public void Should_be_able_to_handle_timeout()
+        {
+            scheduleRepository.HandleTimeout();
+        }
+
+
+        [Test]
+        [Explicit("Required a database")]
+        public void Should_be_able_to_mark_as_published()
+        {
+            scheduleRepository.MarkAsPublished(Guid.Empty);
+        }
+    }
+}
+
+// ReSharper restore InconsistentNaming

--- a/Source/EasyNetQ.Scheduler.Mongo.Tests/SchedulerServiceTests.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo.Tests/SchedulerServiceTests.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using EasyNetQ.Scheduler.Mongo.Core;
+using EasyNetQ.Topology;
+using NUnit.Framework;
+using Rhino.Mocks;
+
+namespace EasyNetQ.Scheduler.Mongo.Tests
+{
+    [TestFixture]
+    public class SchedulerServiceTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            bus = MockRepository.GenerateStub<IBus>();
+            advancedBus = MockRepository.GenerateStub<IAdvancedBus>();
+
+            bus.Stub(x => x.IsConnected).Return(true);
+            bus.Stub(x => x.Advanced).Return(advancedBus);
+
+            scheduleRepository = MockRepository.GenerateStub<IScheduleRepository>();
+
+            schedulerService = new SchedulerService(
+                bus,
+                MockRepository.GenerateStub<IEasyNetQLogger>(),
+                scheduleRepository,
+                new SchedulerServiceConfiguration
+                    {
+                        HandleTimeoutInterval = TimeSpan.FromSeconds(1),
+                        PublishInterval = TimeSpan.FromSeconds(1),
+                        SubscriptionId = "Scheduler",
+                        PublishMaxSchedules = 2
+                    });
+        }
+
+        private SchedulerService schedulerService;
+        private IBus bus;
+        private IAdvancedBus advancedBus;
+        private IScheduleRepository scheduleRepository;
+
+        [Test]
+        public void Should_get_pending_scheduled_messages_and_update_them()
+        {
+            var id = Guid.NewGuid();
+            scheduleRepository.Stub(x => x.GetPending()).Return(new Schedule
+                {
+                    Id = id,
+                    BindingKey = "msg1"
+                });
+
+            schedulerService.OnPublishTimerTick(null);
+
+            scheduleRepository.AssertWasCalled(x => x.MarkAsPublished(id));
+            advancedBus.AssertWasCalled(x => x.Publish(
+                Arg<Exchange>.Is.Anything,
+                Arg<string>.Is.Equal("msg1"),
+                Arg<bool>.Is.Anything,
+                Arg<bool>.Is.Anything,
+                Arg<MessageProperties>.Is.Anything,
+                Arg<byte[]>.Is.Anything));
+        }
+
+
+        [Test]
+        public void Should_hadle_publish_timeout_()
+        {
+            schedulerService.OnHandleTimeoutTimerTick(null);
+            scheduleRepository.AssertWasCalled(x => x.HandleTimeout());
+        }
+    }
+}
+
+// ReSharper restore InconsistentNaming

--- a/Source/EasyNetQ.Scheduler.Mongo.Tests/TestExtensions.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo.Tests/TestExtensions.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace EasyNetQ.Scheduler.Mongo.Tests
+{
+    public static class TestExtensions
+    {
+        public static T ShouldNotBeNull<T>(this T obj)
+        {
+            Assert.IsNotNull(obj);
+            return obj;
+        }
+
+        public static T ShouldNotBeNull<T>(this T obj, string message)
+        {
+            Assert.IsNotNull(obj, message);
+            return obj;
+        }
+
+        public static T ShouldEqual<T>(this T actual, object expected)
+        {
+            Assert.AreEqual(expected, actual);
+            return actual;
+        }
+
+        public static T ShouldEqual<T>(this T actual, object expected, string message)
+        {
+            Assert.AreEqual(expected, actual, message);
+            return actual;
+        }
+
+        public static Exception ShouldBeThrownBy(this Type exceptionType, TestDelegate testDelegate)
+        {
+            return Assert.Throws(exceptionType, testDelegate);
+        }
+
+        public static void ShouldBe<T>(this object actual)
+        {
+            Assert.IsInstanceOf<T>(actual);
+        }
+
+        public static void ShouldBeNull(this object actual)
+        {
+            Assert.IsNull(actual);
+        }
+
+        public static void ShouldBeTheSameAs(this object actual, object expected)
+        {
+            Assert.AreSame(expected, actual);
+        }
+
+        public static T CastTo<T>(this object source)
+        {
+            return (T)source;
+        }
+
+        public static void ShouldBeTrue(this bool source)
+        {
+            Assert.IsTrue(source);
+        }
+
+        public static void ShouldBeTrue(this bool source, string message)
+        {
+            Assert.IsTrue(source, message);
+        }
+
+        public static void ShouldBeFalse(this bool source)
+        {
+            Assert.IsFalse(source);
+        }
+
+        public static void ShouldBeFalse(this bool source, string message)
+        {
+            Assert.IsFalse(source, message);
+        }
+
+        public static void ShouldBeEmpty<T>(this IEnumerable<T> collection)
+        {
+            Assert.AreEqual(collection.Count(), 0,
+            string.Format("Expected collection to be empty, but had {0} items", collection.Count()));
+        }
+    }
+}

--- a/Source/EasyNetQ.Scheduler.Mongo.Tests/packages.config
+++ b/Source/EasyNetQ.Scheduler.Mongo.Tests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="RhinoMocks" version="3.6.1" targetFramework="net45" />
+</packages>

--- a/Source/EasyNetQ.Scheduler.Mongo/ConfigurationBase.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo/ConfigurationBase.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Configuration;
+
+namespace EasyNetQ.Scheduler.Mongo
+{
+    public class ConfigurationBase
+    {
+        protected static int GetIntAppSetting(string settingKey)
+        {
+            var appSetting = ConfigurationManager.AppSettings[settingKey];
+            int value;
+            if (!Int32.TryParse(appSetting, out value))
+            {
+                throw new ApplicationException(String.Format("AppSetting '{0}' value '{1}' is not a valid integer",
+                                                             settingKey, appSetting));
+            }
+            return value;
+        }
+
+        protected static TimeSpan GetTimeSpanAppSettings(string settingKey)
+        {
+            var appSetting = ConfigurationManager.AppSettings[settingKey];
+            TimeSpan value;
+            if (!TimeSpan.TryParse(appSetting, out value))
+            {
+                throw new ApplicationException(string.Format("AppSetting '{0}' value '{1}' is not a valid timespan",
+                                                             settingKey, appSetting));
+            }
+            return value;
+        }
+    }
+}

--- a/Source/EasyNetQ.Scheduler.Mongo/EasyNetQ.Scheduler.Mongo.csproj
+++ b/Source/EasyNetQ.Scheduler.Mongo/EasyNetQ.Scheduler.Mongo.csproj
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{AFD272B4-4A2B-43D4-81ED-666F8918FD01}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>EasyNetQ.Scheduler.Mongo</RootNamespace>
+    <AssemblyName>EasyNetQ.Scheduler.Mongo</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="log4net">
+      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Topshelf">
+      <HintPath>..\packages\Topshelf.3.1.3\lib\net40-full\Topshelf.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ConfigurationBase.cs" />
+    <Compile Include="Logger.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ScheduleRepositoryConfiguration.cs" />
+    <Compile Include="SchedulerServiceConfiguration.cs" />
+    <Compile Include="SchedulerServiceFactory.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="log4net.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\EasyNetQ.Scheduler.Mongo.Core\EasyNetQ.Scheduler.Mongo.Core.csproj">
+      <Project>{f444e58f-da2a-47e8-8246-c4bdd9a192b2}</Project>
+      <Name>EasyNetQ.Scheduler.Mongo.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\EasyNetQ\EasyNetQ.csproj">
+      <Project>{b8def709-5168-48f1-b8d3-ad44e4a4a22b}</Project>
+      <Name>EasyNetQ</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Source/EasyNetQ.Scheduler.Mongo/Logger.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo/Logger.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using log4net;
+
+namespace EasyNetQ.Scheduler.Mongo
+{
+    public class Logger : IEasyNetQLogger
+    {
+        private readonly ILog log;
+
+        public Logger(ILog log)
+        {
+            this.log = log;
+        }
+
+        public void DebugWrite(string format, params object[] args)
+        {
+            log.DebugFormat(format, args);
+        }
+
+        public void InfoWrite(string format, params object[] args)
+        {
+            log.InfoFormat(format, args);
+        }
+
+        public void ErrorWrite(string format, params object[] args)
+        {
+            log.ErrorFormat(format, args);
+        }
+
+        public void ErrorWrite(Exception exception)
+        {
+            log.ErrorFormat(exception.ToString());
+        }
+    }
+}

--- a/Source/EasyNetQ.Scheduler.Mongo/Program.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo/Program.cs
@@ -1,0 +1,38 @@
+﻿using EasyNetQ.Scheduler.Mongo.Core;
+using Topshelf;
+using log4net.Config;
+
+namespace EasyNetQ.Scheduler.Mongo
+{
+    public class Program
+    {
+        private static void Main()
+        {
+            XmlConfigurator.Configure();
+
+            HostFactory.Run(hostConfiguration =>
+                {
+                    hostConfiguration.RunAsLocalSystem();
+                    hostConfiguration.SetDescription("EasyNetQ.Scheduler");
+                    hostConfiguration.SetDisplayName("EasyNetQ.Scheduler");
+                    hostConfiguration.SetServiceName("EasyNetQ.Scheduler");
+
+                    hostConfiguration.Service<ISchedulerService>(serviceConfiguration =>
+                        {
+                            serviceConfiguration.ConstructUsing(_ => SchedulerServiceFactory.CreateScheduler());
+
+                            serviceConfiguration.WhenStarted((service, _) =>
+                                {
+                                    service.Start();
+                                    return true;
+                                });
+                            serviceConfiguration.WhenStopped((service, _) =>
+                                {
+                                    service.Stop();
+                                    return true;
+                                });
+                        });
+                });
+        }
+    }
+}

--- a/Source/EasyNetQ.Scheduler.Mongo/Properties/AssemblyInfo.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("EasyNetQ.Scheduler.Mongo")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("EasyNetQ.Scheduler.Mongo")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("f5512d34-ac6e-415d-9cb8-16427f935b64")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/EasyNetQ.Scheduler.Mongo/ScheduleRepositoryConfiguration.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo/ScheduleRepositoryConfiguration.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Configuration;
+using EasyNetQ.Scheduler.Mongo.Core;
+
+namespace EasyNetQ.Scheduler.Mongo
+{
+    public class ScheduleRepositoryConfiguration : ConfigurationBase, IScheduleRepositoryConfiguration
+    {
+        public string ConnectionString { get; set; }
+        public string DatabaseName { get; set; }
+        public string CollectionName { get; set; }
+        public TimeSpan DeleteTimeout { get; set; }
+        public TimeSpan PublishTimeout { get; set; }
+
+        public static ScheduleRepositoryConfiguration FromConfigFile()
+        {
+            var connectionString = ConfigurationManager.ConnectionStrings["mongodb"];
+            return new ScheduleRepositoryConfiguration
+                {
+                    ConnectionString = connectionString.ConnectionString,
+                    CollectionName = ConfigurationManager.AppSettings["collectionName"],
+                    DatabaseName = ConfigurationManager.AppSettings["databaseName"],
+                    DeleteTimeout = GetTimeSpanAppSettings("deleteTimeout"),
+                    PublishTimeout = GetTimeSpanAppSettings("publishTimeout")
+                };
+        }
+    }
+}

--- a/Source/EasyNetQ.Scheduler.Mongo/SchedulerServiceConfiguration.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo/SchedulerServiceConfiguration.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Configuration;
+using EasyNetQ.Scheduler.Mongo.Core;
+
+namespace EasyNetQ.Scheduler.Mongo
+{
+    public class SchedulerServiceConfiguration : ConfigurationBase, ISchedulerServiceConfiguration
+    {
+        public string SubscriptionId { get; set; }
+        public TimeSpan PublishInterval { get; set; }
+        public TimeSpan HandleTimeoutInterval { get; set; }
+        public int PublishMaxSchedules { get; set; }
+
+        public static SchedulerServiceConfiguration FromConfigFile()
+        {
+            return new SchedulerServiceConfiguration
+                {
+                    SubscriptionId = ConfigurationManager.AppSettings["subscriptionId"],
+                    PublishInterval = GetTimeSpanAppSettings("publishInterval"),
+                    PublishMaxSchedules = GetIntAppSetting("publishMaxSchedules"),
+                    HandleTimeoutInterval = GetTimeSpanAppSettings("handleTimeoutInterval"),
+                };
+        }
+    }
+}

--- a/Source/EasyNetQ.Scheduler.Mongo/SchedulerServiceFactory.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo/SchedulerServiceFactory.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using EasyNetQ.Scheduler.Mongo.Core;
+using log4net;
+
+namespace EasyNetQ.Scheduler.Mongo
+{
+    public static class SchedulerServiceFactory
+    {
+        public static ISchedulerService CreateScheduler()
+        {
+            var bus = RabbitHutch.CreateBus();
+            var logger = new Logger(LogManager.GetLogger("EasyNetQ.Scheduler"));
+
+            return new SchedulerService(
+                bus,
+                logger,
+                new ScheduleRepository(ScheduleRepositoryConfiguration.FromConfigFile(), () => DateTime.UtcNow),
+                SchedulerServiceConfiguration.FromConfigFile());
+        }
+    }
+}

--- a/Source/EasyNetQ.Scheduler.Mongo/app.config
+++ b/Source/EasyNetQ.Scheduler.Mongo/app.config
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0"?>
+<configuration>
+
+  <configSections>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
+  </configSections>
+
+  <connectionStrings>
+    <add name="rabbit" connectionString="host=localhost"/>
+    <add name="mongodb" connectionString="mongodb://localhost:27017/?w=1&amp;readPreference=primary&amp;uuidRepresentation=csharpLegacy" />
+  </connectionStrings>
+
+  <appSettings>
+    
+    <add key="subscriptionId" value="Scheduler" />
+
+    <!-- How long between each pol of the database for messages ready to publish -->
+    <add key="publishInterval" value="00:00:05" />
+
+    <!-- The maximum number of schedule messages to return on each database pol -->
+    <add key="publishMaxSchedules" value="1000" />
+
+    <!-- The mongodb database name to store schedules-->
+    <add key="databaseName" value="EasyNetQ"/>
+
+    <!-- The mongodb collection name to store schedules-->
+    <add key="collectionName" value="Schedules"/>
+
+    <!-- The message publish timeout-->
+    <add key="publishTimeout" value="00:01:00"/>
+
+    <!-- The message delete timeout-->
+    <add key="deleteTimeout" value="00:05:00"/>
+
+
+    <!-- How long between each handle for messages failed to publish-->
+    <add key="handleTimeoutInterval" value="00:05:00"/>
+  </appSettings>
+
+  <log4net>
+    <appender name="main" type="log4net.Appender.ConsoleAppender">
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%-5level - %message%newline" />
+      </layout>
+    </appender>
+
+    <appender name="FileAppender" type="log4net.Appender.FileAppender">
+      <file value="log-file.txt" />
+      <appendToFile value="true" />
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+      </layout>
+    </appender>
+
+    <root>
+      <level value="DEBUG" />
+      <appender-ref ref="main" />
+      <appender-ref ref="FileAppender" />
+    </root>
+  </log4net>
+
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
+  </startup>
+
+</configuration>

--- a/Source/EasyNetQ.Scheduler.Mongo/log4net.config
+++ b/Source/EasyNetQ.Scheduler.Mongo/log4net.config
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<log4net>
+  <appender name="main" type="log4net.Appender.ConsoleAppender">
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%-5level - %message%newline" />
+    </layout>
+  </appender>
+
+  <appender name="FileAppender" type="log4net.Appender.FileAppender">
+    <file value="log-file.txt" />
+    <appendToFile value="true" />
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+    </layout>
+  </appender>  
+  
+  <root>
+    <level value="DEBUG" />
+    <appender-ref ref="main" />
+    <appender-ref ref="FileAppender" />
+  </root>
+</log4net>

--- a/Source/EasyNetQ.Scheduler.Mongo/packages.config
+++ b/Source/EasyNetQ.Scheduler.Mongo/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="log4net" version="2.0.3" targetFramework="net45" />
+  <package id="Topshelf" version="3.1.3" targetFramework="net45" />
+</packages>

--- a/Source/EasyNetQ.Scheduler/ConfigurationBase.cs
+++ b/Source/EasyNetQ.Scheduler/ConfigurationBase.cs
@@ -5,17 +5,17 @@ namespace EasyNetQ.Scheduler
 {
     public class ConfigurationBase
     {
-		public static short GetShortAppSetting(string settingKey)
-		{
-			var appSetting = ConfigurationManager.AppSettings[settingKey];
-			short value;
-			if (!short.TryParse(appSetting, out value))
-			{
-				throw new ApplicationException(string.Format("AppSetting '{0}' value '{1}' is not a valid short",
-					settingKey, appSetting));
-			}
-			return value;
-		}
+        public static short GetShortAppSetting(string settingKey)
+        {
+            var appSetting = ConfigurationManager.AppSettings[settingKey];
+            short value;
+            if (!short.TryParse(appSetting, out value))
+            {
+                throw new ApplicationException(string.Format("AppSetting '{0}' value '{1}' is not a valid short",
+                                                             settingKey, appSetting));
+            }
+            return value;
+        }
 
         public static int GetIntAppSetting(string settingKey)
         {
@@ -24,7 +24,7 @@ namespace EasyNetQ.Scheduler
             if (!int.TryParse(appSetting, out value))
             {
                 throw new ApplicationException(string.Format("AppSetting '{0}' value '{1}' is not a valid integer",
-                    settingKey, appSetting));
+                                                             settingKey, appSetting));
             }
             return value;
         }

--- a/Source/EasyNetQ.Tests/Integration/SchedulingTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/SchedulingTests.cs
@@ -86,7 +86,7 @@ namespace EasyNetQ.Tests.Integration
             bus.FuturePublish(DateTime.UtcNow.AddSeconds(3), "my_cancellation_key", invitation);
             bus.CancelFuturePublish("my_cancellation_key");
 
-            Thread.Sleep(5000);
+            Thread.Sleep(10000);
             Assert.AreEqual(1, messagesReceived);
         }
 

--- a/Source/EasyNetQ.sln
+++ b/Source/EasyNetQ.sln
@@ -1,8 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30110.0
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ", "EasyNetQ\EasyNetQ.csproj", "{B8DEF709-5168-48F1-B8D3-AD44E4A4A22B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ.Tests", "EasyNetQ.Tests\EasyNetQ.Tests.csproj", "{640DEC15-3A17-4E85-B38A-CFB379426DC2}"
@@ -89,6 +87,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "postgres", "postgres", "{CD
 		..\DatabaseScripts\EasyNetQ.Scheduler\postgres\uspMarkWorkItemForPurge.sql = ..\DatabaseScripts\EasyNetQ.Scheduler\postgres\uspMarkWorkItemForPurge.sql
 		..\DatabaseScripts\EasyNetQ.Scheduler\postgres\uspWorkItemsSelfPurge.sql = ..\DatabaseScripts\EasyNetQ.Scheduler\postgres\uspWorkItemsSelfPurge.sql
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ.Scheduler.Mongo.Core", "EasyNetQ.Scheduler.Mongo.Core\EasyNetQ.Scheduler.Mongo.Core.csproj", "{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ.Scheduler.Mongo", "EasyNetQ.Scheduler.Mongo\EasyNetQ.Scheduler.Mongo.csproj", "{AFD272B4-4A2B-43D4-81ED-666F8918FD01}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ.Scheduler.Mongo.Tests", "EasyNetQ.Scheduler.Mongo.Tests\EasyNetQ.Scheduler.Mongo.Tests.csproj", "{4E7F926F-D939-4962-A7EF-112DE41B4236}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -310,6 +314,36 @@ Global
 		{74FB0A3D-2C72-462C-B498-15C0AE615D35}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{74FB0A3D-2C72-462C-B498-15C0AE615D35}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{74FB0A3D-2C72-462C-B498-15C0AE615D35}.Release|x86.ActiveCfg = Release|Any CPU
+		{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}.Release|x86.ActiveCfg = Release|Any CPU
+		{AFD272B4-4A2B-43D4-81ED-666F8918FD01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AFD272B4-4A2B-43D4-81ED-666F8918FD01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AFD272B4-4A2B-43D4-81ED-666F8918FD01}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{AFD272B4-4A2B-43D4-81ED-666F8918FD01}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{AFD272B4-4A2B-43D4-81ED-666F8918FD01}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AFD272B4-4A2B-43D4-81ED-666F8918FD01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AFD272B4-4A2B-43D4-81ED-666F8918FD01}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AFD272B4-4A2B-43D4-81ED-666F8918FD01}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{AFD272B4-4A2B-43D4-81ED-666F8918FD01}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{AFD272B4-4A2B-43D4-81ED-666F8918FD01}.Release|x86.ActiveCfg = Release|Any CPU
+		{4E7F926F-D939-4962-A7EF-112DE41B4236}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E7F926F-D939-4962-A7EF-112DE41B4236}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E7F926F-D939-4962-A7EF-112DE41B4236}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{4E7F926F-D939-4962-A7EF-112DE41B4236}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{4E7F926F-D939-4962-A7EF-112DE41B4236}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4E7F926F-D939-4962-A7EF-112DE41B4236}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E7F926F-D939-4962-A7EF-112DE41B4236}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E7F926F-D939-4962-A7EF-112DE41B4236}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{4E7F926F-D939-4962-A7EF-112DE41B4236}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{4E7F926F-D939-4962-A7EF-112DE41B4236}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Hi guys!

Unfortunatly, we don't have sql-based db in other projects, so we have to port your scheduler to mongodb:)
Here is a simple implementation, may be not as perfomance as possible, but we use it in production as well.

Some notes about implementation:
1) I have to split scheduler.mongo solution into two parts: core and executable. The reason is following: I need to reuse core part, but i don't like to use topshelf and store settings in app.config. 
2) The basic idea is explained here(https://blog.serverdensity.com/replacing-rabbitmq-with-mongodb/).
In addition, I use ttl sparse index on PublishedTime to purge items from collection.
