### PR TITLE
Change RabbitMQ.Client version to 3.3.0 into EasyNetQ.nuspec dependencies

### DIFF
--- a/Package/EasyNetQ/EasyNetQ.nuspec
+++ b/Package/EasyNetQ/EasyNetQ.nuspec
@@ -17,7 +17,7 @@
     <copyright>Copyright Mike Hadlow 2012</copyright>
     <tags>RabbitMQ Messaging AMQP</tags>
     <dependencies>
-      <dependency id="RabbitMQ.Client" version="[3.2.4.0]" />
+      <dependency id="RabbitMQ.Client" version="[3.3.0]" />
       <dependency id="Newtonsoft.Json" version="4.5" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
sorry about that.

![image](https://cloud.githubusercontent.com/assets/1633595/2840388/33844698-d054-11e3-960a-7ee299a0d46f.png)
