### PR TITLE
Switching NextSeqId in BackingQueueStatus from an int to a long

### DIFF
--- a/Source/EasyNetQ.Management.Client.Tests/EasyNetQ.Management.Client.Tests.csproj
+++ b/Source/EasyNetQ.Management.Client.Tests/EasyNetQ.Management.Client.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Model\PermissionInfoTests.cs" />
     <Compile Include="Model\PolicySerializationTests.cs" />
     <Compile Include="Model\PublishInfoTests.cs" />
+    <Compile Include="Model\QueueSerializationTests.cs" />
     <Compile Include="Model\UserInfoTests.cs" />
     <Compile Include="ResourceLoader.cs" />
     <Compile Include="ManagementClientTests.cs" />

--- a/Source/EasyNetQ.Management.Client.Tests/Json/Queues.json
+++ b/Source/EasyNetQ.Management.Client.Tests/Json/Queues.json
@@ -84,7 +84,7 @@
          "target_ram_count":"infinity",
          "ram_msg_count":0,
          "ram_ack_count":0,
-         "next_seq_id":0,
+         "next_seq_id":2147483648,
          "persistent_count":0,
          "avg_ingress_rate":0.0,
          "avg_egress_rate":0.0,

--- a/Source/EasyNetQ.Management.Client.Tests/Model/QueueSerializationTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/QueueSerializationTests.cs
@@ -1,0 +1,25 @@
+﻿// ReSharper disable InconsistentNaming
+
+using System.Collections.Generic;
+using EasyNetQ.Management.Client.Model;
+using NUnit.Framework;
+
+namespace EasyNetQ.Management.Client.Tests.Model
+{
+    [TestFixture]
+    public class QueueSerializationTests
+    {
+        private List<Queue> queues;
+
+        [Test]
+        public void BackingQueueStatus_With_NextSeqId_Exceeding_IntMaxLength_Can_Be_Deserialized()
+        {
+            queues = ResourceLoader.LoadObjectFromJson<List<Queue>>("Queues.json");
+            var queue = queues[1];
+
+            queue.BackingQueueStatus.NextSeqId.ShouldEqual(((long)int.MaxValue) + 1);
+        }
+    }
+}
+
+// ReSharper restore InconsistentNaming

--- a/Source/EasyNetQ.Management.Client/Model/BackingQueueStatus.cs
+++ b/Source/EasyNetQ.Management.Client/Model/BackingQueueStatus.cs
@@ -14,7 +14,7 @@ namespace EasyNetQ.Management.Client.Model
         public string TargetRamCount { get; set; }
         public int RamMsgCount { get; set; }
         public int RamAckCount { get; set; }
-        public int NextSeqId { get; set; }
+        public long NextSeqId { get; set; }
         public int PersistentCount { get; set; }
         public double AvgIngressRate { get; set; }
         public double AvgEgressRate { get; set; }


### PR DESCRIPTION
We started running into an issue where the `backing_queue_status.next_seq_id` was being returned from RabbitMQ with a value that exceeded the range of an `int`. This just modifies that property from an `int` to a `long`.
