### PR TITLE
Do not register component if already registered with Castle Windsor

### DIFF
--- a/Source/EasyNetQ.DI.Windsor/WindsorAdapter.cs
+++ b/Source/EasyNetQ.DI.Windsor/WindsorAdapter.cs
@@ -21,9 +21,12 @@ namespace EasyNetQ.DI
         public IServiceRegister Register<TService>(Func<IServiceProvider, TService> serviceCreator)
             where TService : class
         {
-            windsorContainer.Register(
-                Component.For<TService>().UsingFactoryMethod(() => serviceCreator(this)).LifeStyle.Singleton
-                );
+            if(!windsorContainer.Kernel.HasComponent(typeof(TService)))
+            {
+                windsorContainer.Register(
+                    Component.For<TService>().UsingFactoryMethod(() => serviceCreator(this)).LifeStyle.Singleton
+                    );
+            }
             return this;
         }
 
@@ -31,9 +34,12 @@ namespace EasyNetQ.DI
             where TService : class
             where TImplementation : class, TService
         {
-            windsorContainer.Register(
-                Component.For<TService>().ImplementedBy<TImplementation>().LifeStyle.Singleton
-                );
+            if(!windsorContainer.Kernel.HasComponent(typeof(TService)))
+            {
+                windsorContainer.Register(
+                    Component.For<TService>().ImplementedBy<TImplementation>().LifeStyle.Singleton
+                    );
+            }
             return this;
         }
 


### PR DESCRIPTION
Check that a component is not already registered with Castle Windsor before registering a default component. This allows an application to register their preferred implementation first, such as a custom naming conventions, and when the default components are registered, anything that has already been registered will be skipped.

Without this fix, Castle Windsor throws an exception during default components registration.
