### PR TITLE
x-cancel-on-ha-failover is now false by default and can be configured...

### DIFF
--- a/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
+++ b/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
@@ -15,7 +15,7 @@ namespace EasyNetQ.Tests.ConnectionString
 
         private const string connectionString =
             "virtualHost=Copa;username=Copa;host=192.168.1.1;password=abc_xyz;port=12345;" + 
-            "requestedHeartbeat=3;prefetchcount=2;timeout=12;publisherConfirms=true";
+            "requestedHeartbeat=3;prefetchcount=2;timeout=12;publisherConfirms=true;cancelOnHaFailover=true";
 
         [SetUp]
         public void SetUp()
@@ -37,6 +37,7 @@ namespace EasyNetQ.Tests.ConnectionString
             connectionConfiguration.PrefetchCount.ShouldEqual(2);
             connectionConfiguration.Timeout.ShouldEqual(12);
             connectionConfiguration.PublisherConfirms.ShouldBeTrue();
+            connectionConfiguration.CancelOnHaFailover.ShouldBeTrue();
         }
 
         [Test]

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_consume_is_called.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_consume_is_called.cs
@@ -39,7 +39,7 @@ namespace EasyNetQ.Tests.ConsumeTests
                 Arg<IDictionary<string, object>>.Is.Equal(new Dictionary<string, object>
                     {
                         {"x-priority", 0},
-                        {"x-cancel-on-ha-failover", true}
+                        {"x-cancel-on-ha-failover", false}
                     }),
                 Arg<IBasicConsumer>.Is.Same(MockBuilder.Consumers[0])));
         }
@@ -49,11 +49,12 @@ namespace EasyNetQ.Tests.ConsumeTests
         {
             MockBuilder.Logger.AssertWasCalled(x =>
                                                x.InfoWrite(
-                                                   "Declared Consumer. queue='{0}', consumer tag='{1}' prefetchcount={2} priority={3}",
+                                                   "Declared Consumer. queue='{0}', consumer tag='{1}' prefetchcount={2} priority={3} x-cancel-on-ha-failover={4}",
                                                    "my_queue",
                                                    ConsumerTag,
                                                    (ushort) 50, 
-                                                   0));
+                                                   0,
+                                                   false));
         }
     }
 }

--- a/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
+++ b/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
@@ -41,6 +41,7 @@ namespace EasyNetQ.ConnectionString
             BuildKeyValueParser("timeout", Number, c => c.Timeout),
             BuildKeyValueParser("publisherConfirms", Bool, c => c.PublisherConfirms),
             BuildKeyValueParser("persistentMessages", Bool, c => c.PersistentMessages),
+            BuildKeyValueParser("cancelOnHaFailover", Bool, c => c.CancelOnHaFailover),
             BuildKeyValueParser("product", Text, c => c.Product),
             BuildKeyValueParser("platform", Text, c => c.Platform)
         }.Aggregate((a, b) => a.Or(b));

--- a/Source/EasyNetQ/Consumer/IConsumerConfiguration.cs
+++ b/Source/EasyNetQ/Consumer/IConsumerConfiguration.cs
@@ -2,8 +2,12 @@
 {
     public interface IConsumerConfiguration
     {
-        IConsumerConfiguration WithPriority(int priority);
         int Priority { get; }
+        bool CancelOnHaFailover { get; }
+
+        IConsumerConfiguration WithPriority(int priority);
+
+        IConsumerConfiguration WithCancelOnHaFailover(bool cancelOnHaFailover = true);
     }
 
     public class ConsumerConfiguration : IConsumerConfiguration
@@ -11,13 +15,21 @@
         public ConsumerConfiguration()
         {
             Priority = 0;
+            CancelOnHaFailover = false;
         }
 
         public int Priority { get; private set; }
+        public bool CancelOnHaFailover { get; private set; }
 
         public IConsumerConfiguration WithPriority(int priority)
         {
             Priority = priority;
+            return this;
+        }
+
+        public IConsumerConfiguration WithCancelOnHaFailover(bool cancelOnHaFailover = true)
+        {
+            CancelOnHaFailover = cancelOnHaFailover;
             return this;
         }
     }

--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -79,7 +79,7 @@ namespace EasyNetQ.Consumer
             IDictionary<string, object> arguments = new Dictionary<string, object>
                 {
                     {"x-priority", configuration.Priority},
-                    {"x-cancel-on-ha-failover", true}
+                    {"x-cancel-on-ha-failover", configuration.CancelOnHaFailover || connectionConfiguration.CancelOnHaFailover}
                 };
             try
             {
@@ -94,8 +94,8 @@ namespace EasyNetQ.Consumer
                     arguments,          // arguments
                     this);              // consumer
 
-                logger.InfoWrite("Declared Consumer. queue='{0}', consumer tag='{1}' prefetchcount={2} priority={3}",
-                                  queue.Name, consumerTag, connectionConfiguration.PrefetchCount, configuration.Priority);
+                logger.InfoWrite("Declared Consumer. queue='{0}', consumer tag='{1}' prefetchcount={2} priority={3} x-cancel-on-ha-failover={4}",
+                                  queue.Name, consumerTag, connectionConfiguration.PrefetchCount, configuration.Priority, configuration.CancelOnHaFailover);
             }
             catch (Exception exception)
             {

--- a/Source/EasyNetQ/FluentConfiguration/ISubscriptionConfiguration.cs
+++ b/Source/EasyNetQ/FluentConfiguration/ISubscriptionConfiguration.cs
@@ -30,6 +30,12 @@ namespace EasyNetQ.FluentConfiguration
         /// </summary>
         /// <returns></returns>
         ISubscriptionConfiguration WithPriority(int priority);
+
+        /// <summary>
+        /// Configures the consumer's x-cancel-on-ha-failover attribute
+        /// </summary>
+        /// <returns></returns>
+        ISubscriptionConfiguration WithCancelOnHaFailover(bool cancelOnHaFailover = true);
     }
 
     public class SubscriptionConfiguration : ISubscriptionConfiguration
@@ -37,12 +43,20 @@ namespace EasyNetQ.FluentConfiguration
         public IList<string> Topics { get; private set; }
         public bool AutoDelete { get; private set; }
         public int Priority { get; private set; }
+        public bool CancelOnHaFailover { get; private set; }
 
         public SubscriptionConfiguration()
         {
             Topics = new List<string>();
             AutoDelete = false;
             Priority = 0;
+            CancelOnHaFailover = false;
+        }
+
+        public ISubscriptionConfiguration WithTopic(string topic)
+        {
+            Topics.Add(topic);
+            return this;
         }
 
         public ISubscriptionConfiguration WithAutoDelete(bool autoDelete = true)
@@ -57,9 +71,9 @@ namespace EasyNetQ.FluentConfiguration
             return this;
         }
 
-        public ISubscriptionConfiguration WithTopic(string topic)
+        public ISubscriptionConfiguration WithCancelOnHaFailover(bool cancelOnHaFailover = true)
         {
-            Topics.Add(topic);
+            CancelOnHaFailover = cancelOnHaFailover;
             return this;
         }
     }

--- a/Source/EasyNetQ/IConnectionConfiguration.cs
+++ b/Source/EasyNetQ/IConnectionConfiguration.cs
@@ -33,6 +33,8 @@ namespace EasyNetQ
 
         bool PublisherConfirms { get; }
         bool PersistentMessages { get; set; }
+
+        bool CancelOnHaFailover { get; }
     }
 
     public interface IHostConfiguration
@@ -58,6 +60,7 @@ namespace EasyNetQ
         public ushort Timeout { get; set; }
         public bool PublisherConfirms { get; set; }
         public bool PersistentMessages { get; set; }
+        public bool CancelOnHaFailover { get; set; }
         public string Product { get; set; }
         public string Platform { get; set; }
 
@@ -72,6 +75,7 @@ namespace EasyNetQ
             Timeout = 10; // seconds
             PublisherConfirms = false;
             PersistentMessages = true;
+            CancelOnHaFailover = false;
 
             // prefetchCount determines how many messages will be allowed in the local in-memory queue
             // setting to zero makes this infinite, but risks an out-of-memory exception.

--- a/Source/EasyNetQ/RabbitBus.cs
+++ b/Source/EasyNetQ/RabbitBus.cs
@@ -144,7 +144,11 @@ namespace EasyNetQ
                 advancedBus.Bind(exchange, queue, topic);
             }
 
-            return advancedBus.Consume<T>(queue, (message, messageReceivedInfo) => onMessage(message.Body), x => x.WithPriority(configuration.Priority));
+            return advancedBus.Consume<T>(
+                queue,
+                (message, messageReceivedInfo) => onMessage(message.Body),
+                x => x.WithPriority(configuration.Priority)
+                      .WithCancelOnHaFailover(configuration.CancelOnHaFailover));
         }
 
         public TResponse Request<TRequest, TResponse>(TRequest request)

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.32.3.0")]
+[assembly: AssemblyVersion("0.33.0.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.33.0.0 x-cancel-on-ha-failover is now false by default and can be configured with the cancelOnHaFailover connection string value and with the fluent interface method WithCancelOnHaFailover. If you set on connection string, it can't be overridden by the fluent method, instead if you leave it disabled from connection string, you can manage the behavior per consumer with the fluent interface. Possible breaking change for whom they was expecting a consumer shutdown after a cluster HA fail-over, now the consumer will be redeclared and continue to consume.
 // 0.32.3.0 RabbitMQ.Client version 3.3.2
 // 0.32.2.0 Updated JSON.Net to the latest version
 // 0.32.1.0 Add support for message versioning


### PR DESCRIPTION
...with the cancelOnHaFailover connection string value and with the fluent interface method WithCancelOnHaFailover. This should close the issues #218 and #121.

If you set on connection string, it can't be overridden by the fluent method, instead if you leave it disabled from connection string, you can manage the behavior per consumer with the fluent interface.

Possible breaking change for whom they was expecting a consumer shutdown after a cluster HA fail-over, now the consumer will be redeclared and continue to consume.
