### PR TITLE
Fix bug with future publish based on rabbitmq

### DIFF
--- a/Source/EasyNetQ.Tests/Integration/SchedulingTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/SchedulingTests.cs
@@ -28,6 +28,32 @@ namespace EasyNetQ.Tests.Integration
         }
 
         [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        [Explicit("Needs an instance of RabbitMQ on localhost to work AND scheduler service running")]
+        public void Should_throw_exception_because_of_messageDelay()
+        {
+            var invitation = new PartyInvitation
+            {
+                Text = "Please come to my party",
+                Date = new DateTime(2011, 5, 24)
+            };
+            bus.FuturePublish(TimeSpan.FromMilliseconds(int.MaxValue), invitation);
+        }
+
+        [Test]
+        [Explicit("Needs an instance of RabbitMQ on localhost to work AND scheduler service running")]
+        public void Should_not_throw_exception_because_of_messageDelay()
+        {
+            var invitation = new PartyInvitation
+            {
+                Text = "Please come to my party",
+                Date = new DateTime(2011, 5, 24)
+            };
+            bus.FuturePublish(TimeSpan.FromMilliseconds(int.MaxValue - 1), invitation);
+        }
+
+
+        [Test]
         [Explicit("Needs an instance of RabbitMQ on localhost to work AND scheduler service running")]
         public void Should_be_able_to_schedule_a_message_2()
         {

--- a/Source/EasyNetQ/Preconditions.cs
+++ b/Source/EasyNetQ/Preconditions.cs
@@ -51,7 +51,7 @@ namespace EasyNetQ
         /// Thrown if <paramref name="name"/> or <paramref name="message"/> are
         /// blank.
         /// </exception>
-        public static void CheckNotNull<T>(T value, string name, string message) where T : class 
+        public static void CheckNotNull<T>(T value, string name, string message) where T : class
         {
             CheckNotBlank(name, "name", "name must not be blank");
             CheckNotBlank(message, "message", "message must not be blank");
@@ -222,6 +222,13 @@ namespace EasyNetQ
             {
                 throw new ArgumentException(message, name);
             }
+        }
+
+        public static void CheckLess(TimeSpan value, TimeSpan maxValue, string name)
+        {
+            if (value < maxValue)
+                return;
+            throw new ArgumentOutOfRangeException(name, string.Format("Arguments {0} must be less than maxValue", name));
         }
     }
 }

--- a/Source/EasyNetQ/RabbitBusExtensions.cs
+++ b/Source/EasyNetQ/RabbitBusExtensions.cs
@@ -6,6 +6,8 @@ namespace EasyNetQ
 {
     public static class RabbitBusExtensions
     {
+        private static readonly TimeSpan MaxMessageDelay = TimeSpan.FromMilliseconds(int.MaxValue);
+
         /// <summary>
         /// Schedule a message to be published at some time in the future.
         /// </summary>
@@ -16,12 +18,12 @@ namespace EasyNetQ
         public static void FuturePublish<T>(this IBus bus, TimeSpan messageDelay, T message) where T : class
         {
             Preconditions.CheckNotNull(message, "message");
-
+            Preconditions.CheckLess(messageDelay, MaxMessageDelay, "messageDelay");
             var advancedBus = bus.Advanced;
             var conventions = advancedBus.Container.Resolve<IConventions>();
             var connectionConfiguration = advancedBus.Container.Resolve<IConnectionConfiguration>();
             var delay = Round(messageDelay);
-            var delayString = delay.ToString(@"hh\_mm\_ss");
+            var delayString = delay.ToString(@"dd\_hh\_mm\_ss");
             var exchangeName = conventions.ExchangeNamingConvention(typeof(T));
             var futureExchangeName = exchangeName + "_" + delayString;
             var futureQueueName = conventions.QueueNamingConvention(typeof(T), delayString);
@@ -55,12 +57,12 @@ namespace EasyNetQ
         public static Task FuturePublishAsync<T>(this IBus bus, TimeSpan messageDelay, T message) where T : class
         {
             Preconditions.CheckNotNull(message, "message");
-
+            Preconditions.CheckLess(messageDelay, MaxMessageDelay, "messageDelay");
             var advancedBus = bus.Advanced;
             var conventions = advancedBus.Container.Resolve<IConventions>();
             var connectionConfiguration = advancedBus.Container.Resolve<IConnectionConfiguration>();
             var delay = Round(messageDelay);
-            var delayString = delay.ToString(@"hh\_mm\_ss");
+            var delayString = delay.ToString(@"dd\_hh\_mm\_ss");
             var exchangeName = conventions.ExchangeNamingConvention(typeof(T));
             var futureExchangeName = exchangeName + "_" + delayString;
             var futureQueueName = conventions.QueueNamingConvention(typeof(T), delayString);


### PR DESCRIPTION
1 added days to future publish queue's name(yeah, I need 14 days delay)
2 added check for messageDelay. now it must be strictly less than
TimeSpan.FromMilliseconds(int.maxValue).  It's not strict border by
spec, but it's limitation of current parameters passing to rabbitmq
client.
