### PR TITLE
Use String.Format construct conn string parameter error when connecting to a Boolean type

### DIFF
--- a/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
+++ b/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
@@ -15,17 +15,17 @@ namespace EasyNetQ.ConnectionString
         public static Parser<ushort> Number = Parse.Number.Select(ushort.Parse);
 
         public static Parser<bool> Bool =
-            (Parse.String("true").Or(Parse.String("false"))).Text().Select(x => x == "true");
+           (Parse.String("true").Or(Parse.String("True")).Or(Parse.String("false")).Or(Parse.String("False"))).Text().Select(x => x == "true" || x == "True");
 
         public static Parser<IHostConfiguration> Host =
             from host in Parse.Char(c => c != ':' && c != ';' && c != ',', "host").Many().Text()
             from port in Parse.Char(':').Then(_ => Number).Or(Parse.Return((ushort)0))
-            select new HostConfiguration {Host = host, Port = port};
+            select new HostConfiguration { Host = host, Port = port };
 
         public static Parser<IEnumerable<IHostConfiguration>> Hosts = Host.ListDelimitedBy(',');
 
         private static Uri result;
-        public static Parser<Uri> AMQP = Parse.CharExcept(';').Many().Text().Where(x => Uri.TryCreate(x,UriKind.Absolute, out result)).Select(_ => new Uri(_));
+        public static Parser<Uri> AMQP = Parse.CharExcept(';').Many().Text().Where(x => Uri.TryCreate(x, UriKind.Absolute, out result)).Select(_ => new Uri(_));
 
         public static Parser<UpdateConfiguration> Part = new List<Parser<UpdateConfiguration>>
         {
@@ -47,7 +47,7 @@ namespace EasyNetQ.ConnectionString
         }.Aggregate((a, b) => a.Or(b));
 
         public static Parser<UpdateConfiguration> AMQPAlone =
-            AMQP.Select(_ => (Func<ConnectionConfiguration, ConnectionConfiguration>) (configuration
+            AMQP.Select(_ => (Func<ConnectionConfiguration, ConnectionConfiguration>)(configuration
                                                                                        =>
                 {
                     configuration.AMQPConnectionString = _;
@@ -116,6 +116,6 @@ namespace EasyNetQ.ConnectionString
                 from head in parser
                 from tail in Parse.Char(delimiter).Then(_ => parser).Many()
                 select head.Cons(tail);
-        } 
+        }
     }
 }


### PR DESCRIPTION
Use String.Format construct conn string parameter error when connecting to a Boolean type

Fixed constructed using Boolean String head uppercase unusual cause problems

Example:
bool flag = true;
string conn = String.Format("host=localhost;publisherConfirms={0}",flag);

conn = "host=localhost;publisherConfirms=True"

Error in
\Sprache\ParserOfT.cs  line 34
if (!success.Remainder.AtEnd)
{
     throw new ParseException(string.Format("Parsing failure: Couldn't parse the whole input; unparsable remainder is: \"{0}\".", success.Remainder.Source.Substring(success.Remainder.Position)));
 }

Incidentally formatting codes ^_^
