### PR TITLE
Add exception handling around responder function, to avoid timeout on the client...

### DIFF
--- a/Source/EasyNetQ/Producer/Rpc.cs
+++ b/Source/EasyNetQ/Producer/Rpc.cs
@@ -208,33 +208,55 @@ namespace EasyNetQ.Producer
         {
             var tcs = new TaskCompletionSource<object>();
 
-            responder(requestMessage.Body).ContinueWith(task =>
+            try
             {
-                if(task.IsFaulted)
+                responder(requestMessage.Body).ContinueWith(task =>
                 {
-                    if(task.Exception != null)
+                    if (task.IsFaulted)
                     {
-                        var body = ReflectionHelpers.CreateInstance<TResponse>();
-                        var responseMessage = new Message<TResponse>(body);
-                        responseMessage.Properties.Headers.Add(IsFaultedKey, true);
-                        responseMessage.Properties.Headers.Add(ExceptionMessageKey, task.Exception.InnerException.Message);
-                        responseMessage.Properties.CorrelationId = requestMessage.Properties.CorrelationId;
-
-                        advancedBus.Publish(Exchange.GetDefault(), requestMessage.Properties.ReplyTo, false, false, responseMessage);
-                        tcs.SetException(task.Exception);
+                        if (task.Exception != null)
+                        {
+                            OnResponderFailure<TRequest, TResponse>(requestMessage, task.Exception.InnerException.Message, task.Exception);
+                            tcs.SetException(task.Exception);
+                        }
                     }
-                }
-                else
-                {
-                    var responseMessage = new Message<TResponse>(task.Result);
-                    responseMessage.Properties.CorrelationId = requestMessage.Properties.CorrelationId;
-
-                    advancedBus.Publish(Exchange.GetDefault(), requestMessage.Properties.ReplyTo, false, false, responseMessage);
-                    tcs.SetResult(null);
-                }
-            });
-
+                    else
+                    {
+                        OnResponderSuccess(requestMessage, task.Result);
+                        tcs.SetResult(null);
+                    }
+                });
+            }
+            catch (Exception e)
+            {
+                OnResponderFailure<TRequest, TResponse>(requestMessage, e.Message, e);
+                tcs.SetException(e);
+            }
+            
             return tcs.Task;
+        }
+
+        protected virtual void OnResponderSuccess<TRequest, TResponse>(IMessage<TRequest> requestMessage, TResponse response)
+            where TRequest : class
+            where TResponse : class
+        {
+            var responseMessage = new Message<TResponse>(response);
+            responseMessage.Properties.CorrelationId = requestMessage.Properties.CorrelationId;
+
+            advancedBus.Publish(Exchange.GetDefault(), requestMessage.Properties.ReplyTo, false, false, responseMessage);
+        }
+
+        protected virtual void OnResponderFailure<TRequest, TResponse>(IMessage<TRequest> requestMessage, string exceptionMessage, Exception exception)
+            where TRequest : class 
+            where TResponse : class
+        {
+            var body = ReflectionHelpers.CreateInstance<TResponse>();
+            var responseMessage = new Message<TResponse>(body);
+            responseMessage.Properties.Headers.Add(IsFaultedKey, true);
+            responseMessage.Properties.Headers.Add(ExceptionMessageKey, exceptionMessage);
+            responseMessage.Properties.CorrelationId = requestMessage.Properties.CorrelationId;
+
+            advancedBus.Publish(Exchange.GetDefault(), requestMessage.Properties.ReplyTo, false, false, responseMessage);
         }
     }
 }

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.35.1.0")]
+[assembly: AssemblyVersion("0.35.2.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.35.2.0 Attributes caching + Exception handling around responder function, to avoid timeout on the client when the exception is thrown before the task is returned.
 // 0.35.1.0 Configure request for ManagementClient
 // 0.35.0.0 Use ILRepack to internally merge Newtonsoft.Json
 // 0.34.0.0 basic.get added to advanced bus: IAdvancedBus.Get<T>(IQueue queue)


### PR DESCRIPTION
...when the exception is thrown before the task is returned.

The methods are implemented "open for extension".
