### PR TITLE
always set result for TaskCompletionSource, or no ACK signal will be sent to the RabbitMQ server.

### DIFF
--- a/Source/EasyNetQ.DI.Autofac/AutofacMessageDispatcher.cs
+++ b/Source/EasyNetQ.DI.Autofac/AutofacMessageDispatcher.cs
@@ -38,6 +38,10 @@ namespace EasyNetQ.DI
                     {
                         tsc.SetException(task.Exception);
                     }
+                    else
+                    {
+                        tsc.SetResult(null);
+                    }
                 });
 
             return tsc.Task;


### PR DESCRIPTION
Hi, this is a fix for the code I pulled yesterday. 
