### PR TITLE
Add support for notifications when the connection is blocked

### DIFF
--- a/Source/EasyNetQ.Tests/BlockedConnectionNotificationTests.cs
+++ b/Source/EasyNetQ.Tests/BlockedConnectionNotificationTests.cs
@@ -1,0 +1,63 @@
+﻿// ReSharper disable InconsistentNaming
+using EasyNetQ.Tests.Mocking;
+using NUnit.Framework;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using Rhino.Mocks;
+
+namespace EasyNetQ.Tests
+{
+    [TestFixture]
+    public class When_a_connection_becomes_blocked
+    {
+        private MockBuilder mockBuilder;
+        private IConnection connection;
+        private IAdvancedBus advancedBus;
+
+        [SetUp]
+        public void SetUp()
+        {
+            mockBuilder = new MockBuilder();
+
+            connection = mockBuilder.Connection;
+            advancedBus = mockBuilder.Bus.Advanced;
+        }
+
+        [Test]
+        public void Should_raise_blocked_event()
+        {
+            var blocked = false;
+            advancedBus.Blocked += () => blocked = true;
+            connection.Raise(r => r.ConnectionBlocked += null, connection, new ConnectionBlockedEventArgs("some reason"));
+
+            Assert.That(blocked, Is.True);
+        }
+    }
+
+    [TestFixture]
+    public class When_a_connection_becomes_unblocked
+    {
+        private MockBuilder mockBuilder;
+        private IConnection connection;
+        private IAdvancedBus advancedBus;
+
+        [SetUp]
+        public void SetUp()
+        {
+            mockBuilder = new MockBuilder();
+
+            connection = mockBuilder.Connection;
+            advancedBus = mockBuilder.Bus.Advanced;
+        }
+
+        [Test]
+        public void Should_raise_unblocked_event()
+        {
+            var blocked = true;
+            advancedBus.Unblocked += () => blocked = false;
+            connection.Raise(r => r.ConnectionUnblocked += null, connection);
+
+            Assert.That(blocked, Is.False);
+        }
+    }
+}

--- a/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
+++ b/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="AutoSubscriberTests\When_autosubscribing_with_subscription_configuration_action.cs" />
     <Compile Include="AutoSubscriberTests\When_autosubscribing_with_subscription_configuration.cs" />
     <Compile Include="AutoSubscriberTests\When_autosubscribing.cs" />
+    <Compile Include="BlockedConnectionNotificationTests.cs" />
     <Compile Include="ClientCommandDispatcherTests\When_an_action_is_invoked.cs" />
     <Compile Include="ClientCommandDispatcherTests\When_an_action_is_invoked_that_throws.cs" />
     <Compile Include="ConsumerDispatcherFactoryTests.cs" />

--- a/Source/EasyNetQ/EasyNetQ.csproj
+++ b/Source/EasyNetQ/EasyNetQ.csproj
@@ -93,8 +93,10 @@
     <Compile Include="DeliveryModeStrategy.cs" />
     <Compile Include="EasyNetQException.cs" />
     <Compile Include="Events\AckEvent.cs" />
+    <Compile Include="Events\ConnectionBlockedEvent.cs" />
     <Compile Include="Events\ConnectionCreatedEvent.cs" />
     <Compile Include="Events\ConnectionDisconnectedEvent.cs" />
+    <Compile Include="Events\ConnectionUnblockedEvent.cs" />
     <Compile Include="Events\ConsumerModelDisposedEvent.cs" />
     <Compile Include="Events\PublishChannelCreatedEvent.cs" />
     <Compile Include="Events\ReturnedMessageEvent.cs" />

--- a/Source/EasyNetQ/Events/ConnectionBlockedEvent.cs
+++ b/Source/EasyNetQ/Events/ConnectionBlockedEvent.cs
@@ -1,0 +1,12 @@
+namespace EasyNetQ.Events
+{
+    public class ConnectionBlockedEvent
+    {
+        public string Reason { get; private set; }
+
+        public ConnectionBlockedEvent(string reason)
+        {
+            Reason = reason;
+        }
+    }
+}

--- a/Source/EasyNetQ/Events/ConnectionUnblockedEvent.cs
+++ b/Source/EasyNetQ/Events/ConnectionUnblockedEvent.cs
@@ -1,0 +1,7 @@
+namespace EasyNetQ.Events
+{
+    public class ConnectionUnblockedEvent
+    {
+        
+    }
+}

--- a/Source/EasyNetQ/IAdvancedBus.cs
+++ b/Source/EasyNetQ/IAdvancedBus.cs
@@ -368,6 +368,16 @@ namespace EasyNetQ
         event Action Disconnected;
 
         /// <summary>
+        /// Event fires when the bus gets blocked due to the broker running low on resources.
+        /// </summary>
+        event Action Blocked;
+
+        /// <summary>
+        /// Event fires when the bus is unblocked.
+        /// </summary>
+        event Action Unblocked;
+
+        /// <summary>
         /// Event fires when a mandatory or immediate message is returned as un-routable
         /// </summary>
         event Action<byte[], MessageProperties, MessageReturnedInfo> MessageReturned;

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -62,6 +62,8 @@ namespace EasyNetQ
 
             eventBus.Subscribe<ConnectionCreatedEvent>(e => OnConnected());
             eventBus.Subscribe<ConnectionDisconnectedEvent>(e => OnDisconnected());
+            eventBus.Subscribe<ConnectionBlockedEvent>(e => OnBlocked());
+            eventBus.Subscribe<ConnectionUnblockedEvent>(e => OnUnblocked());
             eventBus.Subscribe<ReturnedMessageEvent>(OnMessageReturned);
 
             clientCommandDispatcher = clientCommandDispatcherFactory.GetClientCommandDispatcher(connection);
@@ -518,6 +520,22 @@ namespace EasyNetQ
         protected void OnDisconnected()
         {
             if (Disconnected != null) Disconnected();
+        }
+
+        public virtual event Action Blocked;
+
+        protected void OnBlocked()
+        {
+            var blocked = Blocked;
+            if (blocked != null) blocked();
+        }
+
+        public virtual event Action Unblocked;
+
+        protected void OnUnblocked()
+        {
+            var unblocked = Unblocked;
+            if (unblocked != null) unblocked();
         }
 
         public event Action<byte[], MessageProperties, MessageReturnedInfo> MessageReturned;

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.35.6.0")]
+[assembly: AssemblyVersion("0.36.0.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.36.0.0 Support for blocked connection notifications
 // 0.35.5.0 Basic implementation of produce-consumer interception
 // 0.35.4.0 Future publish refactor: introduced IScheduler interface.
 // 0.35.3.0 Infinite timeout. (set timeout to 0)


### PR DESCRIPTION
This both includes logging in EasyNetQ to make this situation more visible,
and exposes events in IAdvancedBus for clients to be able to respond to
the event.

See http://www.rabbitmq.com/connection-blocked.html for more information.
