### PR TITLE
Handle publish error (prevent unhandled task exception)

### DIFF
--- a/Source/EasyNetQ/Producer/PublisherConfirms.cs
+++ b/Source/EasyNetQ/Producer/PublisherConfirms.cs
@@ -161,7 +161,20 @@ namespace EasyNetQ.Producer
                     TaskCompletionSource = tcs
                 });
 
-            publishAction(model);
+            try
+            {
+                //execute publish
+                publishAction(model);
+            }
+            catch(Exception ex)
+            {
+                //return fault when publish action can't be executed
+                logger.ErrorWrite("Publish Failed. Sequence number: {0}. Exception: {1}", sequenceNumber, ex);
+                timer.Dispose();
+                dictionary.Remove(sequenceNumber);
+                tcs.TrySetException(ex);
+            }
+            
 
             return tcs.Task;
         }


### PR DESCRIPTION
hi,

Thanks for the great library.

During failover testing we found an issue when publishing at high speeds. The rabbitMQ publish action may fail during a disconnect with SocketExceptions. When this occurs, our test program crashed with an unhandled task exception. 

We found the source of this issue in the PublisherConfirms part of the code. When the publish action throws an exception, the created task is never returned to the caller. It is only present in the dictionary, where it will eventually be faulted with a timeout. As soon as the dictionary is cleared (when a connection to RabbitMQ is re-established), the orphaned faulted task will be garbage collected leading to the unhandled task exception.

This pull-request intends to fix that by faulting and removing the task when the publish action fails.

Regards,
Joost
