### PR TITLE
Fix "NullReferenceException" when trying to get message from an empty queue

### DIFF
--- a/Source/EasyNetQ.Tests/Integration/AdvancedApiExamples.cs
+++ b/Source/EasyNetQ.Tests/Integration/AdvancedApiExamples.cs
@@ -123,7 +123,7 @@ namespace EasyNetQ.Tests.Integration
         {
             var queue = advancedBus.QueueDeclare("get_test");
             advancedBus.Publish(Exchange.GetDefault(), "get_test", false, false,
-                new Message<MyMessage>(new MyMessage{ Text = "Oh! Hello!" }));
+                new Message<MyMessage>(new MyMessage { Text = "Oh! Hello!" }));
 
             var getResult = advancedBus.Get<MyMessage>(queue);
 
@@ -132,6 +132,18 @@ namespace EasyNetQ.Tests.Integration
                 Console.Out.WriteLine("Got message: {0}", getResult.Message.Body.Text);
             }
             else
+            {
+                Console.Out.WriteLine("Failed to get message!");
+            }
+        }
+
+        [Test, Explicit]
+        public void Should_set_MessageAvailable_to_false_when_queue_is_empty()
+        {
+            var queue = advancedBus.QueueDeclare("get_empty_queue_test");
+            var getResult = advancedBus.Get<MyMessage>(queue);
+
+            if (!getResult.MessageAvailable)
             {
                 Console.Out.WriteLine("Failed to get message!");
             }

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -463,7 +463,7 @@ namespace EasyNetQ
         {
             Preconditions.CheckNotNull(queue, "queue");
             var result = Get(queue);
-            if (result.Body == null)
+            if (result == null || result.Body == null)
             {
                 logger.DebugWrite("... but no message was available on queue '{0}'", queue.Name);
                 return new BasicGetResult<T>();
@@ -492,6 +492,7 @@ namespace EasyNetQ
             var task = clientCommandDispatcher.Invoke(x => x.BasicGet(queue.Name, true));
             task.Wait();
             var result = task.Result;
+            if (result == null) return null;
             var getResult = new BasicGetResult(
                 result.Body,
                 new MessageProperties(result.BasicProperties),


### PR DESCRIPTION
When we are using BasicGet to retrieve message from queue we need to check if response is equal to null.
Code example from official [RabbitMQ API Guide](https://www.rabbitmq.com/api-guide.html):

``` java
boolean autoAck = false;
GetResponse response = channel.basicGet(queueName, autoAck);
if (response == null) {
    // No message retrieved.
} else {
    AMQP.BasicProperties props = response.getProps();
    byte[] body = response.getBody();
    long deliveryTag = response.getEnvelope().getDeliveryTag();
    ...
```

So when queue is empty, response equals to null and that cause NullReferenceException:

``` csharp
System.NullReferenceException : Object reference not set to an instance of an object.
   at EasyNetQ.RabbitAdvancedBus.Get(IQueue queue) in RabbitAdvancedBus.cs: line 495
   at EasyNetQ.RabbitAdvancedBus.Get(IQueue queue) in RabbitAdvancedBus.cs: line 465
   at EasyNetQ.Tests.Integration.AdvancedApiExamples.Should_set_MessageAvailable_to_false_when_queue_is_empty() in AdvancedApiExamples.cs: line 144
```
