### PR TITLE
fixed publishing messages after restoring connection to RabbitMQ

### DIFF
--- a/Source/EasyNetQ/Producer/PublishExchangeDeclareStrategy.cs
+++ b/Source/EasyNetQ/Producer/PublishExchangeDeclareStrategy.cs
@@ -24,7 +24,7 @@ namespace EasyNetQ.Producer
             return exchangeNames.AddOrUpdate(
                 exchangeName,
                 name => advancedBus.ExchangeDeclareAsync(name, exchangeType),
-                (_, exchangeTask) => exchangeTask);
+                (name, exchangeTask) => exchangeTask.IsFaulted ? advancedBus.ExchangeDeclareAsync(name, exchangeType) : exchangeTask);
         }
 
         public Task<IExchange> DeclareExchangeAsync(IAdvancedBus advancedBus, Type messageType, string exchangeType)


### PR DESCRIPTION
this should fix such case
1. turn off RabbitMQ
2. publish message
3. exchangeTask in exchangeNames became faulted
4. turn on RabbitMQ
5. publish another message
6. publishing will failed because exchangeTask will be in faulted state

Fix enable recreating of exchangeTask if it is faulted
