### PR TITLE
Fixed exhanges with the plus symbols

### DIFF
--- a/Source/EasyNetQ.Management.Client.Tests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/ManagementClientTests.cs
@@ -139,6 +139,7 @@ namespace EasyNetQ.Management.Client.Tests
         }
 
         private const string testExchange = "management_api_test_exchange";
+        private const string testExchangetestQueueWithPlusChar = "management_api_test_exchange+plus+test";
 
         [Test]
         public void Should_be_able_to_get_an_individual_exchange_by_name()
@@ -160,9 +161,31 @@ namespace EasyNetQ.Management.Client.Tests
         }
 
         [Test]
+        public void Should_be_able_to_create_an_exchange_with_plus_char_in_the_name()
+        {
+            var vhost = managementClient.GetVhost("/");
+            var exhangeInfo = new ExchangeInfo(testExchangetestQueueWithPlusChar, "direct");
+            var queue = managementClient.CreateExchange(exhangeInfo, vhost);
+            queue.Name.ShouldEqual(testExchangetestQueueWithPlusChar);
+        }
+
+        [Test]
         public void Should_be_able_to_delete_an_exchange()
         {
             var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.Name == testExchange);
+            if (exchange == null)
+            {
+                throw new ApplicationException(
+                    string.Format("Test exchange '{0}' hasn't been created", testExchange));
+            }
+
+            managementClient.DeleteExchange(exchange);
+        }
+
+        [Test]
+        public void Should_be_able_to_delete_an_exchange_with_pluses()
+        {
+            var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.Name == testExchangetestQueueWithPlusChar);
             if (exchange == null)
             {
                 throw new ApplicationException(

--- a/Source/EasyNetQ.Management.Client/ManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClient.cs
@@ -165,7 +165,7 @@ namespace EasyNetQ.Management.Client
         public Queue GetQueue(string queueName, Vhost vhost)
         {
             return Get<Queue>(string.Format("queues/{0}/{1}",
-                SanitiseVhostName(vhost.Name), SanitiseQueueName(queueName)));
+                SanitiseVhostName(vhost.Name), SanitiseName(queueName)));
         }
 
         public Exchange CreateExchange(ExchangeInfo exchangeInfo, Vhost vhost)
@@ -179,9 +179,9 @@ namespace EasyNetQ.Management.Client
                 throw new ArgumentNullException("vhost");
             }
 
-            Put(string.Format("exchanges/{0}/{1}", SanitiseVhostName(vhost.Name), exchangeInfo.GetName()), exchangeInfo);
+            Put(string.Format("exchanges/{0}/{1}", SanitiseVhostName(vhost.Name), SanitiseName(exchangeInfo.GetName())), exchangeInfo);
 
-            return GetExchange(exchangeInfo.GetName(), vhost);
+            return GetExchange(SanitiseName(exchangeInfo.GetName()), vhost);
         }
 
         public void DeleteExchange(Exchange exchange)
@@ -191,7 +191,7 @@ namespace EasyNetQ.Management.Client
                 throw new ArgumentNullException("exchange");
             }
 
-            Delete(string.Format("exchanges/{0}/{1}", SanitiseVhostName(exchange.Vhost), exchange.Name));
+            Delete(string.Format("exchanges/{0}/{1}", SanitiseVhostName(exchange.Vhost), SanitiseName(exchange.Name)));
         }
 
         public IEnumerable<Binding> GetBindingsWithSource(Exchange exchange)
@@ -246,7 +246,7 @@ namespace EasyNetQ.Management.Client
                 throw new ArgumentNullException("vhost");
             }
 
-            Put(string.Format("queues/{0}/{1}", SanitiseVhostName(vhost.Name), SanitiseQueueName(queueInfo.GetName())), queueInfo);
+            Put(string.Format("queues/{0}/{1}", SanitiseVhostName(vhost.Name), SanitiseName(queueInfo.GetName())), queueInfo);
 
             return GetQueue(queueInfo.GetName(), vhost);
         }
@@ -258,7 +258,7 @@ namespace EasyNetQ.Management.Client
                 throw new ArgumentNullException("queue");
             }
 
-            Delete(string.Format("queues/{0}/{1}", SanitiseVhostName(queue.Vhost), SanitiseQueueName(queue.Name)));
+            Delete(string.Format("queues/{0}/{1}", SanitiseVhostName(queue.Vhost), SanitiseName(queue.Name)));
         }
 
         public IEnumerable<Binding> GetBindingsForQueue(Queue queue)
@@ -269,7 +269,7 @@ namespace EasyNetQ.Management.Client
             }
 
             return Get<IEnumerable<Binding>>(
-                string.Format("queues/{0}/{1}/bindings", SanitiseVhostName(queue.Vhost), SanitiseQueueName(queue.Name)));
+                string.Format("queues/{0}/{1}/bindings", SanitiseVhostName(queue.Vhost), SanitiseName(queue.Name)));
         }
 
         public void Purge(Queue queue)
@@ -279,7 +279,7 @@ namespace EasyNetQ.Management.Client
                 throw new ArgumentNullException("queue");
             }
 
-            Delete(string.Format("queues/{0}/{1}/contents", SanitiseVhostName(queue.Vhost), SanitiseQueueName(queue.Name)));
+            Delete(string.Format("queues/{0}/{1}/contents", SanitiseVhostName(queue.Vhost), SanitiseName(queue.Name)));
         }
 
         public IEnumerable<Message> GetMessagesFromQueue(Queue queue, GetMessagesCriteria criteria)
@@ -290,7 +290,7 @@ namespace EasyNetQ.Management.Client
             }
 
             return Post<GetMessagesCriteria, IEnumerable<Message>>(
-                string.Format("queues/{0}/{1}/get", SanitiseVhostName(queue.Vhost), SanitiseQueueName(queue.Name)),
+                string.Format("queues/{0}/{1}/get", SanitiseVhostName(queue.Vhost), SanitiseName(queue.Name)),
                 criteria);
         }
 
@@ -315,7 +315,7 @@ namespace EasyNetQ.Management.Client
             }
 
             Post<BindingInfo, object>(
-                string.Format("bindings/{0}/e/{1}/q/{2}", SanitiseVhostName(queue.Vhost), exchange.Name, SanitiseQueueName(queue.Name)),
+                string.Format("bindings/{0}/e/{1}/q/{2}", SanitiseVhostName(queue.Vhost), exchange.Name, SanitiseName(queue.Name)),
                 bindingInfo);
         }
 
@@ -352,7 +352,7 @@ namespace EasyNetQ.Management.Client
 
             return Get<IEnumerable<Binding>>(
                 string.Format("bindings/{0}/e/{1}/q/{2}", SanitiseVhostName(queue.Vhost),
-                    exchange.Name, SanitiseQueueName(queue.Name)));
+                    exchange.Name, SanitiseName(queue.Name)));
         }
 
         public void DeleteBinding(Binding binding)
@@ -699,7 +699,7 @@ namespace EasyNetQ.Management.Client
             return vhostName.Replace("/", "%2f");
         }
 
-        private string SanitiseQueueName(string queueName)
+        private string SanitiseName(string queueName)
         {
             return queueName.Replace("+", "%2B");
         }


### PR DESCRIPTION
The management client did not handle exhanges with symbols the way it
did queues. I updated this and added supporting tests.
