### PR TITLE
Add support for sending and receiving requests on a specific queue

### DIFF
--- a/Source/EasyNetQ.Tests.SimpleService/Program.cs
+++ b/Source/EasyNetQ.Tests.SimpleService/Program.cs
@@ -13,7 +13,9 @@ namespace EasyNetQ.Tests.SimpleService
             var bus = RabbitHutch.CreateBus("host=localhost",
                 x => x.Register<IEasyNetQLogger>(_ => new NoDebugLogger()));
             bus.Respond<TestRequestMessage, TestResponseMessage>(HandleRequest);
+            bus.Respond<TestRequestMessage, TestResponseMessage>("EasyNetQ.CustomTestQueue", HandleRequest);
             bus.RespondAsync<TestAsyncRequestMessage, TestAsyncResponseMessage>(HandleAsyncRequest);
+            bus.RespondAsync<TestAsyncRequestMessage, TestAsyncResponseMessage>("EasyNetQ.CustomTestQueue", HandleAsyncRequest);
 
             Console.WriteLine("Waiting to service requests");
             Console.WriteLine("Ctrl-C to exit");

--- a/Source/EasyNetQ.Tests/Integration/RequestResponseTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/RequestResponseTests.cs
@@ -72,12 +72,8 @@ namespace EasyNetQ.Tests.Integration
         {
             var request = new TestRequestMessage { Text = "Hello from the client! " };
 
-            var typeNameSerializer = new TypeNameSerializer();
-            var conventions = new Conventions(typeNameSerializer);
-            var routingKey = conventions.RpcRoutingKeyNamingConvention(typeof(TestRequestMessage));
-
             Console.WriteLine("Making request");
-            var response = bus.Request<TestRequestMessage, TestResponseMessage>(routingKey, request);
+            var response = bus.Request<TestRequestMessage, TestResponseMessage>("EasyNetQ.CustomTestQueue", request);
 
             Console.WriteLine("Got response: '{0}'", response.Text);
         }
@@ -136,12 +132,8 @@ namespace EasyNetQ.Tests.Integration
             var autoResetEvent = new AutoResetEvent(false);
             var request = new TestAsyncRequestMessage { Text = "Hello async from the client!" };
 
-            var typeNameSerializer = new TypeNameSerializer();
-            var conventions = new Conventions(typeNameSerializer);
-            var routingKey = conventions.RpcRoutingKeyNamingConvention(typeof(TestAsyncRequestMessage));
-
             Console.Out.WriteLine("Making request");
-            bus.RequestAsync<TestAsyncRequestMessage, TestAsyncResponseMessage>(routingKey, request).ContinueWith(response =>
+            bus.RequestAsync<TestAsyncRequestMessage, TestAsyncResponseMessage>("EasyNetQ.CustomTestQueue", request).ContinueWith(response =>
             {
                 Console.Out.WriteLine("response = {0}", response.Result.Text);
                 autoResetEvent.Set();

--- a/Source/EasyNetQ/IBus.cs
+++ b/Source/EasyNetQ/IBus.cs
@@ -178,6 +178,19 @@ namespace EasyNetQ
             where TResponse : class;
 
         /// <summary>
+        /// Responds to an RPC request.
+        /// </summary>
+        /// <typeparam name="TRequest">The request type.</typeparam>
+        /// <typeparam name="TResponse">The response type.</typeparam>
+        /// <param name="queue">The queue to receive from</param>
+        /// <param name="responder">
+        /// A function to run when the request is received. It should return the response.
+        /// </param>
+        IDisposable Respond<TRequest, TResponse>(string queue, Func<TRequest, TResponse> responder)
+            where TRequest : class
+            where TResponse : class;
+
+        /// <summary>
         /// Responds to an RPC request asynchronously.
         /// </summary>
         /// <typeparam name="TRequest">The request type.</typeparam>
@@ -186,6 +199,19 @@ namespace EasyNetQ
         /// A function to run when the request is received.
         /// </param>
         IDisposable RespondAsync<TRequest, TResponse>(Func<TRequest, Task<TResponse>> responder) 
+            where TRequest : class
+            where TResponse : class;
+
+        /// <summary>
+        /// Responds to an RPC request asynchronously.
+        /// </summary>
+        /// <typeparam name="TRequest">The request type.</typeparam>
+        /// <typeparam name="TResponse">The response type</typeparam>
+        /// <param name="queue">The queue to receive from</param>
+        /// <param name="responder">
+        /// A function to run when the request is received.
+        /// </param>
+        IDisposable RespondAsync<TRequest, TResponse>(string queue, Func<TRequest, Task<TResponse>> responder)
             where TRequest : class
             where TResponse : class;
 

--- a/Source/EasyNetQ/Producer/IRpc.cs
+++ b/Source/EasyNetQ/Producer/IRpc.cs
@@ -40,5 +40,16 @@ namespace EasyNetQ.Producer
         IDisposable Respond<TRequest, TResponse>(Func<TRequest, Task<TResponse>> responder)
             where TRequest : class
             where TResponse : class;
+
+        /// <summary>
+        /// Set up a responder for an RPC service.
+        /// </summary>
+        /// <typeparam name="TRequest">The request type</typeparam>
+        /// <typeparam name="TResponse">The response type</typeparam>
+        /// <param name="queue">The queue to receive from</param>
+        /// <param name="responder">A function that performs the response</param>
+        IDisposable Respond<TRequest, TResponse>(string queue, Func<TRequest, Task<TResponse>> responder)
+            where TRequest : class
+            where TResponse : class;
     }
 }

--- a/Source/EasyNetQ/RabbitBus.cs
+++ b/Source/EasyNetQ/RabbitBus.cs
@@ -208,6 +208,19 @@ namespace EasyNetQ
             return RespondAsync(taskResponder);
         }
 
+        public virtual IDisposable Respond<TRequest, TResponse>(string queue, Func<TRequest, TResponse> responder)
+            where TRequest : class
+            where TResponse : class
+        {
+            Preconditions.CheckNotNull(queue, "queue");
+            Preconditions.CheckNotNull(responder, "responder");
+
+            Func<TRequest, Task<TResponse>> taskResponder =
+                request => Task<TResponse>.Factory.StartNew(_ => responder(request), null);
+
+            return RespondAsync(queue, taskResponder);
+        }
+
         public virtual IDisposable RespondAsync<TRequest, TResponse>(Func<TRequest, Task<TResponse>> responder)
             where TRequest : class
             where TResponse : class
@@ -215,6 +228,16 @@ namespace EasyNetQ
             Preconditions.CheckNotNull(responder, "responder");
 
             return rpc.Respond(responder);
+        }
+
+        public virtual IDisposable RespondAsync<TRequest, TResponse>(string queue, Func<TRequest, Task<TResponse>> responder)
+            where TRequest : class
+            where TResponse : class
+        {
+            Preconditions.CheckNotNull(queue, "queue");
+            Preconditions.CheckNotNull(responder, "responder");
+
+            return rpc.Respond(queue, responder);
         }
 
         public virtual void Send<T>(string queue, T message)


### PR DESCRIPTION
- Add Request<TRequest, TResponse>(string queue, TRequest request) to IBus and IRpc
- Add RequestAsync<TRequest, TResponse>(string queue, TRequest request) to IBus
- Add integration tests for new Request methods
- Add Respond<TRequest, TResponse>(string queue, Func<TRequest, TResponse> responder) to IBus and IRpc
- Add RespondAsync<TRequest, TResponse>(string queue, Func<TRequest, Task<TResponse>> responder) to IBus
- Modify integration tests to respond on custom queue

This is in reference to a question I posed on the discussion lists [here](https://groups.google.com/forum/#!topic/easynetq/zAjmUoIirVM)
