### PR TITLE
Simplify the usage of ConnectionStringParser

### DIFF
--- a/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
+++ b/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
@@ -11,7 +11,7 @@ namespace EasyNetQ.Tests.ConnectionString
     [TestFixture]
     public class ConnectionStringParserTests
     {
-        private IConnectionStringParser connectionStringParser;
+        private ConnectionStringParser connectionStringParser;
 
         private const string connectionString =
             "virtualHost=Copa;username=Copa;host=192.168.1.1;password=abc_xyz;port=12345;" + 

--- a/Source/EasyNetQ/ConnectionString/IConnectionStringParser.cs
+++ b/Source/EasyNetQ/ConnectionString/IConnectionStringParser.cs
@@ -1,17 +1,16 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Sprache;
 
 namespace EasyNetQ.ConnectionString
 {
-    public interface IConnectionStringParser
+    public interface IConnectionStringParser<out T> where T : IConnectionConfiguration
     {
-        IConnectionConfiguration Parse(string connectionString);
+        T Parse(string connectionString);
     }
 
-    public class ConnectionStringParser : IConnectionStringParser
+    public class ConnectionStringParser : IConnectionStringParser<ConnectionConfiguration>
     {
-        public IConnectionConfiguration Parse(string connectionString)
+        public ConnectionConfiguration Parse(string connectionString)
         {
             try
             {


### PR DESCRIPTION
When parsing the connection string, the resulting object is read-only. That's a pain when you want to tweak the configuration. I've changed the IConnectionStringParser to be a generic interface, so you can specify which concrete implementation of IConnectionConfiguration you're actually parsing to. Then I also made the default ConnectionStringParser expose the fact that it's working with the default implementation, so you can write:

```
var config = new ConnectionStringParser().Parse("....");
config.PrefetchCount = 1;
```

I'd even go further and drop IConnectionConfiguration. Why do you pull an interface out of a POCO? If you need the ability to extend (I can't forsee anybody doing that, honestly - it's a core domain object), then make the getters/setters virtual. If you want immutable data, I'd use struct. If that would happen, I'd also pull the static helper into ConnectionConfiguration, so you could do:

```
var config = ConnectionConfiguration.Parse("...");
config.PrefetchCount = 1;
```

Looking forward to your thoughts.
