### PR TITLE
Making RabbitMQ dependcy >=3.4

### DIFF
--- a/Package/EasyNetQ/EasyNetQ.nuspec
+++ b/Package/EasyNetQ/EasyNetQ.nuspec
@@ -17,7 +17,7 @@
     <copyright>Copyright Mike Hadlow 2012</copyright>
     <tags>RabbitMQ Messaging AMQP</tags>
     <dependencies>
-      <dependency id="RabbitMQ.Client" version="[3.3.2]" />
+      <dependency id="RabbitMQ.Client" version="[3.4,]" />
       <dependency id="System.Collections.Immutable.Net40" version="[1.0.30.17]" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
Alternative to previous pull request if you want 3.4 as minimum.  Again it is nuget guidance to leave the upper bound open
