### PR TITLE
Services registration order fixed

### DIFF
--- a/Source/EasyNetQ/RabbitHutch.cs
+++ b/Source/EasyNetQ/RabbitHutch.cs
@@ -156,8 +156,8 @@ namespace EasyNetQ
                     "Have you called SetContainerFactory(...) with a function that returns null?");
             }
 
-            registerServices(container);
             container.Register(_ => connectionConfiguration);
+            registerServices(container);
             ComponentRegistration.RegisterServices(container);
 
             return container.Resolve<IBus>();


### PR DESCRIPTION
When registering custom `IInternalConsumerFactory` in `RabbitHutch.CreateBus` it throws exception `No service of type ConnectionConfiguration has been registered`.

Solution: ConnectionConfiguration should be registered before user's services registration.
