### PR TITLE
'Declared Consumer' log message fix

### DIFF
--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -95,7 +95,7 @@ namespace EasyNetQ.Consumer
                     this);              // consumer
 
                 logger.InfoWrite("Declared Consumer. queue='{0}', consumer tag='{1}' prefetchcount={2} priority={3} x-cancel-on-ha-failover={4}",
-                                  queue.Name, consumerTag, connectionConfiguration.PrefetchCount, configuration.Priority, configuration.CancelOnHaFailover);
+                                  queue.Name, consumerTag, configuration.PrefetchCount, configuration.Priority, configuration.CancelOnHaFailover);
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
When using `RabbitAdvancedBus.Consume` with `x => x.WithPrefetchCount(i)` the log message "Declared Consumer..." uses default value of 50 instead of the actual value used in `Model.BasicQos`
