### PR TITLE
RabbitHutch comments update

### DIFF
--- a/Source/EasyNetQ/RabbitHutch.cs
+++ b/Source/EasyNetQ/RabbitHutch.cs
@@ -56,7 +56,7 @@ namespace EasyNetQ
         /// </param>
         /// <param name="registerServices">
         /// Override default services. For example, to override the default IEasyNetQLogger:
-        /// RabbitHutch.CreateBus("host=localhost", x => x.Register&lt;IEasyNetQLogger&gt;(_ => myLogger));
+        /// RabbitHutch.CreateBus("host=localhost", x => x.Register{IEasyNetQLogger}(_ => myLogger));
         /// </param>
         /// <returns>
         /// A new RabbitBus instance.
@@ -96,7 +96,7 @@ namespace EasyNetQ
         /// </param>
         /// <param name="registerServices">
         /// Override default services. For example, to override the default IEasyNetQLogger:
-        /// RabbitHutch.CreateBus("host=localhost", x => x.Register&lt;IEasyNetQLogger&gt;(_ => myLogger));
+        /// RabbitHutch.CreateBus("host=localhost", x => x.Register{IEasyNetQLogger}(_ => myLogger));
         /// </param>
         /// <returns>
         /// A new RabbitBus instance.
@@ -141,7 +141,7 @@ namespace EasyNetQ
         /// </param>
         /// <param name="registerServices">
         /// Override default services. For example, to override the default IEasyNetQLogger:
-        /// RabbitHutch.CreateBus("host=localhost", x => x.Register&lt;IEasyNetQLogger&gt;(_ => myLogger));
+        /// RabbitHutch.CreateBus("host=localhost", x => x.Register{IEasyNetQLogger}(_ => myLogger));
         /// </param>
         /// <returns></returns>
         public static IBus CreateBus(ConnectionConfiguration connectionConfiguration, Action<IServiceRegister> registerServices)


### PR DESCRIPTION
- EasyNetQ.CreateBus(string connectionString) and EasyNetQ.CreateBus(string connectionString, Action<IServiceRegister> registerServices) were mentioning that, if not specified, the default
  requestedHeartbeat would be 0. This is incorrect, the default value is set in EasyNetQ.ConnectionConfiguration ctor “RequestedHeartbeat = 10;”
- Fixed some '&lt;' and '&gt;' characters (probably the result of a former conversion), now using proper curly brackets to designate generics in comments.
