### PR TITLE
Fix typo in 'Failed to connect' error message.

### DIFF
--- a/Source/EasyNetQ/PersistentConnection.cs
+++ b/Source/EasyNetQ/PersistentConnection.cs
@@ -95,7 +95,7 @@ namespace EasyNetQ
             }
             else
             {
-                logger.ErrorWrite("Failed to connected to any Broker. Retrying in {0} ms\n", 
+                logger.ErrorWrite("Failed to connect to any Broker. Retrying in {0} ms\n", 
                     connectAttemptIntervalMilliseconds);
                 StartTryToConnect();
             }


### PR DESCRIPTION
A small thing, but we were seeing a lot of these messages in our logs, and I noticed the typo.