### PR TITLE
Responder prefetch count customization

### DIFF
--- a/Source/EasyNetQ/EasyNetQ.csproj
+++ b/Source/EasyNetQ/EasyNetQ.csproj
@@ -214,12 +214,9 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets. -->
   <Target Name="BeforeBuild">
   </Target>
   <Target Name="AfterBuild">
-    <!-- /internalize /targetplatform:v4 /out:$(OutputPath)\EasyNetQ.dll $(OutputPath)\EasyNetQ.dll $(OutputPath)\Newtonsoft.Json.dll -->
     <Exec Command="..\..\Tools\ILRepack\ILRepack.exe /internalize /targetplatform:v4 /out:$(OutputPath)\EasyNetQ.dll $(OutputPath)\EasyNetQ.dll $(OutputPath)\Newtonsoft.Json.dll" />
   </Target>
 </Project>

--- a/Source/EasyNetQ/EasyNetQ.csproj
+++ b/Source/EasyNetQ/EasyNetQ.csproj
@@ -158,6 +158,7 @@
     <Compile Include="Producer\IPersistentChannelFactory.cs" />
     <Compile Include="Producer\IPublisher.cs" />
     <Compile Include="Producer\IPublishExchangeDeclareStrategy.cs" />
+    <Compile Include="Producer\IResponderConfiguration.cs" />
     <Compile Include="Producer\IRpc.cs" />
     <Compile Include="Producer\ISendReceive.cs" />
     <Compile Include="Producer\PersistentChannel.cs" />
@@ -218,7 +219,7 @@
   <Target Name="BeforeBuild">
   </Target>
   <Target Name="AfterBuild">
-      <!-- /internalize /targetplatform:v4 /out:$(OutputPath)\EasyNetQ.dll $(OutputPath)\EasyNetQ.dll $(OutputPath)\Newtonsoft.Json.dll -->
+    <!-- /internalize /targetplatform:v4 /out:$(OutputPath)\EasyNetQ.dll $(OutputPath)\EasyNetQ.dll $(OutputPath)\Newtonsoft.Json.dll -->
     <Exec Command="..\..\Tools\ILRepack\ILRepack.exe /internalize /targetplatform:v4 /out:$(OutputPath)\EasyNetQ.dll $(OutputPath)\EasyNetQ.dll $(OutputPath)\Newtonsoft.Json.dll" />
   </Target>
 </Project>

--- a/Source/EasyNetQ/IBus.cs
+++ b/Source/EasyNetQ/IBus.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using EasyNetQ.Consumer;
 using EasyNetQ.FluentConfiguration;
+using EasyNetQ.Producer;
 
 namespace EasyNetQ
 {
@@ -154,6 +155,21 @@ namespace EasyNetQ
             where TResponse : class;
 
         /// <summary>
+        /// Responds to an RPC request.
+        /// </summary>
+        /// <typeparam name="TRequest">The request type.</typeparam>
+        /// <typeparam name="TResponse">The response type.</typeparam>
+        /// <param name="responder">
+        /// A function to run when the request is received. It should return the response.
+        /// </param>
+        /// <param name="configure">
+        /// A function for responder configuration
+        /// </param>
+        IDisposable Respond<TRequest, TResponse>(Func<TRequest, TResponse> responder, Action<IResponderConfiguration> configure)
+            where TRequest : class
+            where TResponse : class;
+
+        /// <summary>
         /// Responds to an RPC request asynchronously.
         /// </summary>
         /// <typeparam name="TRequest">The request type.</typeparam>
@@ -162,6 +178,21 @@ namespace EasyNetQ
         /// A function to run when the request is received.
         /// </param>
         IDisposable RespondAsync<TRequest, TResponse>(Func<TRequest, Task<TResponse>> responder) 
+            where TRequest : class
+            where TResponse : class;
+
+        /// <summary>
+        /// Responds to an RPC request asynchronously.
+        /// </summary>
+        /// <typeparam name="TRequest">The request type.</typeparam>
+        /// <typeparam name="TResponse">The response type</typeparam>
+        /// <param name="responder">
+        /// A function to run when the request is received.
+        /// </param>
+        /// <param name="configure">
+        /// A function for responder configuration
+        /// </param>
+        IDisposable RespondAsync<TRequest, TResponse>(Func<TRequest, Task<TResponse>> responder, Action<IResponderConfiguration> configure)
             where TRequest : class
             where TResponse : class;
 

--- a/Source/EasyNetQ/Producer/IResponderConfiguration.cs
+++ b/Source/EasyNetQ/Producer/IResponderConfiguration.cs
@@ -1,0 +1,23 @@
+﻿namespace EasyNetQ.Producer
+{
+    public interface IResponderConfiguration
+    {
+        IResponderConfiguration WithPrefetchCount(ushort prefetchCount);
+    }
+
+    public class ResponderConfiguration : IResponderConfiguration
+    {
+        public ResponderConfiguration(ushort defaultPrefetchCount)
+        {
+            PrefetchCount = defaultPrefetchCount;
+        }
+
+        public ushort PrefetchCount { get; private set; }
+
+        public IResponderConfiguration WithPrefetchCount(ushort prefetchCount)
+        {
+            PrefetchCount = prefetchCount;
+            return this;
+        }
+    }
+}

--- a/Source/EasyNetQ/Producer/IRpc.cs
+++ b/Source/EasyNetQ/Producer/IRpc.cs
@@ -28,5 +28,17 @@ namespace EasyNetQ.Producer
         IDisposable Respond<TRequest, TResponse>(Func<TRequest, Task<TResponse>> responder)
             where TRequest : class
             where TResponse : class;
+
+
+        /// <summary>
+        /// Set up a responder for an RPC service.
+        /// </summary>
+        /// <typeparam name="TRequest">The request type</typeparam>
+        /// <typeparam name="TResponse">The response type</typeparam>
+        /// <param name="responder">A function that performs the response</param>
+        /// <param name="configure">A function that performs the configuration</param>
+        IDisposable Respond<TRequest, TResponse>(Func<TRequest, Task<TResponse>> responder, Action<IResponderConfiguration> configure)
+            where TRequest : class
+            where TResponse : class;
     }
 }


### PR DESCRIPTION
Hi guys!

Here is a customization of rpc's respond side: prefetch count of responder's consumer.

It seems reasonable, because each responder in service can have different needs of prefetch count: very fast methods(hight prefetch count) or slow(with needs of better distribution between consumers).

What do you think about it?