### PR TITLE
ReflectionHelpers-improvements

### DIFF
--- a/Source/EasyNetQ.Tests/ReflectionHelpersTests.cs
+++ b/Source/EasyNetQ.Tests/ReflectionHelpersTests.cs
@@ -15,7 +15,7 @@ namespace EasyNetQ.Tests
         }
 
         [Test]
-        [ExpectedException(typeof (Exception))]
+        [ExpectedException(typeof(MissingMethodException))]
         public void ShouldFailToCreateClassWithoutDefaultConstructor()
         {
             ReflectionHelpers.CreateInstance<ClassWithoutDefaultConstuctor>();
@@ -57,14 +57,14 @@ namespace EasyNetQ.Tests
         [Test]
         public void ShouldGetAttributes()
         {
-            Assert.IsTrue(typeof (TestAttributedClass).GetAttributes<OneTestAttribute>().Any());
-            Assert.IsTrue(typeof (TestAttributedClass).GetAttributes<AnotherTestAttribute>().Any());
+            Assert.IsTrue(typeof(TestAttributedClass).GetAttributes<OneTestAttribute>().Any());
+            Assert.IsTrue(typeof(TestAttributedClass).GetAttributes<AnotherTestAttribute>().Any());
         }
 
         [Test, Explicit("Fails on build server")]
         public void ShouldPerformFasterThanGetCustomAttributes()
         {
-            var type = typeof (TestAttributedClass);
+            var type = typeof(TestAttributedClass);
             // warmup
             for (var i = 0; i < 10; ++i)
             {
@@ -97,12 +97,19 @@ namespace EasyNetQ.Tests
             Console.WriteLine(getAttributesTime);
         }
 
+        [Test]
+        public void ShouldGetAttribute()
+        {
+            Assert.IsNotNull(typeof(TestAttributedClass).GetAttribute<OneTestAttribute>());
+            Assert.IsNotNull(typeof(TestAttributedClass).GetAttribute<AnotherTestAttribute>());
+        }
     }
 
     [AttributeUsage(AttributeTargets.Class)]
-    public class OneTestAttribute :Attribute
+    public class OneTestAttribute : Attribute
     {
-        public int Value {
+        public int Value
+        {
             get { return 1; }
         }
     }
@@ -110,7 +117,8 @@ namespace EasyNetQ.Tests
     [AttributeUsage(AttributeTargets.Class)]
     public class AnotherTestAttribute : Attribute
     {
-        public int Value {
+        public int Value
+        {
             get { return 1; }
         }
     }

--- a/Source/EasyNetQ/Conventions.cs
+++ b/Source/EasyNetQ/Conventions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 
 
 namespace EasyNetQ
@@ -77,8 +76,7 @@ namespace EasyNetQ
 
         private QueueAttribute GetQueueAttribute(Type messageType)
         {
-            var attr = messageType.GetAttributes<QueueAttribute>().FirstOrDefault();
-            return attr ?? new QueueAttribute(string.Empty);
+            return messageType.GetAttribute<QueueAttribute>() ?? new QueueAttribute(string.Empty);
         }
 
 		public ExchangeNameConvention ExchangeNamingConvention { get; set; }

--- a/Source/EasyNetQ/DeliveryModeStrategy.cs
+++ b/Source/EasyNetQ/DeliveryModeStrategy.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 
 namespace EasyNetQ
 {
@@ -21,10 +20,8 @@ namespace EasyNetQ
         public bool IsPersistent(Type messageType)
         {
             Preconditions.CheckNotNull(messageType, "messageType");
-            var deliveryModeAttribute = messageType.GetAttributes<DeliveryModeAttribute>().FirstOrDefault();
-            if (deliveryModeAttribute != null)
-                return deliveryModeAttribute.IsPersistent;
-            return connectionConfiguration.PersistentMessages;
+            var deliveryModeAttribute = messageType.GetAttribute<DeliveryModeAttribute>();
+            return deliveryModeAttribute != null ? deliveryModeAttribute.IsPersistent : connectionConfiguration.PersistentMessages;
         }
     }
 }

--- a/Source/EasyNetQ/ITimeoutStrategy.cs
+++ b/Source/EasyNetQ/ITimeoutStrategy.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 
 namespace EasyNetQ
 {
@@ -21,10 +20,8 @@ namespace EasyNetQ
         public ulong GetTimeoutSeconds(Type messageType)
         {
             Preconditions.CheckNotNull(messageType, "messageType");
-            var timeoutAttribute = messageType.GetAttributes<TimeoutSecondsAttribute>().FirstOrDefault();
-            if (timeoutAttribute != null)
-                return timeoutAttribute.Timeout;
-            return connectionConfiguration.Timeout;
+            var timeoutAttribute = messageType.GetAttribute<TimeoutSecondsAttribute>();
+            return timeoutAttribute != null ? timeoutAttribute.Timeout : connectionConfiguration.Timeout;
         }
     }
 }

--- a/Source/EasyNetQ/ReflectionHelpers.cs
+++ b/Source/EasyNetQ/ReflectionHelpers.cs
@@ -8,16 +8,31 @@ namespace EasyNetQ
 {
     public static class ReflectionHelpers
     {
-        private static readonly ConcurrentDictionary<Type, Attribute[]> Attributes = new ConcurrentDictionary<Type, Attribute[]>();
-    
-        public static IEnumerable<TAttribute> GetAttributes<TAttribute>(this Type type)
+        private static readonly ConcurrentDictionary<Type, Dictionary<Type, Attribute[]>> _attributes = new ConcurrentDictionary<Type, Dictionary<Type, Attribute[]>>();
+
+        public static IEnumerable<TAttribute> GetAttributes<TAttribute>(this Type type) where TAttribute : Attribute
         {
-            return Attributes.GetOrAdd(type, t => t.GetCustomAttributes(true)
-                                                   .Cast<Attribute>()
-                                                   .ToArray())
-                             .Where(x => x.GetType() == typeof (TAttribute))
-                             .Cast<TAttribute>()
-                             .ToArray();
+            var typeAttributeDictionary = _attributes.GetOrAdd(type, t => t.GetCustomAttributes(true)
+                                                              .Cast<Attribute>()
+                                                              .GroupBy(attr => attr.GetType())
+                                                              .ToDictionary(group => group.Key, group => group.ToArray()));
+            Attribute[] attributes;
+            return typeAttributeDictionary.TryGetValue(typeof(TAttribute), out attributes) ? attributes.Cast<TAttribute>().ToArray() : new TAttribute[0];
+
+        }
+
+        public static TAttribute GetAttribute<TAttribute>(this Type type) where TAttribute : Attribute
+        {
+            var typeAttributeDictionary = _attributes.GetOrAdd(type, t => t.GetCustomAttributes(true)
+                                                                           .Cast<Attribute>()
+                                                                           .GroupBy(attr => attr.GetType())
+                                                                           .ToDictionary(group => group.Key, group => group.ToArray()));
+            Attribute[] attributes;
+            if (typeAttributeDictionary.TryGetValue(typeof(TAttribute), out attributes) && attributes.Length > 0)
+            {
+                return (TAttribute)attributes[0];
+            }
+            return default(TAttribute);
         }
 
         public static T CreateInstance<T>()
@@ -33,9 +48,11 @@ namespace EasyNetQ
             {
                 if (factory == null)
                 {
-                    var constructorInfo = typeof (T).GetConstructor(new Type[0]);
+                    var constructorInfo = typeof(T).GetConstructor(Type.EmptyTypes);
                     if (constructorInfo == null)
-                        throw new Exception();
+                    {
+                        throw new MissingMethodException("The type that is specified for T does not have a parameterless constructor.");
+                    }
                     factory = Expression.Lambda<Func<T>>(Expression.New(constructorInfo)).Compile();
                 }
                 return factory();

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.40.1.0")]
+[assembly: AssemblyVersion("0.40.2.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.40.2.0 ReflectionHelpers improvement
 // 0.40.1.0 Fix concurrent bugs in DefaultServiceProvider
 // 0.40.0.0 Exclusive Consumer
 // 0.39.6.0 Fix enable recreating of exchangeTask if it is faulted


### PR DESCRIPTION
#354 

- Added `GetAttribute<TAttribute>` and updated `GetAttributes<TAttribute>` implementation to use the new backing store, used to be `ConcurrentDictionary<Type, Attribute[]>` and is now `ConcurrentDictionary<Type, Dictionary<Type, Attribute[]>>`.
- Added `Attribute` constraint on generic parameter of` GetAttribute<TAttribute>` and `GetAttribute<TAttribute>`.
- Updated all references of `GetAttributes<TAttribute>` to use `GetAttribute<TAttribute>` where a single element was retrieved from the resulting collection.
- `DefaultFactories<T>.Get()` now uses `Type.EmptyTypes` instead of instantiating an empty Type array. We'll also throw a `MissingMethodException` when we fail to retrieve a public parameterless constructor to mirror `Activator.CreateInstance<T>()` behavior where we used to throw a messageless `Exception`.