### PR TITLE
ManagementClient: Use ILRepack to intern Newtonsoft.Json, default WebRequest.KeepAlive to false

### DIFF
--- a/Build/EasyNetQ.proj
+++ b/Build/EasyNetQ.proj
@@ -48,6 +48,12 @@
           Command="$(ILRepack) /internalize /targetplatform:v4 /out:$(OutputDir)\EasyNetQ.dll $(OutputDir)\EasyNetQ.dll $(OutputDir)\Newtonsoft.Json.dll" />
     </Target>
 
+  <Target Name="MergeManagementClient" DependsOnTargets="Build">
+    <Exec
+        WorkingDirectory="$(OutputDir)"
+        Command="$(ILRepack) /internalize /targetplatform:v4 /out:$(OutputDir)\EasyNetQ.Management.Client.dll $(OutputDir)\EasyNetQ.Management.Client.dll $(OutputDir)\Newtonsoft.Json.dll" />
+  </Target>
+
     <!-- Packaging -->
   
     <Target Name="Package" DependsOnTargets="Merge">
@@ -76,7 +82,7 @@
         <Message Text="##teamcity[buildNumber '%(AsmInfo.Version)']" />
     </Target>
 
-    <Target Name="PackageManagementClient" DependsOnTargets="Build">
+    <Target Name="PackageManagementClient" DependsOnTargets="MergeManagementClient">
 
         <ItemGroup>
             <FilesToDelete Include="$(Package)\EasyNetQ.Management.Client\*.nupkg"  />

--- a/Package/EasyNetQ.Management.Client/EasyNetQ.Management.Client.nuspec
+++ b/Package/EasyNetQ.Management.Client/EasyNetQ.Management.Client.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>EasyNetQ.Management.Client</id>
     <!-- Version gets updated from EasyNetQ.dll version number during the build's packaging process -->
-    <version>0.35.1.0</version>
+    <version>0.43.0.0</version>
     <title>EasyNetQ.Management.Client</title>
     <authors>Mike Hadlow</authors>
     <owners>Mike Hadlow</owners>
@@ -17,7 +17,6 @@
     <copyright>Copyright Mike Hadlow 2012</copyright>
     <tags>RabbitMQ Messaging AMQP REST API</tags>
     <dependencies>
-      <dependency id="Newtonsoft.Json" version="6.0.5" />
     </dependencies>
   </metadata>
 </package>

--- a/Source/EasyNetQ.Management.Client/ManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClient.cs
@@ -682,6 +682,7 @@ namespace EasyNetQ.Management.Client
 			var request = (HttpWebRequest)WebRequest.Create(uri);
             request.Credentials = new NetworkCredential(username, password); 
             request.Timeout = request.ReadWriteTimeout = (int)timeout.TotalMilliseconds;
+            request.KeepAlive = false; //default WebRequest.KeepAlive to false to resolve spurious 'the request was aborted: the request was canceled' exceptions
 
             configureRequest(request);
 

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.42.0.0")]
+[assembly: AssemblyVersion("0.43.0.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.43.0.0 Use ILRepack to internally merge Newtonsoft.Json in ManagementClient, default WebRequest.KeepAlive to false to resolve spurious 'the request was aborted: the request was canceled' exceptions
 // 0.42.0.0 Switched from local to UTC datetimes.
 // 0.41.0.0 Dynamic removal 
 // 0.40.6.0 Added parameter to set the 'x-dead-letter-routing-key' argument when declaring a queue.

--- a/hall_of_fame.md
+++ b/hall_of_fame.md
@@ -56,3 +56,4 @@ No particular order. Don't forget to add your name with your pull request.
 * Andrey Katamanov
 * Jeff Huntsman
 * Mathieu Leenhardt
+* Steven Bone


### PR DESCRIPTION
- Remove dependency on specific version of Newtonsoft.Json for the Management Client by ILRepacking Newtonsoft.Json
- Default WebRequest.KeepAlive to false to resolve spurious 'the request was aborted: the request was canceled' exceptions when using management client with high frequency.

See also discussion in #365 regarding KeepAlive = false