### PR TITLE
Ability to configure Receive() consumer behavior

### DIFF
--- a/Source/EasyNetQ/IBus.cs
+++ b/Source/EasyNetQ/IBus.cs
@@ -229,8 +229,30 @@ namespace EasyNetQ
         /// </summary>
         /// <typeparam name="T">The type of message to receive</typeparam>
         /// <param name="queue">The queue to receive from</param>
+        /// <param name="onMessage">The message handler</param>
+        /// <param name="configure">Action to configure consumer with</param>
+        IDisposable Receive<T>(string queue, Action<T> onMessage, Action<IConsumerConfiguration> configure) where T : class;
+
+        /// <summary>
+        /// Receive messages from a queue.
+        /// Multiple calls to Receive for the same queue, but with different message types
+        /// will add multiple message handlers to the same consumer.
+        /// </summary>
+        /// <typeparam name="T">The type of message to receive</typeparam>
+        /// <param name="queue">The queue to receive from</param>
         /// <param name="onMessage">The asychronous message handler</param>
         IDisposable Receive<T>(string queue, Func<T, Task> onMessage) where T : class;
+
+        /// <summary>
+        /// Receive messages from a queue.
+        /// Multiple calls to Receive for the same queue, but with different message types
+        /// will add multiple message handlers to the same consumer.
+        /// </summary>
+        /// <typeparam name="T">The type of message to receive</typeparam>
+        /// <param name="queue">The queue to receive from</param>
+        /// <param name="onMessage">The asychronous message handler</param>
+        /// <param name="configure">Action to configure consumer with</param>
+        IDisposable Receive<T>(string queue, Func<T, Task> onMessage, Action<IConsumerConfiguration> configure) where T : class;
 
         /// <summary>
         /// Receive a message from the specified queue. Dispatch them to the given handlers
@@ -239,6 +261,15 @@ namespace EasyNetQ
         /// <param name="addHandlers">A function to add handlers</param>
         /// <returns>Consumer cancellation. Call Dispose to stop consuming</returns>
         IDisposable Receive(string queue, Action<IReceiveRegistration> addHandlers);
+
+        /// <summary>
+        /// Receive a message from the specified queue. Dispatch them to the given handlers
+        /// </summary>
+        /// <param name="queue">The queue to take messages from</param>
+        /// <param name="addHandlers">A function to add handlers</param>
+        /// <param name="configure">Action to configure consumer with</param>
+        /// <returns>Consumer cancellation. Call Dispose to stop consuming</returns>
+        IDisposable Receive(string queue, Action<IReceiveRegistration> addHandlers, Action<IConsumerConfiguration> configure);
 
         /// <summary>
         /// Fires once the bus has connected to a RabbitMQ server.

--- a/Source/EasyNetQ/Producer/ISendReceive.cs
+++ b/Source/EasyNetQ/Producer/ISendReceive.cs
@@ -31,7 +31,14 @@ namespace EasyNetQ.Producer
         /// <returns>Consumer cancellation. Call Dispose to stop consuming</returns>
         IDisposable Receive<T>(string queue, Action<T> onMessage) where T : class;
 
-        // TODO doc
+        /// <summary>
+        /// Receive a message from the specified queue
+        /// </summary>
+        /// <typeparam name="T">The type of message to receive</typeparam>
+        /// <param name="queue">The queue to receive from</param>
+        /// <param name="onMessage">The synchronous function that handles the message</param>
+        /// <param name="configure">Action to configure consumer with</param>
+        /// <returns>Consumer cancellation. Call Dispose to stop consuming</returns>
         IDisposable Receive<T>(string queue, Action<T> onMessage, Action<IConsumerConfiguration> configure) where T : class;
 
         /// <summary>
@@ -43,7 +50,14 @@ namespace EasyNetQ.Producer
         /// <returns>Consumer cancellation. Call Dispose to stop consuming</returns>
         IDisposable Receive<T>(string queue, Func<T, Task> onMessage) where T : class;
 
-        // TODO doc
+        /// <summary>
+        /// Receive a message from the specified queue
+        /// </summary>
+        /// <typeparam name="T">The type of message to receive</typeparam>
+        /// <param name="queue">The queue to receive from</param>
+        /// <param name="onMessage">The asynchronous function that handles the message</param>
+        /// <param name="configure">Action to configure consumer with</param>
+        /// <returns>Consumer cancellation. Call Dispose to stop consuming</returns>
         IDisposable Receive<T>(string queue, Func<T, Task> onMessage, Action<IConsumerConfiguration> configure) where T : class;
 
         /// <summary>
@@ -54,7 +68,13 @@ namespace EasyNetQ.Producer
         /// <returns>Consumer cancellation. Call Dispose to stop consuming</returns>
         IDisposable Receive(string queue, Action<IReceiveRegistration> addHandlers);
 
-        // TODO doc
+        /// <summary>
+        /// Receive a message from the specified queue. Dispatch them to the given handlers
+        /// </summary>
+        /// <param name="queue">The queue to take messages from</param>
+        /// <param name="addHandlers">A function to add handlers</param>
+        /// <param name="configure">Action to configure consumer with</param>
+        /// <returns>Consumer cancellation. Call Dispose to stop consuming</returns>
         IDisposable Receive(string queue, Action<IReceiveRegistration> addHandlers, Action<IConsumerConfiguration> configure);
     }
 }

--- a/Source/EasyNetQ/Producer/ISendReceive.cs
+++ b/Source/EasyNetQ/Producer/ISendReceive.cs
@@ -31,6 +31,9 @@ namespace EasyNetQ.Producer
         /// <returns>Consumer cancellation. Call Dispose to stop consuming</returns>
         IDisposable Receive<T>(string queue, Action<T> onMessage) where T : class;
 
+        // TODO doc
+        IDisposable Receive<T>(string queue, Action<T> onMessage, Action<IConsumerConfiguration> configure) where T : class;
+
         /// <summary>
         /// Receive a message from the specified queue
         /// </summary>
@@ -40,6 +43,9 @@ namespace EasyNetQ.Producer
         /// <returns>Consumer cancellation. Call Dispose to stop consuming</returns>
         IDisposable Receive<T>(string queue, Func<T, Task> onMessage) where T : class;
 
+        // TODO doc
+        IDisposable Receive<T>(string queue, Func<T, Task> onMessage, Action<IConsumerConfiguration> configure) where T : class;
+
         /// <summary>
         /// Receive a message from the specified queue. Dispatch them to the given handlers
         /// </summary>
@@ -47,5 +53,8 @@ namespace EasyNetQ.Producer
         /// <param name="addHandlers">A function to add handlers</param>
         /// <returns>Consumer cancellation. Call Dispose to stop consuming</returns>
         IDisposable Receive(string queue, Action<IReceiveRegistration> addHandlers);
+
+        // TODO doc
+        IDisposable Receive(string queue, Action<IReceiveRegistration> addHandlers, Action<IConsumerConfiguration> configure);
     }
 }

--- a/Source/EasyNetQ/Producer/SendReceive.cs
+++ b/Source/EasyNetQ/Producer/SendReceive.cs
@@ -101,6 +101,7 @@ namespace EasyNetQ.Producer
         public IDisposable Receive(string queue, Action<IReceiveRegistration> addHandlers, Action<IConsumerConfiguration> configure)
         {
             Preconditions.CheckNotNull(queue, "queue");
+            Preconditions.CheckNotNull(addHandlers, "addHandlers");
             Preconditions.CheckNotNull(configure, "configure");
 
             var declaredQueue = DeclareQueue(queue);

--- a/Source/EasyNetQ/RabbitBus.cs
+++ b/Source/EasyNetQ/RabbitBus.cs
@@ -232,15 +232,32 @@ namespace EasyNetQ
             return sendReceive.Receive(queue, onMessage);
         }
 
+        public virtual IDisposable Receive<T>(string queue, Action<T> onMessage, Action<IConsumerConfiguration> configure)
+            where T : class
+        {
+            return sendReceive.Receive(queue, onMessage, configure);
+        }
+
         public virtual IDisposable Receive<T>(string queue, Func<T, Task> onMessage)
             where T : class
         {
             return sendReceive.Receive(queue, onMessage);
         }
 
+        public virtual IDisposable Receive<T>(string queue, Func<T, Task> onMessage, Action<IConsumerConfiguration> configure)
+            where T : class
+        {
+            return sendReceive.Receive(queue, onMessage, configure);
+        }
+
         public virtual IDisposable Receive(string queue, Action<IReceiveRegistration> addHandlers)
         {
             return sendReceive.Receive(queue, addHandlers);
+        }
+
+        public virtual IDisposable Receive(string queue, Action<IReceiveRegistration> addHandlers, Action<IConsumerConfiguration> configure)
+        {
+            return sendReceive.Receive(queue, addHandlers, configure);
         }
 
         public virtual event Action Connected;

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.43.0.0")]
+[assembly: AssemblyVersion("0.44.0.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.44.0.0 Added Action<IConsumerConfiguration> overloads to Receive() on IBus, ISendReceive, and their implementations
 // 0.43.0.0 Use ILRepack to internally merge Newtonsoft.Json in ManagementClient, default WebRequest.KeepAlive to false to resolve spurious 'the request was aborted: the request was canceled' exceptions
 // 0.42.0.0 Switched from local to UTC datetimes.
 // 0.41.0.0 Dynamic removal 


### PR DESCRIPTION
Adds support to `IBus`, `ISendReceive`, and their implementations for configuring the consumer properties via an `Action<IConsumerConfiguration>()`. This behavior already exists on other calls like `Subscribe()`.

This should allow for setting properties like `PrefetchCount` for `Receive()` consumers.

-----

*Original PR contents*

Opening this PR early to provide some context for discussion. I'm interested in configuring `PrefetchCount` for `Receive`/`Receive<T>` consumers, but there's no method override that supports that. A couple questions here:

1. Is this a reasonable approach?
2. Would you prefer a specific configuration builder over `IConsumerConfiguration` (like `ISubscriptionConfiguration` and `IResponderConfiguration`)?
    - I'm really only concerned about `PrefetchCount`, so it'll probably get the most testing from me. I assume the other properties on `IConsumerConfiguration` will Just Work since it's already supported by `RabbitAdvancedBus.Consume()`, but a specific configuration builder would be an opportunity to isolate this change to `PrefetchCount` if you'd prefer that.
