### PR TITLE
SSL Enabled Cluster Support - Added SSL Options per Host Configuration

### DIFF
--- a/Source/EasyNetQ/ConnectionConfiguration.cs
+++ b/Source/EasyNetQ/ConnectionConfiguration.cs
@@ -128,7 +128,13 @@ namespace EasyNetQ
 
     public class HostConfiguration
     {
+		public HostConfiguration()
+		{
+			Ssl = new SslOption();
+		}
+
         public string Host { get; set; }
         public ushort Port { get; set; }
+		public SslOption Ssl { get; private set; }
     }
 }

--- a/Source/EasyNetQ/ConnectionConfiguration.cs
+++ b/Source/EasyNetQ/ConnectionConfiguration.cs
@@ -128,13 +128,13 @@ namespace EasyNetQ
 
     public class HostConfiguration
     {
-		public HostConfiguration()
-		{
-			Ssl = new SslOption();
-		}
+        public HostConfiguration()
+        {
+            Ssl = new SslOption();
+        }
 
         public string Host { get; set; }
         public ushort Port { get; set; }
-		public SslOption Ssl { get; private set; }
+        public SslOption Ssl { get; private set; }
     }
 }

--- a/Source/EasyNetQ/IConnectionFactory.cs
+++ b/Source/EasyNetQ/IConnectionFactory.cs
@@ -57,8 +57,12 @@ namespace EasyNetQ
                 if (connectionFactory.Port == -1)
                     connectionFactory.Port = hostConfiguration.Port;
 
-                if (Configuration.Ssl.Enabled)
-                    connectionFactory.Ssl = Configuration.Ssl;
+				if (hostConfiguration.Ssl.Enabled)
+					connectionFactory.Ssl = hostConfiguration.Ssl;
+
+				//Prefer SSL configurations per each host but fall back to ConnectionConfiguration's SSL configuration for backwards compatibility
+				else if (Configuration.Ssl.Enabled)
+					connectionFactory.Ssl = Configuration.Ssl;
 
                 connectionFactory.RequestedHeartbeat = Configuration.RequestedHeartbeat;
                 connectionFactory.ClientProperties = Configuration.ClientProperties;

--- a/Source/EasyNetQ/IConnectionFactory.cs
+++ b/Source/EasyNetQ/IConnectionFactory.cs
@@ -57,12 +57,12 @@ namespace EasyNetQ
                 if (connectionFactory.Port == -1)
                     connectionFactory.Port = hostConfiguration.Port;
 
-				if (hostConfiguration.Ssl.Enabled)
-					connectionFactory.Ssl = hostConfiguration.Ssl;
+                if (hostConfiguration.Ssl.Enabled)
+                    connectionFactory.Ssl = hostConfiguration.Ssl;
 
-				//Prefer SSL configurations per each host but fall back to ConnectionConfiguration's SSL configuration for backwards compatibility
-				else if (Configuration.Ssl.Enabled)
-					connectionFactory.Ssl = Configuration.Ssl;
+                //Prefer SSL configurations per each host but fall back to ConnectionConfiguration's SSL configuration for backwards compatibility
+                else if (Configuration.Ssl.Enabled)
+                    connectionFactory.Ssl = Configuration.Ssl;
 
                 connectionFactory.RequestedHeartbeat = Configuration.RequestedHeartbeat;
                 connectionFactory.ClientProperties = Configuration.ClientProperties;

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.44.0.0")]
+[assembly: AssemblyVersion("0.44.1.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.44.1.0 SSL enabled cluster support - Added SSL options per host configuration
 // 0.44.0.0 Added Action<IConsumerConfiguration> overloads to Receive() on IBus, ISendReceive, and their implementations
 // 0.43.1.0 Management Client fix for URI slash escaping in .NET 4.0 with https connection.
 // 0.43.0.0 Use ILRepack to internally merge Newtonsoft.Json in ManagementClient, default WebRequest.KeepAlive to false to resolve spurious 'the request was aborted: the request was canceled' exceptions


### PR DESCRIPTION
Needed distinct SSL options for each host configuration in a clustered
RabbitMQ environment. Before, you could only configure SSL options once
on the ConnectionConfiguration object. When you had multiple hosts
configured and the client attempted to connect to the next node in the
cluster, the connection would fail because the SSL ServerName property
didn't match. Now, you can configure SSL options on each Host object and
cycling the connection through the nodes uses the distinct SSL options.

closes #370