### PR TITLE
When a subscriptionId is null the queue name end with '_'

### DIFF
--- a/Source/EasyNetQ/Conventions.cs
+++ b/Source/EasyNetQ/Conventions.cs
@@ -57,7 +57,10 @@ namespace EasyNetQ
                         if (string.IsNullOrEmpty(attr.QueueName))
                         {
                             var typeName = typeNameSerializer.Serialize(messageType);
-                            return string.Format("{0}_{1}", typeName, subscriptionId);
+
+                            return string.IsNullOrEmpty(subscriptionId)
+                                ? typeName
+                                : string.Format("{0}_{1}", typeName, subscriptionId);
                         }
 
                         return string.IsNullOrEmpty(subscriptionId)

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.44.1.0")]
+[assembly: AssemblyVersion("0.44.2.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.44.2.0 Bug fix, when a subscriptionId is null the queue name end with '_'
 // 0.44.1.0 SSL enabled cluster support - Added SSL options per host configuration
 // 0.44.0.0 Added Action<IConsumerConfiguration> overloads to Receive() on IBus, ISendReceive, and their implementations
 // 0.43.1.0 Management Client fix for URI slash escaping in .NET 4.0 with https connection.


### PR DESCRIPTION
Hello, a simply fix on queue naming convention.