### PR TITLE
issue demonstrating 2 publishes to advanced bus fail

### DIFF
--- a/Source/EasyNetQ.Tests/Integration/AdvancedApiExamples.cs
+++ b/Source/EasyNetQ.Tests/Integration/AdvancedApiExamples.cs
@@ -102,6 +102,7 @@ namespace EasyNetQ.Tests.Integration
 
             var body = Encoding.UTF8.GetBytes("Hello World!");
             advancedBus.Publish(exchange, "routing_key", false, new MessageProperties(), body);
+            advancedBus.Publish(exchange, "routing_key", false, new MessageProperties(), body);
 
             Thread.Sleep(5000);
         }


### PR DESCRIPTION
However, the second 'Publish' will fail, even if a valid exchange is specified:

RabbitMQ.Client.Exceptions.AlreadyClosedException : Already closed: The AMQP operation was interrupted: AMQP close-reason, initiated by Peer, code=404, text="NOT_FOUND - no exchange 'non-existent-exchange' in vhost '/'", classId=60, methodId=40, cause=

I think the expected behaviour should be that the first unit test (PublishToAnExchange) should fail immediately if the exchange doesn't exist, right? 

The current behaviour leads to quite hard-to-track errors. 

https://groups.google.com/forum/#!topic/easynetq/I3jHumFfgh4
