### PR TITLE
Add messageproperties to SubscribeAsync

### DIFF
--- a/Source/EasyNetQ/IBus.cs
+++ b/Source/EasyNetQ/IBus.cs
@@ -137,6 +137,30 @@ namespace EasyNetQ
             where T : class;
 
         /// <summary>
+        /// Subscribes to a stream of messages that match a .NET type.
+        /// </summary>
+        /// <typeparam name="T">The type to subscribe to</typeparam>
+        /// <param name="subscriptionId">
+        /// A unique identifier for the subscription. Two subscriptions with the same subscriptionId
+        /// and type will get messages delivered in turn. This is useful if you want multiple subscribers
+        /// to load balance a subscription in a round-robin fashion.
+        /// </param>
+        /// <param name="onMessage">
+        /// The action to run when a message arrives. onMessage can immediately return a Task and
+        /// then continue processing asynchronously. When the Task completes the message will be
+        /// Ack'd.
+        /// </param>
+        /// <param name="configure">
+        /// Fluent configuration e.g. x => x.WithTopic("uk.london").WithArgument("x-message-ttl", "60")
+        /// </param>
+        /// <returns>
+        /// An <see cref="ISubscriptionResult"/>
+        /// Call Dispose on it or on its <see cref="ISubscriptionResult.ConsumerCancellation"/> to cancel the subscription.
+        /// </returns>
+        ISubscriptionResult SubscribeAsync<T>(string subscriptionId, Func<T, MessageProperties, Task> onMessage, Action<ISubscriptionConfiguration> configure) 
+            where T : class;
+
+        /// <summary>
         /// Makes an RPC style request
         /// </summary>
         /// <typeparam name="TRequest">The request type.</typeparam>


### PR DESCRIPTION
Would be nice to have some of the messageProperties on SubscribeAsync, mainly the CorrelationId for the capability to log using this id for the entirety of the message processing of the long running job.