### PR TITLE
Bug fix publish message on  EasyNetQ_Default_Error_Queue

### DIFF
--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.46.0.0")]
+[assembly: AssemblyVersion("0.46.1.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.46.1.0 Bug fix, when the message broker connection is lost is not possible any more publish a message on queue EasyNetQ_Default_Error_Queue.
 // 0.46.0.0 Implementation of AdvancedBusEventHandlers and events are gone from IBus.
 // 0.45.0.0 IBus Subscription methods now return an ISubscriptionResult and IAdvancedBus exposes IConventions.
 // 0.44.3.0 RabbitHutch.CreateBus overload


### PR DESCRIPTION
hello, it's seem when the message broker connection is lost is not possible any more publish a message on queue EasyNetQ_Default_Error_Queue. I had the problem when the disconnection duration is longer than the heartbit duration, so in this case the ```ShutdownReport```on RabbitMQ.Client is gretar than 0 and the ```IConnection.Dispose``` will throw an exception.