### PR TITLE
Fix RabbitAdvancedBus auto connect

### DIFF
--- a/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
+++ b/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="ConsumeTests\When_a_message_is_received.cs" />
     <Compile Include="ConsumeTests\When_a_polymorphic_message_is_delivered_to_the_consumer.cs" />
     <Compile Include="ConsumeTests\When_consume_is_called.cs" />
+    <Compile Include="Integration\AdvancedBusTests.cs" />
     <Compile Include="MessageFactoryTests.cs" />
     <Compile Include="TimeoutStrategyTest.cs" />
     <Compile Include="DefaultMessageSerializationStrategyTests.cs" />

--- a/Source/EasyNetQ.Tests/Integration/AdvancedBusTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/AdvancedBusTests.cs
@@ -1,0 +1,43 @@
+﻿using System.Text;
+using NUnit.Framework;
+
+namespace EasyNetQ.Tests.Integration
+{
+    [TestFixture]
+    [Explicit("Requires a RabbitMQ instance on localhost to work")]
+    public class AdvancedBusTests
+    {
+        private IBus bus;
+
+        [SetUp]
+        public void SetUp()
+        {
+            bus = RabbitHutch.CreateBus("host=localhost");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            bus.Dispose();
+        }
+
+        [Test]
+        public void Should_be_able_to_declare_exchange_during_first_on_connected_event()
+        {
+            bus.Advanced.ExchangeDeclare("my_test_exchange", "topic", autoDelete: true);
+        }
+
+        [Test]
+        public void Should_be_able_to_declare_queue_during_first_on_connected_event()
+        {
+            bus.Advanced.QueueDeclare("my_test_queue", autoDelete: true);
+        }
+
+        [Test]
+        public void Should_be_able_to_public_message_during_first_on_connected_event()
+        {
+            var exchange = bus.Advanced.ExchangeDeclare("my_test_exchange", "topic", autoDelete: true);
+            bus.Advanced.Publish(exchange, "key", false, false, new MessageProperties(), Encoding.UTF8.GetBytes("Hello world"));
+        }
+    }
+}

--- a/Source/EasyNetQ.Tests/Integration/AdvancedBusTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/AdvancedBusTests.cs
@@ -9,12 +9,6 @@ namespace EasyNetQ.Tests.Integration
     {
         private IBus bus;
 
-        [SetUp]
-        public void SetUp()
-        {
-            bus = RabbitHutch.CreateBus("host=localhost");
-        }
-
         [TearDown]
         public void TearDown()
         {
@@ -24,20 +18,35 @@ namespace EasyNetQ.Tests.Integration
         [Test]
         public void Should_be_able_to_declare_exchange_during_first_on_connected_event()
         {
-            bus.Advanced.ExchangeDeclare("my_test_exchange", "topic", autoDelete: true);
+            var advancedBusEventHandlers = new AdvancedBusEventHandlers(connected: (s, e) =>
+                {
+                    var advancedBus = ((IAdvancedBus)s);
+                    advancedBus.ExchangeDeclare("my_test_exchange", "topic", autoDelete: true);
+                });
+            bus = RabbitHutch.CreateBus("host=localhost", advancedBusEventHandlers);
         }
 
         [Test]
         public void Should_be_able_to_declare_queue_during_first_on_connected_event()
         {
-            bus.Advanced.QueueDeclare("my_test_queue", autoDelete: true);
+            var advancedBusEventHandlers = new AdvancedBusEventHandlers(connected: (s, e) =>
+            {
+                var advancedBus = ((IAdvancedBus)s);
+                advancedBus.QueueDeclare("my_test_queue", autoDelete: true);
+            });
+            bus = RabbitHutch.CreateBus("host=localhost", advancedBusEventHandlers);
         }
 
         [Test]
         public void Should_be_able_to_public_message_during_first_on_connected_event()
         {
-            var exchange = bus.Advanced.ExchangeDeclare("my_test_exchange", "topic", autoDelete: true);
-            bus.Advanced.Publish(exchange, "key", false, false, new MessageProperties(), Encoding.UTF8.GetBytes("Hello world"));
+            var advancedBusEventHandlers = new AdvancedBusEventHandlers(connected: (s, e) =>
+            {
+                var advancedBus = ((IAdvancedBus)s);
+                var exchange = advancedBus.ExchangeDeclare("my_test_exchange", "topic", autoDelete: true);
+                advancedBus.Publish(exchange, "key", false, false, new MessageProperties(), Encoding.UTF8.GetBytes("Hello world"));
+            });
+            bus = RabbitHutch.CreateBus("host=localhost", advancedBusEventHandlers);
         }
     }
 }

--- a/Source/EasyNetQ.Tests/Integration/ClientCommandDispatcherTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/ClientCommandDispatcherTests.cs
@@ -30,8 +30,8 @@ namespace EasyNetQ.Tests.Integration
             var connectionFactory = new ConnectionFactoryWrapper(configuration, hostSelectionStrategy);
             connection = new PersistentConnection(connectionFactory, logger, eventBus);
             var persistentChannelFactory = new PersistentChannelFactory(logger, configuration, eventBus);
-
             dispatcher = new ClientCommandDispatcher(connection, persistentChannelFactory);
+            connection.InitAsync().Wait();
         }
 
         [TearDown]

--- a/Source/EasyNetQ.Tests/Integration/ClientCommandDispatcherTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/ClientCommandDispatcherTests.cs
@@ -31,7 +31,7 @@ namespace EasyNetQ.Tests.Integration
             connection = new PersistentConnection(connectionFactory, logger, eventBus);
             var persistentChannelFactory = new PersistentChannelFactory(logger, configuration, eventBus);
             dispatcher = new ClientCommandDispatcher(connection, persistentChannelFactory);
-            connection.InitAsync().Wait();
+            connection.Initialize();
         }
 
         [TearDown]

--- a/Source/EasyNetQ.Tests/Integration/PersistentChannelTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/PersistentChannelTests.cs
@@ -26,6 +26,7 @@ namespace EasyNetQ.Tests.Integration
             var connectionFactory = new ConnectionFactoryWrapper(configuration, hostSelectionStrategy);
             connection = new PersistentConnection(connectionFactory, logger, eventBus);
             persistentChannel = new PersistentChannel(connection, logger, configuration, new EventBus());
+            connection.InitAsync().Wait();
         }
 
         [TearDown]

--- a/Source/EasyNetQ.Tests/Integration/PersistentChannelTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/PersistentChannelTests.cs
@@ -26,7 +26,7 @@ namespace EasyNetQ.Tests.Integration
             var connectionFactory = new ConnectionFactoryWrapper(configuration, hostSelectionStrategy);
             connection = new PersistentConnection(connectionFactory, logger, eventBus);
             persistentChannel = new PersistentChannel(connection, logger, configuration, new EventBus());
-            connection.InitAsync().Wait();
+            connection.Initialize();
         }
 
         [TearDown]

--- a/Source/EasyNetQ/PersistentConnection.cs
+++ b/Source/EasyNetQ/PersistentConnection.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading;
-using System.Threading.Tasks;
 using EasyNetQ.Events;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
@@ -12,10 +11,10 @@ namespace EasyNetQ
     {
         bool IsConnected { get; }
         /// <summary>
-        /// Initialization method that should be only called once,
+        /// Initialization method that should be called only once,
         /// usually right after the implementation constructor has run.
         /// </summary>
-        Task InitAsync();
+        void Initialize();
         IModel CreateModel();
     }
 
@@ -44,7 +43,7 @@ namespace EasyNetQ
             this.eventBus = eventBus;
         }
 
-        public Task InitAsync()
+        public void Initialize()
         {
             lock (locker)
             {
@@ -53,7 +52,7 @@ namespace EasyNetQ
                     throw new EasyNetQException("This PersistentConnection has already been initialized.");
                 }
                 initialized = true;
-                return Task.Factory.StartNew(() => TryToConnect(null));
+                TryToConnect(null);
             }
         }
 

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -94,8 +94,8 @@ namespace EasyNetQ
             }
 
             connection = new PersistentConnection(connectionFactory, logger, eventBus);
-
             clientCommandDispatcher = clientCommandDispatcherFactory.GetClientCommandDispatcher(connection);
+            connection.InitAsync().Wait();
         }
 
 

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -98,8 +98,7 @@ namespace EasyNetQ
             connection.Initialize();
         }
 
-
-
+        
         // ---------------------------------- consume --------------------------------------
 
         public IDisposable Consume<T>(IQueue queue, Action<IMessage<T>, MessageReceivedInfo> onMessage) where T : class

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -95,7 +95,7 @@ namespace EasyNetQ
 
             connection = new PersistentConnection(connectionFactory, logger, eventBus);
             clientCommandDispatcher = clientCommandDispatcherFactory.GetClientCommandDispatcher(connection);
-            connection.InitAsync().Wait();
+            connection.Initialize();
         }
 
 

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
-// 0.47.0.0 It's now required to call PersistentConnection.InitAsync() to bootstrap a PersistentConnection and make it start attempting to connect.
+// 0.47.0.0 It's now required to call PersistentConnection.Initialize() to bootstrap a PersistentConnection and make it start attempting to connect.
 // 0.46.1.0 Fix NullReferenceException on Serialize
 // 0.46.0.0 Implementation of AdvancedBusEventHandlers and events are gone from IBus.
 // 0.45.0.0 IBus Subscription methods now return an ISubscriptionResult and IAdvancedBus exposes IConventions.

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.46.1.0")]
+[assembly: AssemblyVersion("0.47.0.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.47.0.0 It's now required to call PersistentConnection.InitAsync() to bootstrap a PersistentConnection and make it start attempting to connect.
 // 0.46.1.0 Fix NullReferenceException on Serialize
 // 0.46.0.0 Implementation of AdvancedBusEventHandlers and events are gone from IBus.
 // 0.45.0.0 IBus Subscription methods now return an ISubscriptionResult and IAdvancedBus exposes IConventions.


### PR DESCRIPTION
Fix for #390 

- `PersistentConnection` now has a Initialize method which kicks off the `TryToConnect` loop. Checks have been added to make sure it's called only once per `PersistentConnection`.
- It was required to be able to have all `RabbitAdvancedBus` members correctly initialized before a connection is made. Since it's now possible to handle the first `OnConnected` event, it's also possible to use the bus directly from those event handlers. The `IPersistentConnection` and `IClientCommandDispatcher` in `RabbitAdvancedBus` were still null when the first `OnConnected` event was raised during `IPersistentConnection` instantiation. Thus we needed to make this a two step process to be able to assign members, then start connecting. This is the only place where we're instantiating a `PersistentConnection` so hopefully this shouldn't have any side effects.
- Added a couple integration tests (they're still fairly messy :smiley:) to make sure we can use use the sender of the `OnConnected` event (i.e. The `IAdvancedBus`) within the handler of the first event ([issue](https://github.com/EasyNetQ/EasyNetQ/pull/390#issuecomment-76941141) reported by @paperslice).
- The version was flagged as new minor version, it's technically a breaking change since `PersistentConnection` won't start to connect automatically during instantiation.