### PR TITLE
Message delivery mode and misc

### DIFF
--- a/Source/EasyNetQ/EasyNetQ.csproj
+++ b/Source/EasyNetQ/EasyNetQ.csproj
@@ -67,6 +67,7 @@
     <Compile Include="AutoSubscribe\AutoSubscriberConsumerAttribute.cs" />
     <Compile Include="Consumer\AckStrategies.cs" />
     <Compile Include="Consumer\ConsumerCancellation.cs" />
+    <Compile Include="MessageDeliveryMode.cs" />
     <Compile Include="SubscriptionResult.cs" />
     <Compile Include="Consumer\ConsumerExecutionContext.cs" />
     <Compile Include="Consumer\ConsumerFactory.cs" />

--- a/Source/EasyNetQ/MessageDeliveryMode.cs
+++ b/Source/EasyNetQ/MessageDeliveryMode.cs
@@ -1,8 +1,8 @@
 ﻿namespace EasyNetQ
 {
-    public enum MessageDeliveryMode : byte
+    public static class MessageDeliveryMode
     {
-        NonPersistent = 1,
-        Persistent = 2
+        public const byte NonPersistent = 1;
+        public const byte Persistent = 2;
     }
 }

--- a/Source/EasyNetQ/MessageDeliveryMode.cs
+++ b/Source/EasyNetQ/MessageDeliveryMode.cs
@@ -1,0 +1,8 @@
+﻿namespace EasyNetQ
+{
+    public enum MessageDeliveryMode : byte
+    {
+        NonPersistent = 1,
+        Persistent = 2
+    }
+}

--- a/Source/EasyNetQ/NonGeneric/NonGenericExtensions.cs
+++ b/Source/EasyNetQ/NonGeneric/NonGenericExtensions.cs
@@ -93,7 +93,8 @@ namespace EasyNetQ.NonGeneric
             
             var exchange = publishExchangeDeclareStrategy.DeclareExchange(advancedBus, messageType, ExchangeType.Topic);
             var easyNetQMessage = MessageFactory.CreateInstance(messageType, message);
-            easyNetQMessage.Properties.DeliveryMode = (byte)(messageDeliveryModeStrategy.IsPersistent(messageType) ? 2 : 1);
+            easyNetQMessage.Properties.DeliveryMode = messageDeliveryModeStrategy.IsPersistent(messageType) ? 
+                MessageDeliveryMode.Persistent : MessageDeliveryMode.NonPersistent;
 
             return advancedBus.PublishAsync(exchange, topic, false, false, easyNetQMessage);
         }

--- a/Source/EasyNetQ/Producer/SendReceive.cs
+++ b/Source/EasyNetQ/Producer/SendReceive.cs
@@ -32,9 +32,15 @@ namespace EasyNetQ.Producer
 
             DeclareQueue(queue);
             
-            var wrappedMessage = new Message<T>(message);
-            wrappedMessage.Properties.DeliveryMode = (byte)(messageDeliveryModeStrategy.IsPersistent(typeof(T)) ? 2 : 1);
-            
+            var wrappedMessage = new Message<T>(message)
+            {
+                Properties =
+                {
+                    DeliveryMode = messageDeliveryModeStrategy.IsPersistent(typeof(T)) ? 
+                        MessageDeliveryMode.Persistent : MessageDeliveryMode.NonPersistent
+                }
+            };
+
             advancedBus.Publish(Exchange.GetDefault(), queue, false, false, wrappedMessage);
         }
 
@@ -46,8 +52,14 @@ namespace EasyNetQ.Producer
 
             DeclareQueue(queue);
 
-            var wrappedMessage = new Message<T>(message);
-            wrappedMessage.Properties.DeliveryMode = (byte)(messageDeliveryModeStrategy.IsPersistent(typeof(T)) ? 2 : 1);
+            var wrappedMessage = new Message<T>(message)
+            {
+                Properties =
+                {
+                    DeliveryMode = messageDeliveryModeStrategy.IsPersistent(typeof(T)) ?
+                        MessageDeliveryMode.Persistent : MessageDeliveryMode.NonPersistent
+                }
+            };
 
             return advancedBus.PublishAsync(Exchange.GetDefault(), queue, false, false, wrappedMessage);
         }

--- a/Source/EasyNetQ/RabbitBus.cs
+++ b/Source/EasyNetQ/RabbitBus.cs
@@ -71,7 +71,14 @@ namespace EasyNetQ
             var messageType = typeof (T);
             return publishExchangeDeclareStrategy.DeclareExchangeAsync(advancedBus, messageType, ExchangeType.Topic).Then(exchange =>
                 {
-                    var easyNetQMessage = new Message<T>(message) { Properties = { DeliveryMode = (byte)(messageDeliveryModeStrategy.IsPersistent(messageType) ? 2 : 1) } };
+                    var easyNetQMessage = new Message<T>(message)
+                    {
+                        Properties =
+                        {
+                            DeliveryMode = messageDeliveryModeStrategy.IsPersistent(messageType) ? 
+                                MessageDeliveryMode.Persistent : MessageDeliveryMode.NonPersistent
+                        }
+                    };
                     return advancedBus.PublishAsync(exchange, topic, false, false, easyNetQMessage); 
                 });
         }

--- a/Source/EasyNetQ/Scheduler.cs
+++ b/Source/EasyNetQ/Scheduler.cs
@@ -73,13 +73,21 @@ namespace EasyNetQ
             {
                 var typeName = typeNameSerializer.Serialize(typeof(T));
                 var messageBody = serializer.MessageToBytes(message);
-                var easyNetQMessage = new Message<ScheduleMe>(new ScheduleMe
+                var scheduleMe = new ScheduleMe
                 {
                     WakeTime = futurePublishDate,
                     BindingKey = typeName,
                     CancellationKey = cancellationKey,
                     InnerMessage = messageBody
-                }) { Properties = { DeliveryMode = (byte)(messageDeliveryModeStrategy.IsPersistent(messageType) ? 2 : 1) } };
+                };
+                var easyNetQMessage = new Message<ScheduleMe>(scheduleMe)
+                {
+                    Properties =
+                    {
+                        DeliveryMode = messageDeliveryModeStrategy.IsPersistent(messageType) ? 
+                            MessageDeliveryMode.Persistent : MessageDeliveryMode.NonPersistent
+                    }
+                };
                 return advancedBus.PublishAsync(exchange, conventions.TopicNamingConvention(messageType), false, false, easyNetQMessage);
             });
         }
@@ -102,7 +110,8 @@ namespace EasyNetQ
                                                        {
                                                            Properties =
                                                            {
-                                                               DeliveryMode = (byte)(messageDeliveryModeStrategy.IsPersistent(typeof(T)) ? 2 : 1)
+                                                               DeliveryMode = messageDeliveryModeStrategy.IsPersistent(typeof(T)) ?
+                                                                    MessageDeliveryMode.Persistent : MessageDeliveryMode.NonPersistent
                                                            }
                                                        };
                                                        return advancedBus.PublishAsync(futureExchange, "#", false, false, easyNetQMessage);
@@ -119,10 +128,15 @@ namespace EasyNetQ
             var messageType = typeof(UnscheduleMe);
             return publishExchangeDeclareStrategy.DeclareExchangeAsync(advancedBus, messageType, ExchangeType.Topic).Then(exchange =>
             {
-                var easyNetQMessage = new Message<UnscheduleMe>(new UnscheduleMe
+                var unscheduleMe = new UnscheduleMe { CancellationKey = cancellationKey };
+                var easyNetQMessage = new Message<UnscheduleMe>(unscheduleMe)
                 {
-                    CancellationKey = cancellationKey
-                }) { Properties = { DeliveryMode = (byte)(messageDeliveryModeStrategy.IsPersistent(messageType) ? 2 : 1) } };
+                    Properties =
+                    {
+                        DeliveryMode = messageDeliveryModeStrategy.IsPersistent(messageType) ?
+                            MessageDeliveryMode.Persistent : MessageDeliveryMode.NonPersistent
+                    }
+                };
                 return advancedBus.PublishAsync(exchange, conventions.TopicNamingConvention(messageType), false, false, easyNetQMessage);
             });
         }

--- a/Source/EasyNetQ/Topology/Exchange.cs
+++ b/Source/EasyNetQ/Topology/Exchange.cs
@@ -2,11 +2,13 @@
 {
     public class Exchange : IExchange
     {
+        private static readonly Exchange defaultExchange = new Exchange("");
+
         public string Name { get; private set; }
 
         public static IExchange GetDefault()
         {
-            return new Exchange("");
+            return defaultExchange;
         }
 
         public Exchange(string name)

--- a/Source/EasyNetQ/Topology/ExchangeType.cs
+++ b/Source/EasyNetQ/Topology/ExchangeType.cs
@@ -1,6 +1,6 @@
 ﻿namespace EasyNetQ.Topology
 {
-    public class ExchangeType
+    public static class ExchangeType
     {
         public const string Direct = "direct";
         public const string Topic = "topic";

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.47.2.0")]
+[assembly: AssemblyVersion("0.47.3.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.47.3.0 Using MessageDeliveryMode instead of hardcoded 1/2 and Exchange/ExchangeType update.
 // 0.47.2.0 Logging is disabled by default.
 // 0.47.1.0 Bug fix, when the message broker connection is lost is not possible any more publish a message on queue EasyNetQ_Default_Error_Queue.
 // 0.47.0.0 It's now required to call PersistentConnection.Initialize() to bootstrap a PersistentConnection and make it start attempting to connect.


### PR DESCRIPTION
- We now have a static class `MessageDeliveryMode` with constants to be used when setting `MessageProperties.DeliveryMode`, instead of hard coding 1 and 2 in multiple places for non-persistent and persistent mode. That was bugging me for a while but never got around changing it. :stuck_out_tongue:
- `ExchangeType` is the same kind of constant container and should never be instantiated, it's now static to enforce that.
- The default exchange returned by `Exchange.GetDefault` is now a static readonly member, so we won't be instantiated a new empty exchange on each call.