### PR TITLE
Rpc silent fail fix

### DIFF
--- a/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
+++ b/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
@@ -102,6 +102,7 @@
     <Compile Include="ConsumeTests\When_a_polymorphic_message_is_delivered_to_the_consumer.cs" />
     <Compile Include="ConsumeTests\When_consume_is_called.cs" />
     <Compile Include="Integration\AdvancedBusTests.cs" />
+    <Compile Include="Integration\RpcTests.cs" />
     <Compile Include="MessageFactoryTests.cs" />
     <Compile Include="PersistentChannelTests\When_a_ConnectionCreatedEvent_is_published.cs" />
     <Compile Include="TimeoutStrategyTest.cs" />

--- a/Source/EasyNetQ.Tests/Integration/RpcTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/RpcTests.cs
@@ -1,0 +1,72 @@
+﻿using System.Threading;
+using EasyNetQ.Loggers;
+using EasyNetQ.Tests.ProducerTests.Very.Long.Namespace.Certainly.Longer.Than.The255.Char.Length.That.RabbitMQ.Likes.That.Will.Certainly.Cause.An.AMQP.Exception.If.We.Dont.Do.Something.About.It.And.Stop.It.From.Happening;
+using NUnit.Framework;
+
+namespace EasyNetQ.Tests.Integration
+{
+    [TestFixture, Explicit("Requires a RabbitMQ instance on localhost")]
+    public class RpcTests
+    {
+        private class RpcRequest
+        {
+            public int Value { get; set; }
+        }
+
+        private class RpcResponse
+        {
+            public int Value { get; set; }
+        }
+
+        private IBus bus;
+
+        [SetUp]
+        public void SetUp()
+        {
+            bus = RabbitHutch.CreateBus("host=localhost", x => x.Register<IEasyNetQLogger>(_ => new ConsoleLogger()));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            bus.Dispose();
+        }
+
+        [Test]
+        public void Should_be_able_to_publish_and_receive_response()
+        {
+            bus.Respond<RpcRequest, RpcResponse>(req => new RpcResponse { Value = req.Value });
+            var request = new RpcRequest { Value = 5 };
+            var response = bus.Request<RpcRequest, RpcResponse>(request);
+
+            Assert.IsNotNull(response);
+            Assert.IsTrue(request.Value == response.Value);
+        }
+
+        [Test]
+        [ExpectedException(typeof(EasyNetQException))]
+        public void Should_throw_when_requesting_over_long_message()
+        {
+            bus.Respond<MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes, RpcRequest>(
+                req => new RpcRequest());
+
+            bus.Request<MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes, RpcRequest>(
+                new MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes());
+
+            Thread.Sleep(2000);
+        }
+
+        [Test]
+        [ExpectedException(typeof(EasyNetQException))]
+        public void Should_throw_when_responding_to_over_long_message()
+        {
+            bus.Respond<RpcRequest, MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes>(
+                req => new MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes());
+
+            bus.Request<RpcRequest, MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes>(
+                new RpcRequest());
+
+            Thread.Sleep(2000);
+        }
+    }
+}

--- a/Source/EasyNetQ/Producer/Rpc.cs
+++ b/Source/EasyNetQ/Producer/Rpc.cs
@@ -14,20 +14,21 @@ namespace EasyNetQ.Producer
     public class Rpc : IRpc
     {
         private readonly ConnectionConfiguration connectionConfiguration;
-        protected readonly IAdvancedBus advancedBus;
-        protected readonly IConventions conventions;
-        protected readonly IPublishExchangeDeclareStrategy publishExchangeDeclareStrategy;
-        protected readonly IMessageDeliveryModeStrategy messageDeliveryModeStrategy;
+        private readonly IAdvancedBus advancedBus;
+        private readonly IConventions conventions;
+        private readonly IPublishExchangeDeclareStrategy publishExchangeDeclareStrategy;
+        private readonly IMessageDeliveryModeStrategy messageDeliveryModeStrategy;
         private readonly ITimeoutStrategy timeoutStrategy;
+        private readonly ITypeNameSerializer typeNameSerializer;
 
         private readonly object responseQueuesAddLock = new object();
         private readonly ConcurrentDictionary<RpcKey, string> responseQueues = new ConcurrentDictionary<RpcKey, string>();
         private readonly ConcurrentDictionary<string, ResponseAction> responseActions = new ConcurrentDictionary<string, ResponseAction>();
 
-        protected readonly TimeSpan disablePeriodicSignaling = TimeSpan.FromMilliseconds(-1);
+        private readonly TimeSpan disablePeriodicSignaling = TimeSpan.FromMilliseconds(-1);
 
-        protected const string IsFaultedKey = "IsFaulted";
-        protected const string ExceptionMessageKey = "ExceptionMessage";
+        private const string isFaultedKey = "IsFaulted";
+        private const string exceptionMessageKey = "ExceptionMessage";
 
         public Rpc(
             ConnectionConfiguration connectionConfiguration,
@@ -36,7 +37,8 @@ namespace EasyNetQ.Producer
             IConventions conventions,
             IPublishExchangeDeclareStrategy publishExchangeDeclareStrategy,
             IMessageDeliveryModeStrategy messageDeliveryModeStrategy,
-            ITimeoutStrategy timeoutStrategy)
+            ITimeoutStrategy timeoutStrategy,
+            ITypeNameSerializer typeNameSerializer)
         {
             Preconditions.CheckNotNull(connectionConfiguration, "configuration");
             Preconditions.CheckNotNull(advancedBus, "advancedBus");
@@ -45,6 +47,7 @@ namespace EasyNetQ.Producer
             Preconditions.CheckNotNull(publishExchangeDeclareStrategy, "publishExchangeDeclareStrategy");
             Preconditions.CheckNotNull(messageDeliveryModeStrategy, "messageDeliveryModeStrategy");
             Preconditions.CheckNotNull(timeoutStrategy, "timeoutStrategy");
+            Preconditions.CheckNotNull(typeNameSerializer, "typeNameSerializer");
 
             this.connectionConfiguration = connectionConfiguration;
             this.advancedBus = advancedBus;
@@ -52,6 +55,7 @@ namespace EasyNetQ.Producer
             this.publishExchangeDeclareStrategy = publishExchangeDeclareStrategy;
             this.messageDeliveryModeStrategy = messageDeliveryModeStrategy;
             this.timeoutStrategy = timeoutStrategy;
+            this.typeNameSerializer = typeNameSerializer;
 
             eventBus.Subscribe<ConnectionCreatedEvent>(OnConnectionCreated);
         }
@@ -112,13 +116,13 @@ namespace EasyNetQ.Producer
                     string exceptionMessage = "The exception message has not been specified.";
                     if(msg.Properties.HeadersPresent)
                     {
-                        if(msg.Properties.Headers.ContainsKey(IsFaultedKey))
+                        if(msg.Properties.Headers.ContainsKey(isFaultedKey))
                         {
-                            isFaulted = Convert.ToBoolean(msg.Properties.Headers[IsFaultedKey]);
+                            isFaulted = Convert.ToBoolean(msg.Properties.Headers[isFaultedKey]);
                         }
-                        if(msg.Properties.Headers.ContainsKey(ExceptionMessageKey))
+                        if(msg.Properties.Headers.ContainsKey(exceptionMessageKey))
                         {
-                            exceptionMessage = Encoding.UTF8.GetString((byte[])msg.Properties.Headers[ExceptionMessageKey]);
+                            exceptionMessage = Encoding.UTF8.GetString((byte[])msg.Properties.Headers[exceptionMessageKey]);
                         }
                     }
 
@@ -213,6 +217,10 @@ namespace EasyNetQ.Producer
         {
             Preconditions.CheckNotNull(responder, "responder");
             Preconditions.CheckNotNull(configure, "configure");
+            // We're explicitely validating TResponse here because the type won't be used directly.
+            // It'll only be used when executing a successful responder, which will silently fail if TResponse serialized length exceeds the limit.
+            Preconditions.CheckShortString(typeNameSerializer.Serialize(typeof(TResponse)), "TResponse");
+
             var configuration = new ResponderConfiguration(connectionConfiguration.PrefetchCount);
             configure(configuration);
 
@@ -282,8 +290,8 @@ namespace EasyNetQ.Producer
         {
             var body = ReflectionHelpers.CreateInstance<TResponse>();
             var responseMessage = new Message<TResponse>(body);
-            responseMessage.Properties.Headers.Add(IsFaultedKey, true);
-            responseMessage.Properties.Headers.Add(ExceptionMessageKey, exceptionMessage);
+            responseMessage.Properties.Headers.Add(isFaultedKey, true);
+            responseMessage.Properties.Headers.Add(exceptionMessageKey, exceptionMessage);
             responseMessage.Properties.CorrelationId = requestMessage.Properties.CorrelationId;
             responseMessage.Properties.DeliveryMode = MessageDeliveryMode.NonPersistent;
 

--- a/Source/EasyNetQ/Producer/Rpc.cs
+++ b/Source/EasyNetQ/Producer/Rpc.cs
@@ -14,10 +14,10 @@ namespace EasyNetQ.Producer
     public class Rpc : IRpc
     {
         private readonly ConnectionConfiguration connectionConfiguration;
-        private readonly IAdvancedBus advancedBus;
-        private readonly IConventions conventions;
-        private readonly IPublishExchangeDeclareStrategy publishExchangeDeclareStrategy;
-        private readonly IMessageDeliveryModeStrategy messageDeliveryModeStrategy;
+        protected readonly IAdvancedBus advancedBus;
+        protected readonly IConventions conventions;
+        protected readonly IPublishExchangeDeclareStrategy publishExchangeDeclareStrategy;
+        protected readonly IMessageDeliveryModeStrategy messageDeliveryModeStrategy;
         private readonly ITimeoutStrategy timeoutStrategy;
         private readonly ITypeNameSerializer typeNameSerializer;
 
@@ -25,10 +25,10 @@ namespace EasyNetQ.Producer
         private readonly ConcurrentDictionary<RpcKey, string> responseQueues = new ConcurrentDictionary<RpcKey, string>();
         private readonly ConcurrentDictionary<string, ResponseAction> responseActions = new ConcurrentDictionary<string, ResponseAction>();
 
-        private readonly TimeSpan disablePeriodicSignaling = TimeSpan.FromMilliseconds(-1);
+        protected readonly TimeSpan disablePeriodicSignaling = TimeSpan.FromMilliseconds(-1);
 
-        private const string isFaultedKey = "IsFaulted";
-        private const string exceptionMessageKey = "ExceptionMessage";
+        protected const string isFaultedKey = "IsFaulted";
+        protected const string exceptionMessageKey = "ExceptionMessage";
 
         public Rpc(
             ConnectionConfiguration connectionConfiguration,

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.47.7.0")]
+[assembly: AssemblyVersion("0.47.8.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.47.8.0 Rpc.Respond will validate serialized length of TResponse upon method call to prevent silent exception when executing responder.
 // 0.47.7.0 Validating ConnectionConfiguration in lowest level method of RabbitHutch.
 // 0.47.6.0 AtLeastOneWithDefault -> DefaultIfEmpty
 // 0.47.5.0 PersistentChannel update preventing race condition following PersistentConnection quick connection/disconnection.


### PR DESCRIPTION
#406 

We're now validating the the length of TReponse in `Rpc.Respond`. Note that the `Preconditions.CheckShortString` will actually never be hit because we'll be throwing in `TypeNameSerializer.Serialize` before.

I'll update the version number when #401 will be merged so I don't have to update it multiple times.