### PR TITLE
typenameserializer uses ConcurrentDictionary

### DIFF
--- a/Source/EasyNetQ/TypeNameSerializer.cs
+++ b/Source/EasyNetQ/TypeNameSerializer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 
 namespace EasyNetQ
 {
@@ -10,37 +11,44 @@ namespace EasyNetQ
 
     public class TypeNameSerializer : ITypeNameSerializer
     {
+        private readonly ConcurrentDictionary<string, Type> deserializedTypes = new ConcurrentDictionary<string, Type>();
+
         public Type DeSerialize(string typeName)
         {
             Preconditions.CheckNotBlank(typeName, "typeName");
-            var nameParts = typeName.Split(':');
-            if (nameParts.Length != 2)
+
+            return deserializedTypes.GetOrAdd(typeName, t =>
             {
-                throw new EasyNetQException(
-                    "type name {0}, is not a valid EasyNetQ type name. Expected Type:Assembly", 
-                    typeName);
-            }
-            var type = Type.GetType(nameParts[0] + ", " + nameParts[1]);
-            if (type == null)
-            {
-                throw new EasyNetQException(
-                    "Cannot find type {0}",
-                    typeName);
-            }
-            return type;
+                var nameParts = t.Split(':');
+                if (nameParts.Length != 2)
+                {
+                    throw new EasyNetQException("type name {0}, is not a valid EasyNetQ type name. Expected Type:Assembly", t);
+                }
+                var type = Type.GetType(nameParts[0] + ", " + nameParts[1]);
+                if (type == null)
+                {
+                    throw new EasyNetQException("Cannot find type {0}", t);
+                }
+                return type;
+            });
         }
+
+        private readonly ConcurrentDictionary<Type, string> serializedTypes = new ConcurrentDictionary<Type, string>();
 
         public string Serialize(Type type)
         {
             Preconditions.CheckNotNull(type, "type");
-            var typeName = type.FullName + ":" + type.Assembly.GetName().Name;
-            if (typeName.Length > 255)
+
+            return serializedTypes.GetOrAdd(type, t =>
             {
-                throw new EasyNetQException("The serialized name of type '{0}' exceeds the AMQP " + 
-                    "maximum short string length of 255 characters.",
-                    type.Name);
-            }
-            return typeName;
+                var typeName = t.FullName + ":" + t.Assembly.GetName().Name;
+                if (typeName.Length > 255)
+                {
+                    throw new EasyNetQException("The serialized name of type '{0}' exceeds the AMQP " +
+                                                "maximum short string length of 255 characters.", t.Name);
+                }
+                return typeName;
+            });
         }
     }
 }

--- a/Source/EasyNetQ/TypeNameSerializer.cs
+++ b/Source/EasyNetQ/TypeNameSerializer.cs
@@ -9,6 +9,7 @@ namespace EasyNetQ
         Type DeSerialize(string typeName);
     }
 
+	
     public class TypeNameSerializer : ITypeNameSerializer
     {
         private readonly ConcurrentDictionary<string, Type> deserializedTypes = new ConcurrentDictionary<string, Type>();

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.47.8.0")]
+[assembly: AssemblyVersion("0.47.9.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.47.9.0 TypeNameSerializer now uses a ConcurrentDictionary to store se/deserialization results.
 // 0.47.8.0 Rpc.Respond will validate serialized length of TResponse upon method call to prevent silent exception when executing responder.
 // 0.47.7.0 Validating ConnectionConfiguration in lowest level method of RabbitHutch.
 // 0.47.6.0 AtLeastOneWithDefault -> DefaultIfEmpty


### PR DESCRIPTION
Hey guys,

This is a proposal for the default `TypeNameSerializer` to store the result of its calls in ConcurrentDictionaries. The purpose is to improve the overall performance of the library by paying a small (unless you're using thousands of different types, which seems unlikely) price in terms of memory footprint.

Comparison for 100000 calls using a 3.2GHz i7:

 | Serialize | Deserialize
------------ | ------------- | -------------
**Current implementation** | 138 ms | 501 ms
**Updated implementation** | 20 ms | 28 ms
**Change** | 79.7% decrease | 94.5% decrease

Nothing groundbreaking but I think that's nice to have. Feel free to tell me if you think we should keep the current implementation available and offer this one as opt in.

Will update version following your feedback and when other more important PRs will have been merged.