### PR TITLE
Priority queue support

### DIFF
--- a/Source/EasyNetQ.Tests/ExchangeQueueBindingTests.cs
+++ b/Source/EasyNetQ.Tests/ExchangeQueueBindingTests.cs
@@ -28,7 +28,8 @@ namespace EasyNetQ.Tests
                 exclusive: true,
                 autoDelete: true,
                 perQueueMessageTtl: 1000,
-                expires: 2000);
+                expires: 2000,
+                maxPriority: 10);
         }
 
         [Test]
@@ -49,7 +50,8 @@ namespace EasyNetQ.Tests
                     Arg<bool>.Is.Equal(true),
                     Arg<IDictionary<string, object>>.Matches(args => 
                         ((int)args["x-message-ttl"] == 1000) &&
-                        ((int)args["x-expires"] == 2000))));
+                        ((int)args["x-expires"] == 2000) &&
+                        ((byte)args["x-max-priority"] == 10))));
         }
     }
 

--- a/Source/EasyNetQ.Tests/ExchangeQueueBindingTests.cs
+++ b/Source/EasyNetQ.Tests/ExchangeQueueBindingTests.cs
@@ -27,7 +27,7 @@ namespace EasyNetQ.Tests
                 durable: false, 
                 exclusive: true,
                 autoDelete: true,
-                perQueueTtl: 1000,
+                perQueueMessageTtl: 1000,
                 expires: 2000);
         }
 

--- a/Source/EasyNetQ.Tests/Integration/AdvancedApiExamples.cs
+++ b/Source/EasyNetQ.Tests/Integration/AdvancedApiExamples.cs
@@ -47,7 +47,7 @@ namespace EasyNetQ.Tests.Integration
         [Test, Explicit]
         public void DeclareWithTtlAndExpire()
         {
-            advancedBus.QueueDeclare("my_queue", perQueueTtl: 500, expires: 500);
+            advancedBus.QueueDeclare("my_queue", perQueueMessageTtl: 500, expires: 500);
         }
 
         [Test, Explicit]

--- a/Source/EasyNetQ/IAdvancedBus.cs
+++ b/Source/EasyNetQ/IAdvancedBus.cs
@@ -295,8 +295,7 @@ namespace EasyNetQ
 
         /// <summary>
         /// Declare a transient server named queue. Note, this queue will only last for duration of the
-        /// connection. If there is a connection outage, EasyNetQ will not attempt to recreate
-        /// consumers.
+        /// connection. If there is a connection outage, EasyNetQ will not attempt to recreate consumers.
         /// </summary>
         /// <returns>The queue</returns>
         IQueue QueueDeclare();
@@ -310,7 +309,7 @@ namespace EasyNetQ
         void QueueDelete(IQueue queue, bool ifUnused = false, bool ifEmpty = false);
 
         /// <summary>
-        /// Purget a queue
+        /// Purge a queue
         /// </summary>
         /// <param name="queue">The queue to purge</param>
         void QueuePurge(IQueue queue);
@@ -323,13 +322,18 @@ namespace EasyNetQ
         /// <param name="passive">Throw an exception rather than create the exchange if it doens't exist</param>
         /// <param name="durable">Durable exchanges remain active when a server restarts.</param>
         /// <param name="autoDelete">If set, the exchange is deleted when all queues have finished using it.</param>
-        /// <param name="internal">If set, the exchange may not be used directly by publishers, 
-        ///     but only when bound to other exchanges.</param>
+        /// <param name="internal">If set, the exchange may not be used directly by publishers, but only when bound to other exchanges.</param>
         /// <param name="alternateExchange">Route messages to this exchange if they cannot be routed.</param>
         /// <returns>The exchange</returns>
-        IExchange ExchangeDeclare(string name, string type, bool passive = false, bool durable = true, bool autoDelete = false, bool @internal = false, string alternateExchange = null);
-
-
+        IExchange ExchangeDeclare(
+            string name, 
+            string type, 
+            bool passive = false, 
+            bool durable = true, 
+            bool autoDelete = false, 
+            bool @internal = false, 
+            string alternateExchange = null);
+        
         /// <summary>
         /// Declare an exchange
         /// </summary>
@@ -338,11 +342,17 @@ namespace EasyNetQ
         /// <param name="passive">Throw an exception rather than create the exchange if it doens't exist</param>
         /// <param name="durable">Durable exchanges remain active when a server restarts.</param>
         /// <param name="autoDelete">If set, the exchange is deleted when all queues have finished using it.</param>
-        /// <param name="internal">If set, the exchange may not be used directly by publishers, 
-        ///     but only when bound to other exchanges.</param>
+        /// <param name="internal">If set, the exchange may not be used directly by publishers, but only when bound to other exchanges.</param>
         /// <param name="alternateExchange">Route messages to this exchange if they cannot be routed.</param>
         /// <returns>The exchange</returns>
-        Task<IExchange> ExchangeDeclareAsync(string name, string type, bool passive = false, bool durable = true, bool autoDelete = false, bool @internal = false, string alternateExchange = null);
+        Task<IExchange> ExchangeDeclareAsync(
+            string name, 
+            string type, 
+            bool passive = false, 
+            bool durable = true, 
+            bool autoDelete = false, 
+            bool @internal = false, 
+            string alternateExchange = null);
 
         /// <summary>
         /// Delete an exchange

--- a/Source/EasyNetQ/IAdvancedBus.cs
+++ b/Source/EasyNetQ/IAdvancedBus.cs
@@ -241,17 +241,28 @@ namespace EasyNetQ
         /// <param name="name">The name of the queue</param>
         /// <param name="passive">Throw an exception rather than create the queue if it doesn't exist</param>
         /// <param name="durable">Durable queues remain active when a server restarts.</param>
-        /// <param name="exclusive">Exclusive queues may only be accessed by the current connection, 
-        ///     and are deleted when that connection closes.</param>
+        /// <param name="exclusive">Exclusive queues may only be accessed by the current connection, and are deleted when that connection closes.</param>
         /// <param name="autoDelete">If set, the queue is deleted when all consumers have finished using it.</param>
-        /// <param name="perQueueTtl">How long a message published to a queue can live before it is discarded by the server.</param>
+        /// <param name="perQueueMessageTtl">How long a message published to a queue can live before it is discarded by the server.</param>
         /// <param name="expires">Determines how long a queue can remain unused before it is automatically deleted by the server.</param>
-        /// <param name="deadLetterExchange">Determines an exchange's name can remain unused before it is automatically deleted by the server.</param>
-        /// <param name="deadLetterRoutingKey">If set, will route message with the routing key specified, if not set, message will be routed with the same routing keys they were originally published with.</param>
-        /// <returns>
-        /// The queue
-        /// </returns>
-        IQueue QueueDeclare(string name, bool passive = false, bool durable = true, bool exclusive = false, bool autoDelete = false, int perQueueTtl = int.MaxValue, int expires = int.MaxValue, string deadLetterExchange = null, string deadLetterRoutingKey = null);
+        /// <param name="maxPriority">Determines the maximum message priority that the queue should support.</param>
+        /// <param name="deadLetterExchange">The exchange to publish dead-lettered messages to.</param>
+        /// <param name="deadLetterRoutingKey">
+        /// If set, dead-lettered messages will published to their dead letter exchange using the specified routing key. 
+        /// If not set, dead-lettered messages will be published to their dead letter exchange using the same routing key they were originally published with.
+        /// </param>
+        /// <returns>The queue</returns>
+        IQueue QueueDeclare(
+            string name, 
+            bool passive = false, 
+            bool durable = true, 
+            bool exclusive = false, 
+            bool autoDelete = false,
+            int? perQueueMessageTtl = null,
+            int? expires = null,
+            byte? maxPriority = null,
+            string deadLetterExchange = null, 
+            string deadLetterRoutingKey = null);
 
         /// <summary>
         /// Declare a queue. If the queue already exists this method does nothing
@@ -259,16 +270,28 @@ namespace EasyNetQ
         /// <param name="name">The name of the queue</param>
         /// <param name="passive">Throw an exception rather than create the queue if it doesn't exist</param>
         /// <param name="durable">Durable queues remain active when a server restarts.</param>
-        /// <param name="exclusive">Exclusive queues may only be accessed by the current connection, 
-        ///     and are deleted when that connection closes.</param>
+        /// <param name="exclusive">Exclusive queues may only be accessed by the current connection, and are deleted when that connection closes.</param>
         /// <param name="autoDelete">If set, the queue is deleted when all consumers have finished using it.</param>
-        /// <param name="perQueueTtl">How long a message published to a queue can live before it is discarded by the server.</param>
+        /// <param name="perQueueMessageTtl">How long a message published to a queue can live before it is discarded by the server.</param>
         /// <param name="expires">Determines how long a queue can remain unused before it is automatically deleted by the server.</param>
-        /// <param name="deadLetterExchange">Determines an exchange's name can remain unused before it is automatically deleted by the server.</param>
-        /// <param name="deadLetterRoutingKey">If set, will route message with the routing key specified, if not set, message will be routed with the same routing keys they were originally published with.</param>
+        /// <param name="maxPriority">Determines the maximum message priority that the queue should support.</param>
+        /// <param name="deadLetterExchange">The exchange to publish dead-lettered messages to.</param>
+        /// <param name="deadLetterRoutingKey">
+        /// If set, dead-lettered messages will published to their dead letter exchange using the specified routing key. 
+        /// If not set, dead-lettered messages will be published to their dead letter exchange using the same routing key they were originally published with.
+        /// </param>
         /// <returns>The queue</returns>
-        Task<IQueue> QueueDeclareAsync(string name, bool passive = false, bool durable = true, bool exclusive = false, bool autoDelete = false, int perQueueTtl = int.MaxValue, int expires = int.MaxValue, string deadLetterExchange = null, string deadLetterRoutingKey = null);
-
+        Task<IQueue> QueueDeclareAsync(
+            string name, 
+            bool passive = false, 
+            bool durable = true, 
+            bool exclusive = false, 
+            bool autoDelete = false,
+            int? perQueueMessageTtl = null,
+            int? expires = null,
+            byte? maxPriority = null,
+            string deadLetterExchange = null, 
+            string deadLetterRoutingKey = null);
 
         /// <summary>
         /// Declare a transient server named queue. Note, this queue will only last for duration of the

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -312,13 +312,13 @@ namespace EasyNetQ
             }
 
             var arguments = new Dictionary<string, object>();
-            if (perQueueMessageTtl != int.MaxValue)
+            if (perQueueMessageTtl.HasValue)
             {
-                arguments.Add("x-message-ttl", perQueueMessageTtl);
+                arguments.Add("x-message-ttl", perQueueMessageTtl.Value);
             }
-            if (expires != int.MaxValue)
+            if (expires.HasValue)
             {
-                arguments.Add("x-expires", expires);
+                arguments.Add("x-expires", expires.Value);
             }
             if (maxPriority.HasValue)
             {

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using EasyNetQ.Consumer;
@@ -179,35 +180,6 @@ namespace EasyNetQ
 
         // -------------------------------- publish ---------------------------------------------
 
-        public virtual Task PublishAsync(
-            IExchange exchange,
-            string routingKey,
-            bool mandatory,
-            bool immediate,
-            MessageProperties messageProperties,
-            byte[] body)
-        {
-            Preconditions.CheckNotNull(exchange, "exchange");
-            Preconditions.CheckShortString(routingKey, "routingKey");
-            Preconditions.CheckNotNull(messageProperties, "messageProperties");
-            Preconditions.CheckNotNull(body, "body");
-
-            var rawMessage = produceConsumeInterceptor.OnProduce(new RawMessage(messageProperties, body));
-
-            return clientCommandDispatcher.Invoke(x =>
-                {
-                    var properties = x.CreateBasicProperties();
-                    rawMessage.Properties.CopyTo(properties);
-
-                    return publisher.Publish(x, m => m.BasicPublish(exchange.Name, routingKey, mandatory, immediate, properties, rawMessage.Body))
-                                    .Then(() =>
-                                        {
-                                            eventBus.Publish(new PublishedMessageEvent(exchange.Name, routingKey, rawMessage.Properties, rawMessage.Body));
-                                            logger.DebugWrite("Published to exchange: '{0}', routing key: '{1}', correlationId: '{2}'", exchange.Name, routingKey, messageProperties.CorrelationId);
-                                        });
-                }).Unwrap();
-        }
-
         public virtual Task PublishAsync<T>(
             IExchange exchange,
             string routingKey,
@@ -238,8 +210,13 @@ namespace EasyNetQ
             return PublishAsync(exchange, routingKey, mandatory, immediate, serializedMessage.Properties, serializedMessage.Body);
         }
 
-        public void Publish(IExchange exchange, string routingKey, bool mandatory, bool immediate,
-                                 MessageProperties messageProperties, byte[] body)
+        public void Publish(
+            IExchange exchange, 
+            string routingKey, 
+            bool mandatory, 
+            bool immediate,
+            MessageProperties messageProperties, 
+            byte[] body)
         {
             try
             {
@@ -251,7 +228,12 @@ namespace EasyNetQ
             }
         }
 
-        public void Publish<T>(IExchange exchange, string routingKey, bool mandatory, bool immediate, IMessage<T> message) where T : class
+        public void Publish<T>(
+            IExchange exchange, 
+            string routingKey, 
+            bool mandatory, 
+            bool immediate, 
+            IMessage<T> message) where T : class
         {
             try
             {
@@ -263,6 +245,35 @@ namespace EasyNetQ
             }
         }
 
+        public virtual Task PublishAsync(
+            IExchange exchange,
+            string routingKey,
+            bool mandatory,
+            bool immediate,
+            MessageProperties messageProperties,
+            byte[] body)
+        {
+            Preconditions.CheckNotNull(exchange, "exchange");
+            Preconditions.CheckShortString(routingKey, "routingKey");
+            Preconditions.CheckNotNull(messageProperties, "messageProperties");
+            Preconditions.CheckNotNull(body, "body");
+
+            var rawMessage = produceConsumeInterceptor.OnProduce(new RawMessage(messageProperties, body));
+
+            return clientCommandDispatcher.Invoke(x =>
+            {
+                var properties = x.CreateBasicProperties();
+                rawMessage.Properties.CopyTo(properties);
+
+                return publisher.Publish(x, m => m.BasicPublish(exchange.Name, routingKey, mandatory, immediate, properties, rawMessage.Body))
+                                .Then(() =>
+                                {
+                                    eventBus.Publish(new PublishedMessageEvent(exchange.Name, routingKey, rawMessage.Properties, rawMessage.Body));
+                                    logger.DebugWrite("Published to exchange: '{0}', routing key: '{1}', correlationId: '{2}'", exchange.Name, routingKey, messageProperties.CorrelationId);
+                                });
+            }).Unwrap();
+        }
+
         // ---------------------------------- Exchange / Queue / Binding -----------------------------------
 
         public virtual IQueue QueueDeclare(
@@ -271,33 +282,47 @@ namespace EasyNetQ
             bool durable = true,
             bool exclusive = false,
             bool autoDelete = false,
-            int perQueueTtl = int.MaxValue,
-            int expires = int.MaxValue,
+            int? perQueueMessageTtl = null,
+            int? expires = null,
+            byte? maxPriority = null,
             string deadLetterExchange = null,
             string deadLetterRoutingKey = null)
         {
-            return QueueDeclareAsync(name, passive, durable, exclusive, autoDelete, perQueueTtl, expires, deadLetterExchange, deadLetterRoutingKey).Result;
+            return QueueDeclareAsync(name, passive, durable, exclusive, autoDelete, perQueueMessageTtl, expires, maxPriority, deadLetterExchange, deadLetterRoutingKey).Result;
         }
 
-        public Task<IQueue> QueueDeclareAsync(string name, bool passive = false, bool durable = true, bool exclusive = false, bool autoDelete = false, int perQueueTtl = Int32.MaxValue, int expires = Int32.MaxValue, string deadLetterExchange = null, string deadLetterRoutingKey = null)
+        public Task<IQueue> QueueDeclareAsync(
+            string name, 
+            bool passive = false, 
+            bool durable = true, 
+            bool exclusive = false, 
+            bool autoDelete = false, 
+            int? perQueueMessageTtl = null, 
+            int? expires = null,
+            byte? maxPriority = null,
+            string deadLetterExchange = null, 
+            string deadLetterRoutingKey = null)
         {
             Preconditions.CheckNotNull(name, "name");
 
             if (passive)
             {
                 return clientCommandDispatcher.Invoke(x => x.QueueDeclarePassive(name))
-                    .Then(() => (IQueue) new Queue(name, exclusive));
-            }
-            IDictionary<string, object> arguments = new Dictionary<string, object>();
-            
-            if (perQueueTtl != int.MaxValue)
-            {
-                arguments.Add("x-message-ttl", perQueueTtl);
+                    .Then(() => (IQueue)new Queue(name, exclusive));
             }
 
+            var arguments = new Dictionary<string, object>();
+            if (perQueueMessageTtl != int.MaxValue)
+            {
+                arguments.Add("x-message-ttl", perQueueMessageTtl);
+            }
             if (expires != int.MaxValue)
             {
                 arguments.Add("x-expires", expires);
+            }
+            if (maxPriority.HasValue)
+            {
+                arguments.Add("x-max-priority", maxPriority.Value);
             }
             if (!string.IsNullOrEmpty(deadLetterExchange))
             {
@@ -311,29 +336,10 @@ namespace EasyNetQ
             return clientCommandDispatcher.Invoke(x => x.QueueDeclare(name, durable, exclusive, autoDelete, arguments)).Then(() =>
             {
                 logger.DebugWrite("Declared Queue: '{0}' durable:{1}, exclusive:{2}, autoDelete:{3}, args:{4}",
-                    name, durable, exclusive, autoDelete, WriteArguments(arguments));
+                    name, durable, exclusive, autoDelete, string.Join(", ", arguments.Select(kvp => String.Format("{0}={1}", kvp.Key, kvp.Value))));
 
                 return (IQueue)new Queue(name, exclusive);
             });
-        }
-
-        private string WriteArguments(IEnumerable<KeyValuePair<string, object>> arguments)
-        {
-            var builder = new StringBuilder();
-            var first = true;
-            foreach (var argument in arguments)
-            {
-                if (first)
-                {
-                    first = false;
-                }
-                else
-                {
-                    builder.Append(", ");
-                }
-                builder.AppendFormat("{0}={1}", argument.Key, argument.Value);
-            }
-            return builder.ToString();
         }
 
         public virtual IQueue QueueDeclare()
@@ -372,7 +378,6 @@ namespace EasyNetQ
             bool @internal = false,
             string alternateExchange = null)
         {
-
             return ExchangeDeclareAsync(name, type, passive, durable, autoDelete, @internal, alternateExchange).Result;
         }
 

--- a/Source/EasyNetQ/Scheduler.cs
+++ b/Source/EasyNetQ/Scheduler.cs
@@ -101,7 +101,7 @@ namespace EasyNetQ
             var futureExchangeName = exchangeName + "_" + delayString;
             var futureQueueName = conventions.QueueNamingConvention(typeof(T), delayString);
             return advancedBus.ExchangeDeclareAsync(futureExchangeName, ExchangeType.Topic)
-                .Then(futureExchange => advancedBus.QueueDeclareAsync(futureQueueName, perQueueTtl: (int)delay.TotalMilliseconds, deadLetterExchange: exchangeName)
+                .Then(futureExchange => advancedBus.QueueDeclareAsync(futureQueueName, perQueueMessageTtl: (int)delay.TotalMilliseconds, deadLetterExchange: exchangeName)
                                                    .Then(futureQueue => advancedBus.BindAsync(futureExchange, futureQueue, "#"))
                                                    .Then(() =>
                                                    {


### PR DESCRIPTION
This contains support for the new [priority queue feature](http://www.rabbitmq.com/priority.html) added in 3.5. I'll bump the version after #415 is merged since this is required to work.

Another small change committed along, in `RabbitAdvancedBus.QueueDeclare` we used `Int32.MaxValue` as default parameter values for `perQueueTtl` and `expire`, and would considered them only if they were different from this. This seemed a bit weird to me as these values could actually be used, although it wouldn't make a lot of sense, but still. I thought it was better to use nullables, and consider these argument only if an actual value was supplied.