### PR TITLE
No longer allows update to RabbitMq.Client 3.5.0

### DIFF
--- a/Package/EasyNetQ/EasyNetQ.nuspec
+++ b/Package/EasyNetQ/EasyNetQ.nuspec
@@ -17,7 +17,7 @@
     <copyright>Copyright Mike Hadlow 2014</copyright>
     <tags>RabbitMQ Messaging AMQP</tags>
     <dependencies>
-      <dependency id="RabbitMQ.Client" version="[3.4.3,]" />
+      <dependency id="RabbitMQ.Client" version="[3.4.3]" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Lock this version to a supported version of RabbitMQ.Client