### PR TITLE
Added start consuming succeed and failure events

### DIFF
--- a/Source/EasyNetQ/Consumer/ExclusiveConsumer.cs
+++ b/Source/EasyNetQ/Consumer/ExclusiveConsumer.cs
@@ -79,9 +79,13 @@ namespace EasyNetQ.Consumer
                 internalConsumer.Cancelled += consumer => Dispose();
                 var status = internalConsumer.StartConsuming(connection, queue, onMessage, configuration);
                 if (status == StartConsumingStatus.Succeed)
+                {
                     isStarted = true;
+                    eventBus.Publish(new StartConsumingSucceededEvent(this, queue));
+                }
                 else
                 {
+                    eventBus.Publish(new StartConsumingFailedEvent(this, queue));
                     internalConsumer.Dispose();
                     object value;
                     internalConsumers.TryRemove(internalConsumer, out value);

--- a/Source/EasyNetQ/Consumer/PersistentConsumer.cs
+++ b/Source/EasyNetQ/Consumer/PersistentConsumer.cs
@@ -71,12 +71,16 @@ namespace EasyNetQ.Consumer
 
             internalConsumer.Cancelled += consumer => Dispose();
 
-            internalConsumer.StartConsuming(
-                connection, 
+            var status = internalConsumer.StartConsuming(
+                connection,
                 queue,
-                onMessage, 
-                configuration
-                );
+                onMessage,
+                configuration);
+
+            if (status == StartConsumingStatus.Succeed)
+                eventBus.Publish(new StartConsumingSucceededEvent(this, queue));
+            else
+                eventBus.Publish(new StartConsumingFailedEvent(this, queue));
         }
 
         private void ConnectionOnDisconnected()

--- a/Source/EasyNetQ/Consumer/TransientConsumer.cs
+++ b/Source/EasyNetQ/Consumer/TransientConsumer.cs
@@ -45,11 +45,16 @@ namespace EasyNetQ.Consumer
 
             internalConsumer.Cancelled += consumer => Dispose();
 
-            internalConsumer.StartConsuming(
+            var status = internalConsumer.StartConsuming(
                 connection,
                 queue,
                 onMessage,
                 configuration);
+
+            if (status == StartConsumingStatus.Succeed)
+                eventBus.Publish(new StartConsumingSucceededEvent(this, queue));
+            else
+                eventBus.Publish(new StartConsumingFailedEvent(this, queue));
 
             return new ConsumerCancellation(Dispose);
         }

--- a/Source/EasyNetQ/EasyNetQ.csproj
+++ b/Source/EasyNetQ/EasyNetQ.csproj
@@ -68,6 +68,8 @@
     <Compile Include="Consumer\AckStrategies.cs" />
     <Compile Include="Consumer\ConsumerCancellation.cs" />
     <Compile Include="DelayedExchangeScheduler.cs" />
+    <Compile Include="Events\StartConsumingFailedEvent.cs" />
+    <Compile Include="Events\StartConsumingSucceededEvent.cs" />
     <Compile Include="MessageDeliveryMode.cs" />
     <Compile Include="SubscriptionResult.cs" />
     <Compile Include="Consumer\ConsumerExecutionContext.cs" />

--- a/Source/EasyNetQ/Events/StartConsumingFailedEvent.cs
+++ b/Source/EasyNetQ/Events/StartConsumingFailedEvent.cs
@@ -1,0 +1,21 @@
+﻿using EasyNetQ.Consumer;
+using EasyNetQ.Topology;
+
+namespace EasyNetQ.Events
+{
+    /// <summary>
+    /// This event is fired when the consumer cannot start consuming successfully.
+    /// </summary>
+    public class StartConsumingFailedEvent
+    {
+        public IConsumer Consumer { get; private set; }
+
+        public IQueue Queue { get; private set; }
+
+        public StartConsumingFailedEvent(IConsumer consumer, IQueue queue)
+        {
+            Consumer = consumer;
+            Queue = queue;
+        }
+    }
+}

--- a/Source/EasyNetQ/Events/StartConsumingSucceededEvent.cs
+++ b/Source/EasyNetQ/Events/StartConsumingSucceededEvent.cs
@@ -1,0 +1,21 @@
+﻿using EasyNetQ.Consumer;
+using EasyNetQ.Topology;
+
+namespace EasyNetQ.Events
+{
+    /// <summary>
+    /// This event is fired when the consumer starts consuming successfully.
+    /// </summary>
+    public class StartConsumingSucceededEvent
+    {
+        public IConsumer Consumer { get; private set; }
+
+        public IQueue Queue { get; private set; }
+
+        public StartConsumingSucceededEvent(IConsumer consumer, IQueue queue)
+        {
+            Consumer = consumer;
+            Queue = queue;
+        }
+    }
+}

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.47.10.0")]
+[assembly: AssemblyVersion("0.47.11.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.47.11.0 Added start consuming events for failure and success
 // 0.47.10.0 RabbitHutch.CreateBus overloads
 // 0.47.9.0 TypeNameSerializer now uses a ConcurrentDictionary to store se/deserialization results.
 // 0.47.8.0 Rpc.Respond will validate serialized length of TResponse upon method call to prevent silent exception when executing responder.

--- a/hall_of_fame.md
+++ b/hall_of_fame.md
@@ -57,3 +57,4 @@ No particular order. Don't forget to add your name with your pull request.
 * Jeff Huntsman
 * Mathieu Leenhardt
 * Steven Bone
+* Alex Wiese


### PR DESCRIPTION
Added two events to allow detection of when "start consuming" succeeds or fails.

Two classes added (`StartConsumingSucceededEvent` and `StartConsumingFailedEvent`).
Both classes capture the `IConsumer` and `IQueue` used to attempt consuming. 

These events are published by the `StartConsuming` methods of Transient, Persistent, and Exclusive consumers depending on the result of the `InternalConsumer.StartConsuming()` method.

This allows us to detect when consuming fails (for example trying to consume from a queue that is already being consumed by another exclusive consumer). Currently some advanced API methods (such as consume) are asynchronous and do not report success/failure. There is no easy way to detect if operations have actually succeeded (you can view failures in the logs).
