### PR TITLE
An attempt to fix #441

### DIFF
--- a/Source/EasyNetQ/FluentConfiguration/ISubscriptionConfiguration.cs
+++ b/Source/EasyNetQ/FluentConfiguration/ISubscriptionConfiguration.cs
@@ -71,10 +71,10 @@ namespace EasyNetQ.FluentConfiguration
         public int Priority { get; private set; }
         public bool CancelOnHaFailover { get; private set; }
         public ushort PrefetchCount { get; private set; }
-        public int Expires { get; private set; }
+        public int? Expires { get; private set; }
 
         public bool IsExclusive { get; private set; }
-
+         
         public SubscriptionConfiguration(ushort defaultPrefetchCount)
         {
             Topics = new List<string>();
@@ -82,7 +82,6 @@ namespace EasyNetQ.FluentConfiguration
             Priority = 0;
             CancelOnHaFailover = false;
             PrefetchCount = defaultPrefetchCount;
-            Expires = int.MaxValue;
             IsExclusive = false;
         }
 

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.49.1.0")]
+[assembly: AssemblyVersion("0.49.2.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.49.2.0 Fix subscription for events if queues were created in previous versions
 // 0.49.1.0 Priority queue support
 // 0.49.0.0 Updated to RabbitMQ.Client 3.5.1
 // 0.48.1.0 Fix unhandled exception


### PR DESCRIPTION
I got the same problem.

I declared all my existing queues by `QueueDeclare` without `expires` parameter (`null` by default).
But `SubscribeAsync` [uses](https://github.com/EasyNetQ/EasyNetQ/blob/master/Source/EasyNetQ/RabbitBus.cs#L131) `int.MaxValue` as `expires` parameter.