### PR TITLE
Fix #468 Polymorphic Request/Respond Does Not Work As Expected

### DIFF
--- a/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
+++ b/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
@@ -103,6 +103,7 @@
     <Compile Include="ConsumeTests\When_a_polymorphic_message_is_delivered_to_the_consumer.cs" />
     <Compile Include="ConsumeTests\When_consume_is_called.cs" />
     <Compile Include="Integration\AdvancedBusTests.cs" />
+    <Compile Include="Integration\PolymorphicRpc.cs" />
     <Compile Include="Integration\Scheduling\DeadLetterExchangeAndMessageTtlSchedulerTests.cs" />
     <Compile Include="Integration\Scheduling\DelayedExchangeSchedulerTests.cs" />
     <Compile Include="Integration\RpcTests.cs" />

--- a/Source/EasyNetQ.Tests/Integration/PolymorphicRpc.cs
+++ b/Source/EasyNetQ.Tests/Integration/PolymorphicRpc.cs
@@ -1,0 +1,89 @@
+﻿// ReSharper disable InconsistentNaming
+
+using System;
+using System.Threading;
+using EasyNetQ.Loggers;
+using NUnit.Framework;
+
+namespace EasyNetQ.Tests.Integration
+{
+    [TestFixture]
+    [Explicit("Requires a local RabbitMQ instance to work")]
+    public class PolymorphicRpc
+    {
+        private IBus bus;
+
+        [SetUp]
+        public void SetUp()
+        {
+            bus = RabbitHutch.CreateBus("host=localhost", x => x.Register<IEasyNetQLogger, NullLogger>());
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            bus.Dispose();
+        }
+
+        [Test]
+        public void Should_request_some_animals()
+        {
+            var cat = new Cat
+            {
+                Name = "Gobbolino",
+                Meow = "Purr"
+            };
+
+            var dog = new Dog
+            {
+                Name = "Rover",
+                Bark = "Woof"
+            };
+
+            bus.RequestAsync<IAnimal, IAnimal>(cat);
+            bus.RequestAsync<IAnimal, IAnimal>(dog);
+        }
+
+        [Test]
+        public void Should_request_respond_with_correct_message_types()
+        {
+            bus.Respond<IAnimal, IAnimal>(@interface =>
+            {
+                var cat = @interface as Cat;
+                var dog = @interface as Dog;
+
+                if (cat != null)
+                {
+                    Console.Out.WriteLine("Name = {0}", cat.Name);
+                    Console.Out.WriteLine("Meow = {0}", cat.Meow);
+                }
+                else if (dog != null)
+                {
+                    Console.Out.WriteLine("Name = {0}", dog.Name);
+                    Console.Out.WriteLine("Bark = {0}", dog.Bark);
+                }
+                else
+                {
+                    Console.Out.WriteLine("message was not a dog or a cat");
+                }
+
+                return @interface;
+            });
+
+            Thread.Sleep(500);
+
+            IAnimal request = new Cat
+            {
+                Name = "Gobbolino",
+                Meow = "Purr"
+            };
+
+            IAnimal response = bus.Request<IAnimal, IAnimal>(request);
+
+            Assert.AreEqual(request.Name, response.Name);
+            Assert.AreSame(request.GetType(), response.GetType());
+        }
+    }
+}
+
+// ReSharper restore InconsistentNaming

--- a/Source/EasyNetQ.Tests/ProducerTests/When_a_ploymorphic_message_is_sent.cs
+++ b/Source/EasyNetQ.Tests/ProducerTests/When_a_ploymorphic_message_is_sent.cs
@@ -9,7 +9,7 @@ using Rhino.Mocks;
 namespace EasyNetQ.Tests.ProducerTests
 {
     [TestFixture]
-    public class When_a_ploymorphic_message_is_sent
+    public class When_a_polymorphic_message_is_sent
     {
         private MockBuilder mockBuilder;
         private const string interfaceTypeName = "EasyNetQ.Tests.ProducerTests.IMyMessageInterface:EasyNetQ.Tests";

--- a/Source/EasyNetQ/Producer/Rpc.cs
+++ b/Source/EasyNetQ/Producer/Rpc.cs
@@ -110,7 +110,7 @@ namespace EasyNetQ.Producer
                 {
                     timer.Dispose();
 
-                    var msg = ((Message<TResponse>)message);
+                    var msg = ((IMessage<TResponse>)message);
 
                     bool isFaulted = false;
                     string exceptionMessage = "The exception message has not been specified.";

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,7 +2,7 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.50.2.0")]
+[assembly: AssemblyVersion("0.50.3.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
+// 0.50.3.0 Bug fix, Polymorphic request-response did not work with polymorphic response types
 // 0.50.2.0 Updated RabbitMQ client to 3.5.4 and Json.NET to 7.0.1
 // 0.50.1.0 Fix type in Extensions
 // 0.50.0.0 Updated to RabbitMQ.Client 3.5.3


### PR DESCRIPTION
Fix#468 and add integration test.  (Red->Green: Test failed before fix.)

@micdenny: I checked the rest of the codebase for similar uses of `Message<T>` where `IMessage<T>` might be preferred for same reason (support T polymorphic), but did not find any others.