### PR TITLE
Allow specifying the maximum size of the message queue.

### DIFF
--- a/Source/EasyNetQ/IAdvancedBus.cs
+++ b/Source/EasyNetQ/IAdvancedBus.cs
@@ -248,6 +248,8 @@ namespace EasyNetQ
         /// <param name="maxPriority">Determines the maximum message priority that the queue should support.</param>
         /// <param name="deadLetterExchange">Determines an exchange's name can remain unused before it is automatically deleted by the server.</param>
         /// <param name="deadLetterRoutingKey">If set, will route message with the routing key specified, if not set, message will be routed with the same routing keys they were originally published with.</param>
+        /// <param name="maxLength">The maximum number of ready messages that may exist on the queue.  Messages will be dropped or dead-lettered from the front of the queue to make room for new messages once the limit is reached</param>
+        /// <param name="maxLengthBytes">The maximum size of the queue in bytes.  Messages will be dropped or dead-lettered from the front of the queue to make room for new messages once the limit is reached</param>
         /// <returns>
         /// The queue
         /// </returns>
@@ -261,7 +263,9 @@ namespace EasyNetQ
             int? expires = null,
             int? maxPriority = null,
             string deadLetterExchange = null, 
-            string deadLetterRoutingKey = null);
+            string deadLetterRoutingKey = null,
+            int? maxLength = null,
+            int? maxLengthBytes = null);
 
         /// <summary>
         /// Declare a queue. If the queue already exists this method does nothing
@@ -276,6 +280,8 @@ namespace EasyNetQ
         /// <param name="maxPriority">Determines the maximum message priority that the queue should support.</param>
         /// <param name="deadLetterExchange">Determines an exchange's name can remain unused before it is automatically deleted by the server.</param>
         /// <param name="deadLetterRoutingKey">If set, will route message with the routing key specified, if not set, message will be routed with the same routing keys they were originally published with.</param>
+        /// <param name="maxLength">The maximum number of ready messages that may exist on the queue.  Messages will be dropped or dead-lettered from the front of the queue to make room for new messages once the limit is reached</param>
+        /// <param name="maxLengthBytes">The maximum size of the queue in bytes.  Messages will be dropped or dead-lettered from the front of the queue to make room for new messages once the limit is reached</param>
         /// <returns>The queue</returns>
         Task<IQueue> QueueDeclareAsync(
             string name, 
@@ -287,7 +293,9 @@ namespace EasyNetQ
             int? expires = null,
             int? maxPriority = null,
             string deadLetterExchange = null, 
-            string deadLetterRoutingKey = null);
+            string deadLetterRoutingKey = null,
+            int? maxLength = null,
+            int? maxLengthBytes = null);
 
         /// <summary>
         /// Declare a transient server named queue. Note, this queue will only last for duration of the

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -342,10 +342,10 @@ namespace EasyNetQ
             }
             if (maxLengthBytes.HasValue)
             {
-              arguments.Add("x-max-length-bytes", maxLengthBytes.Value);
+                arguments.Add("x-max-length-bytes", maxLengthBytes.Value);
             }
 
-          return clientCommandDispatcher.InvokeAsync(x => x.QueueDeclare(name, durable, exclusive, autoDelete, arguments)).Then(() =>
+            return clientCommandDispatcher.InvokeAsync(x => x.QueueDeclare(name, durable, exclusive, autoDelete, arguments)).Then(() =>
             {
                 logger.DebugWrite("Declared Queue: '{0}', durable:{1}, exclusive:{2}, autoDelete:{3}, args:{4}",
                     name, durable, exclusive, autoDelete, string.Join(", ", arguments.Select(kvp => String.Format("{0}={1}", kvp.Key, kvp.Value))));

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -285,10 +285,12 @@ namespace EasyNetQ
             int? expires = null,
             int? maxPriority = null,
             string deadLetterExchange = null, 
-            string deadLetterRoutingKey = null)
+            string deadLetterRoutingKey = null,
+            int? maxLength = null,
+            int? maxLengthBytes = null)
         {
-            return QueueDeclareAsync(name, passive, durable, exclusive, autoDelete, perQueueMessageTtl, 
-                expires, maxPriority, deadLetterExchange, deadLetterRoutingKey).Result;
+            return QueueDeclareAsync(name, passive, durable, exclusive, autoDelete, perQueueMessageTtl,
+                expires, maxPriority, deadLetterExchange, deadLetterRoutingKey, maxLength, maxLengthBytes).Result;
         }
 
         public Task<IQueue> QueueDeclareAsync(
@@ -301,7 +303,9 @@ namespace EasyNetQ
             int? expires = null,
             int? maxPriority = null,
             string deadLetterExchange = null, 
-            string deadLetterRoutingKey = null)
+            string deadLetterRoutingKey = null,
+            int? maxLength = null,
+            int? maxLengthBytes = null)
         {
             Preconditions.CheckNotNull(name, "name");
 
@@ -332,8 +336,16 @@ namespace EasyNetQ
             {
                 arguments.Add("x-dead-letter-routing-key", deadLetterRoutingKey);
             }
+            if (maxLength.HasValue)
+            {
+                arguments.Add("x-max-length", maxLength.Value);
+            }
+            if (maxLengthBytes.HasValue)
+            {
+              arguments.Add("x-max-length-bytes", maxLengthBytes.Value);
+            }
 
-            return clientCommandDispatcher.InvokeAsync(x => x.QueueDeclare(name, durable, exclusive, autoDelete, arguments)).Then(() =>
+          return clientCommandDispatcher.InvokeAsync(x => x.QueueDeclare(name, durable, exclusive, autoDelete, arguments)).Then(() =>
             {
                 logger.DebugWrite("Declared Queue: '{0}', durable:{1}, exclusive:{2}, autoDelete:{3}, args:{4}",
                     name, durable, exclusive, autoDelete, string.Join(", ", arguments.Select(kvp => String.Format("{0}={1}", kvp.Key, kvp.Value))));

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,10 +2,11 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.50.4.0")]
+[assembly: AssemblyVersion("0.50.5.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
+// 0.50.5.0 Allow specifying the maximum size of the message queue when it is being declared
 // 0.50.4.0 Queue max priority now uses int instead of byte.
 // 0.50.3.0 Bug fix, Polymorphic request-response did not work with polymorphic response types
 // 0.50.2.0 Updated RabbitMQ client to 3.5.4 and Json.NET to 7.0.1
@@ -38,7 +39,7 @@ using System.Reflection;
 // 0.43.1.0 Management Client fix for URI slash escaping in .NET 4.0 with https connection.
 // 0.43.0.0 Use ILRepack to internally merge Newtonsoft.Json in ManagementClient, default WebRequest.KeepAlive to false to resolve spurious 'the request was aborted: the request was canceled' exceptions
 // 0.42.0.0 Switched from local to UTC datetimes.
-// 0.41.0.0 Dynamic removal 
+// 0.41.0.0 Dynamic removal
 // 0.40.6.0 Added parameter to set the 'x-dead-letter-routing-key' argument when declaring a queue.
 // 0.40.5.0 Preconditions will check for blank argument name / exception message only when needed
 // 0.40.4.0 Bug fix of Rpc
@@ -54,7 +55,7 @@ using System.Reflection;
 // 0.39.1.0 Fix multiple queue's creation. Bug fix
 // 0.39.0.0 Added SendAsync
 // 0.38.2.0 RandomHostSelectionStrategy is default hosts selection strategy
-// 0.38.1.0 Configuration of rpc timeout  
+// 0.38.1.0 Configuration of rpc timeout
 // 0.38.0.0 ILMerging to remove the potentially conflicting dependency on System.Collections.Immutable.Net40 from the NuGet
 // 0.37.3.0 Remove POCO interfaces IConnectionConfiguration and IHostConfiguration
 // 0.37.2.0 Upgrade to RabbitMQ.Client 3.4.0


### PR DESCRIPTION
Extended the method signature of QueueDeclare and QueueDeclareAsync to put two more optional parameters at the end to allow specifying the maximum number of messages and/or the maximum size of the queue.

Fixes #472