### PR TITLE
Fix Issue #475 -  AMQP-uri-specified connections get configured twice

### DIFF
--- a/Source/EasyNetQ.Tests/ConnectionConfigurationTests.cs
+++ b/Source/EasyNetQ.Tests/ConnectionConfigurationTests.cs
@@ -1,0 +1,29 @@
+﻿// ReSharper disable InconsistentNaming
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using EasyNetQ.ConnectionString;
+using NUnit.Framework;
+
+namespace EasyNetQ.Tests
+{
+    [TestFixture]
+    public class ConnectionConfigurationTests
+    {
+        
+        [Test]
+        public void The_validate_method_should_apply_AMQPconnection_idempotently()
+        {
+            ConnectionConfiguration connectionConfiguration = new ConnectionStringParser().Parse("amqp://amqphost:1234/");
+            connectionConfiguration.Validate(); // Simulates additional call to .Validate(); made by some RabbitHutch.CreateBus(...) overloads, in addition to call within ConnectionStringParser.Parse().  
+
+            connectionConfiguration.Hosts.Count().ShouldEqual(1);
+            connectionConfiguration.Hosts.Single().Host.ShouldEqual("amqphost");
+            connectionConfiguration.Hosts.Single().Port.ShouldEqual(1234);
+        }
+    }
+}
+
+// ReSharper restore InconsistentNaming

--- a/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
+++ b/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
@@ -89,6 +89,7 @@
     <Compile Include="BlockedConnectionNotificationTests.cs" />
     <Compile Include="ClientCommandDispatcherTests\When_an_action_is_invoked.cs" />
     <Compile Include="ClientCommandDispatcherTests\When_an_action_is_invoked_that_throws.cs" />
+    <Compile Include="ConnectionConfigurationTests.cs" />
     <Compile Include="ConsumerDispatcherFactoryTests.cs" />
     <Compile Include="ConsumeTests\AckStrategyTests.cs" />
     <Compile Include="ConsumeTests\When_cancellation_of_message_handler_occurs.cs" />

--- a/Source/EasyNetQ/ConnectionConfiguration.cs
+++ b/Source/EasyNetQ/ConnectionConfiguration.cs
@@ -103,7 +103,7 @@ namespace EasyNetQ
 
         public void Validate()
         {
-            if (AMQPConnectionString != null)
+            if (AMQPConnectionString != null && !Hosts.Any(h => h.Host == AMQPConnectionString.Host))
             {
                 if(Port == DefaultPort && AMQPConnectionString.Port > 0) 
                         Port = (ushort) AMQPConnectionString.Port;

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,10 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.50.4.0")]
+[assembly: AssemblyVersion("0.50.3.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
-// 0.50.4.0 Fix assigning of AMQP connection in to ConnectionConfiguration to be idempotent.
 // 0.50.3.0 Bug fix, Polymorphic request-response did not work with polymorphic response types
 // 0.50.2.0 Updated RabbitMQ client to 3.5.4 and Json.NET to 7.0.1
 // 0.50.1.0 Fix type in Extensions

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 // 0.50.5.0 Fix assigning of AMQP connection in to ConnectionConfiguration to be idempotent.
+// 0.50.4.0 Queue max priority now uses int instead of byte.
 // 0.50.3.0 Bug fix, Polymorphic request-response did not work with polymorphic response types
 // 0.50.2.0 Updated RabbitMQ client to 3.5.4 and Json.NET to 7.0.1
 // 0.50.1.0 Fix type in Extensions

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,10 +2,11 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.50.3.0")]
+[assembly: AssemblyVersion("0.50.5.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
+// 0.50.5.0 Fix assigning of AMQP connection in to ConnectionConfiguration to be idempotent.
 // 0.50.3.0 Bug fix, Polymorphic request-response did not work with polymorphic response types
 // 0.50.2.0 Updated RabbitMQ client to 3.5.4 and Json.NET to 7.0.1
 // 0.50.1.0 Fix type in Extensions

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,10 +2,11 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.50.3.0")]
+[assembly: AssemblyVersion("0.50.4.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
+// 0.50.4.0 Fix assigning of AMQP connection in to ConnectionConfiguration to be idempotent.
 // 0.50.3.0 Bug fix, Polymorphic request-response did not work with polymorphic response types
 // 0.50.2.0 Updated RabbitMQ client to 3.5.4 and Json.NET to 7.0.1
 // 0.50.1.0 Fix type in Extensions


### PR DESCRIPTION
Fixes #475.  Makes the `ConnectionConfiguration.Validate()` method idempotent with respect to configuring a Host from the `AMQPConnectionString` property.

An alternative evaluated was to ask whether `ConnectionConfiguration.Validate()` needs to be called twice by a connection codepath starting from `RabbitHutch.CreateBus(string connectionString ...)` overload.  However:

+ Various `ConnectionStringParserTests` clearly expect `ConnectionStringParser.Parse()` to invoke `ConnectionConfiguration.Validate()`.
+ The call to `ConnectionConfiguration.Validate()` made by the `RabbitHutch.CreateBus(ConnectionConfiguration connectionConfiguration, AdvancedBusEventHandlers advancedBusEventHandlers, Action<IServiceRegister> registerServices)` overload would seem to be necessary to be retained, in case this public method is called by somebody directly passing in a hand-crafted ConnectionConfiguration instance.  Removing the call to `ConnectionConfiguration.Validate()` here could constitute a bad breaking change - the work done by `Validate()` to configure default ports and `ClientProperties` could be skipped - leading to people's connections going down entirely / behaving very differently.

It was therefore considered safest to make `ConnectionConfiguration.Validate()` idempotent.