### PR TITLE
Added ability to include the internal queue time in the timeout for a…

### DIFF
--- a/Source/EasyNetQ.Tests/ClientCommandDispatcherTests/When_an_action_is_invoked.cs
+++ b/Source/EasyNetQ.Tests/ClientCommandDispatcherTests/When_an_action_is_invoked.cs
@@ -34,7 +34,7 @@ namespace EasyNetQ.Tests.ClientCommandDispatcherTests
                 };
 
             channelFactory.Stub(x => x.CreatePersistentChannel(connection)).Return(channel);
-            channel.Stub(x => x.InvokeChannelAction(null)).IgnoreArguments().WhenCalled(
+            channel.Stub(x => x.InvokeChannelAction(null,DateTime.UtcNow)).IgnoreArguments().WhenCalled(
                 x => ((Action<IModel>)x.Arguments[0])(null));
 
             dispatcher = new ClientCommandDispatcher(connection, channelFactory);

--- a/Source/EasyNetQ.Tests/ClientCommandDispatcherTests/When_an_action_is_invoked_that_throws.cs
+++ b/Source/EasyNetQ.Tests/ClientCommandDispatcherTests/When_an_action_is_invoked_that_throws.cs
@@ -22,7 +22,7 @@ namespace EasyNetQ.Tests.ClientCommandDispatcherTests
             channel = MockRepository.GenerateStub<IPersistentChannel>();
 
             channelFactory.Stub(x => x.CreatePersistentChannel(connection)).Return(channel);
-            channel.Stub(x => x.InvokeChannelAction(null)).IgnoreArguments().WhenCalled(
+            channel.Stub(x => x.InvokeChannelAction(null,DateTime.UtcNow)).IgnoreArguments().WhenCalled(
                 x => ((Action<IModel>)x.Arguments[0])(null));
 
             dispatcher = new ClientCommandDispatcher(connection, channelFactory);

--- a/Source/EasyNetQ.Tests/Integration/PersistentChannelTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/PersistentChannelTests.cs
@@ -38,14 +38,14 @@ namespace EasyNetQ.Tests.Integration
         [Test]
         public void Should_be_able_to_run_channel_actions()
         {
-            persistentChannel.InvokeChannelAction(x => x.ExchangeDeclare("myExchange", "direct"));
+            persistentChannel.InvokeChannelAction(x => x.ExchangeDeclare("myExchange", "direct"),DateTime.UtcNow);
         }
 
         [Test]
         public void Should_allow_non_disconnect_Amqp_exception_to_bubble_up()
         {
             // run test above first
-            persistentChannel.InvokeChannelAction(x => x.ExchangeDeclare("myExchange", "topic"));
+            persistentChannel.InvokeChannelAction(x => x.ExchangeDeclare("myExchange", "topic"),DateTime.UtcNow);
         }
 
         [Test]
@@ -59,7 +59,7 @@ namespace EasyNetQ.Tests.Integration
                     Console.Out.WriteLine("Running exchange declare");
                     x.ExchangeDeclare("myExchange", "direct");
                     Console.Out.WriteLine("Ran exchange declare");
-                });
+                },DateTime.UtcNow);
 
             Thread.Sleep(1000);
         }

--- a/Source/EasyNetQ.Tests/PersistentChannelTests/When_a_channel_action_is_invoked.cs
+++ b/Source/EasyNetQ.Tests/PersistentChannelTests/When_a_channel_action_is_invoked.cs
@@ -5,6 +5,7 @@ using EasyNetQ.Producer;
 using NUnit.Framework;
 using RabbitMQ.Client;
 using Rhino.Mocks;
+using System;
 
 namespace EasyNetQ.Tests.PersistentChannelTests
 {
@@ -29,7 +30,7 @@ namespace EasyNetQ.Tests.PersistentChannelTests
 
             persistentChannel = new PersistentChannel(persistentConnection, logger, configuration, eventBus);
 
-            persistentChannel.InvokeChannelAction(x => x.ExchangeDeclare("MyExchange", "direct"));
+            persistentChannel.InvokeChannelAction(x => x.ExchangeDeclare("MyExchange", "direct"),DateTime.UtcNow );
         }
 
         [Test]

--- a/Source/EasyNetQ.Tests/PersistentChannelTests/When_an_action_is_performed_on_a_closed_channel_that_doesnt_open_again.cs
+++ b/Source/EasyNetQ.Tests/PersistentChannelTests/When_an_action_is_performed_on_a_closed_channel_that_doesnt_open_again.cs
@@ -48,7 +48,7 @@ namespace EasyNetQ.Tests.PersistentChannelTests
         [ExpectedException(typeof(TimeoutException))]
         public void Should_throw_timeout_exception()
         {
-            persistentChannel.InvokeChannelAction(x => x.ExchangeDeclare("MyExchange", "direct"));
+            persistentChannel.InvokeChannelAction(x => x.ExchangeDeclare("MyExchange", "direct"),DateTime.UtcNow);
         }
     }
 }

--- a/Source/EasyNetQ.Tests/PersistentChannelTests/When_an_action_is_performed_on_a_closed_channel_that_then_opens.cs
+++ b/Source/EasyNetQ.Tests/PersistentChannelTests/When_an_action_is_performed_on_a_closed_channel_that_then_opens.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Exceptions;
 using Rhino.Mocks;
+using System;
 
 namespace EasyNetQ.Tests.PersistentChannelTests
 {
@@ -41,7 +42,7 @@ namespace EasyNetQ.Tests.PersistentChannelTests
 
             new Timer(_ => eventBus.Publish(new ConnectionCreatedEvent())).Change(10, Timeout.Infinite);
 
-            persistentChannel.InvokeChannelAction(x => x.ExchangeDeclare("MyExchange", "direct"));
+            persistentChannel.InvokeChannelAction(x => x.ExchangeDeclare("MyExchange", "direct"),DateTime.UtcNow );
         }
 
         [Test]

--- a/Source/EasyNetQ/ConnectionConfiguration.cs
+++ b/Source/EasyNetQ/ConnectionConfiguration.cs
@@ -28,6 +28,10 @@ namespace EasyNetQ
         /// Operation timeout seconds. (default is 10)
         /// </summary>
         public ushort Timeout { get; set; }
+		/// <summary>
+		/// Option to include the time spent in the in-memory queue when calculating the message timeout.
+		/// </summary>
+		public bool IncludeQueTimeInTimeout { get; set; }
         public bool PublisherConfirms { get; set; }
         public bool PersistentMessages { get; set; }
         public bool CancelOnHaFailover { get; set; }
@@ -97,6 +101,7 @@ namespace EasyNetQ
             clientProperties.Add("connected", DateTime.UtcNow.ToString("u")); // UniversalSortableDateTimePattern: yyyy'-'MM'-'dd HH':'mm':'ss'Z'
             clientProperties.Add("requested_heartbeat", RequestedHeartbeat.ToString());
             clientProperties.Add("timeout", Timeout.ToString());
+			clientProperties.Add("includeQueTimeInTimeout", IncludeQueTimeInTimeout.ToString());
             clientProperties.Add("publisher_confirms", PublisherConfirms.ToString());
             clientProperties.Add("persistent_messages", PersistentMessages.ToString());
         }

--- a/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
+++ b/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
@@ -42,7 +42,8 @@ namespace EasyNetQ.ConnectionString
             BuildKeyValueParser("persistentMessages", Bool, c => c.PersistentMessages),
             BuildKeyValueParser("cancelOnHaFailover", Bool, c => c.CancelOnHaFailover),
             BuildKeyValueParser("product", Text, c => c.Product),
-            BuildKeyValueParser("platform", Text, c => c.Platform)
+            BuildKeyValueParser("platform", Text, c => c.Platform),
+			BuildKeyValueParser("includeQueTimeInTimeout", Bool, c => c.IncludeQueTimeInTimeout)
         }.Aggregate((a, b) => a.Or(b));
 
         public static Parser<UpdateConfiguration> AMQPAlone =

--- a/Source/EasyNetQ/Producer/ClientCommandDispatcherSingleton.cs
+++ b/Source/EasyNetQ/Producer/ClientCommandDispatcherSingleton.cs
@@ -50,6 +50,9 @@ namespace EasyNetQ.Producer
             Preconditions.CheckNotNull(channelAction, "channelAction");
 
             var tcs = new TaskCompletionSource<T>();
+			// Set the start time used for calculating the message timeout to be the time when it was added to the queue, 
+			// instead of the time when it is pulled out of the queue when the includeQueTimeInTimeout option is used in the connection string. 
+			DateTime startTime = DateTime.UtcNow; 
 
             try
             {
@@ -62,7 +65,7 @@ namespace EasyNetQ.Producer
                         }
                         try
                         {
-                            persistentChannel.InvokeChannelAction(channel => tcs.SetResult(channelAction(channel)));
+                            persistentChannel.InvokeChannelAction(channel => tcs.SetResult(channelAction(channel)),startTime);
                         }
                         catch (Exception e)
                         {

--- a/Source/EasyNetQ/Producer/IPersistentChannel.cs
+++ b/Source/EasyNetQ/Producer/IPersistentChannel.cs
@@ -5,6 +5,6 @@ namespace EasyNetQ.Producer
 {
     public interface IPersistentChannel : IDisposable
     {
-        void InvokeChannelAction(Action<IModel> channelAction);
+        void InvokeChannelAction(Action<IModel> channelAction,DateTime startTime);
     }
 }

--- a/Source/EasyNetQ/Producer/PersistentChannel.cs
+++ b/Source/EasyNetQ/Producer/PersistentChannel.cs
@@ -87,17 +87,17 @@ namespace EasyNetQ.Producer
             logger.DebugWrite("Persistent channel connected.");
         }
 
-        public void InvokeChannelAction(Action<IModel> channelAction)
+        public void InvokeChannelAction(Action<IModel> channelAction,DateTime startTime)
         {
             Preconditions.CheckNotNull(channelAction, "channelAction");
-            InvokeChannelActionInternal(channelAction, DateTime.UtcNow);
+            InvokeChannelActionInternal(channelAction, configuration.IncludeQueTimeInTimeout? startTime:DateTime.UtcNow);
         }
 
         private void InvokeChannelActionInternal(Action<IModel> channelAction, DateTime startTime)
         {
             if (IsTimedOut(startTime))
             {
-                logger.ErrorWrite("Channel action timed out. Throwing exception to client.");
+                logger.ErrorWrite(String.Format("Channel action timed out. Throwing exception to client. Start Time = {0}",startTime));
                 throw new TimeoutException("The operation requested on PersistentChannel timed out.");
             }
             try

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,7 +2,7 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.50.7.0")]
+[assembly: AssemblyVersion("0.50.7.1")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.


### PR DESCRIPTION
… message

Added connection string parameter "includeQueTimeInTimeout". When set to
True, the time that the message was added to EasyNetQ's internal queue
is used to calculate the timeout. When set to False, the time that the
message was removed from the internal queue will be used ( current
functionality) . Default value is False.
