### PR TITLE
Changed the default expires value of the autosubscriber attribute

### DIFF
--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_subscription_configuration_attribute_no_expires.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_subscription_configuration_attribute_no_expires.cs
@@ -1,0 +1,76 @@
+using System;
+using EasyNetQ.AutoSubscribe;
+using EasyNetQ.FluentConfiguration;
+using NUnit.Framework;
+using Rhino.Mocks;
+
+namespace EasyNetQ.Tests.AutoSubscriberTests
+{
+    [TestFixture]
+    public class When_autosubscribing_with_subscription_configuration_attribute_no_expires
+    {
+        private IBus bus;
+        private Action<ISubscriptionConfiguration> capturedAction;
+       
+        [SetUp]
+        public void SetUp()
+        {
+            bus = MockRepository.GenerateMock<IBus>();
+            
+            var autoSubscriber = new AutoSubscriber(bus, "my_app");
+
+            bus.Stub(x => x.Subscribe(
+                Arg<string>.Is.Equal("MyAttrTest"),
+                Arg<Action<MessageA>>.Is.Anything,
+                Arg<Action<ISubscriptionConfiguration>>.Is.Anything
+                ))
+                .WhenCalled(a =>
+                {
+                    capturedAction= (Action<ISubscriptionConfiguration>)a.Arguments[2];
+                });
+
+            autoSubscriber.Subscribe(GetType().Assembly);
+        }
+
+        [Test]
+        public void Should_have_called_subscribe()
+        {
+            bus.AssertWasCalled(
+                x => x.Subscribe(
+                    Arg<string>.Is.Anything, 
+                    Arg<Action<MessageA>>.Is.Anything, 
+                    Arg<Action<ISubscriptionConfiguration>>.Is.Anything));
+
+        }
+
+        [Test]
+        public void Should_have_called_subscribe_with_no_expires()
+        {
+            var subscriptionConfiguration = new SubscriptionConfiguration(1);
+            
+            capturedAction(subscriptionConfiguration);
+
+            subscriptionConfiguration.AutoDelete.ShouldBeTrue();
+            subscriptionConfiguration.CancelOnHaFailover.ShouldBeTrue();
+            subscriptionConfiguration.Expires.ShouldEqual(null);
+            subscriptionConfiguration.PrefetchCount.ShouldEqual(10);
+            subscriptionConfiguration.Priority.ShouldEqual(10);
+
+        }
+
+        // Discovered by reflection over test assembly, do not remove.
+        private class MyConsumerWithAttr : IConsume<MessageA>
+        {
+            [AutoSubscriberConsumer(SubscriptionId = "MyAttrTest")]
+            [SubscriptionConfiguration(AutoDelete = true, CancelOnHaFailover = true, PrefetchCount = 10, Priority = 10)]
+            public void Consume(MessageA message)
+            {
+            }
+        }
+
+        private class MessageA
+        {
+            public string Text { get; set; }
+        }
+    }
+}

--- a/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
+++ b/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
@@ -89,6 +89,7 @@
     <Compile Include="AutoSubscriberTests\When_autosubscribing_with_subscription_configuration_action.cs" />
     <Compile Include="AutoSubscriberTests\When_autosubscribing_with_subscription_configuration.cs" />
     <Compile Include="AutoSubscriberTests\When_autosubscribing.cs" />
+    <Compile Include="AutoSubscriberTests\When_autosubscribing_with_subscription_configuration_attribute_no_expires.cs" />
     <Compile Include="BlockedConnectionNotificationTests.cs" />
     <Compile Include="ClientCommandDispatcherTests\When_an_action_is_invoked.cs" />
     <Compile Include="ClientCommandDispatcherTests\When_an_action_is_invoked_that_throws.cs" />

--- a/Source/EasyNetQ/AutoSubscribe/AutoSubscriber.cs
+++ b/Source/EasyNetQ/AutoSubscribe/AutoSubscriber.cs
@@ -208,15 +208,16 @@ namespace EasyNetQ.AutoSubscribe
                 {
                     //prefetch count is set to a configurable default in RabbitAdvancedBus
                     //so don't touch it unless SubscriptionConfigurationAttribute value is other than 0.
-                    if(configSettings.PrefetchCount > 0)
-                    {
+                    if (configSettings.PrefetchCount > 0)
                         configuration.WithPrefetchCount(configSettings.PrefetchCount);
-                    }
-                    configuration.WithAutoDelete(configSettings.AutoDelete)
-                                 .WithCancelOnHaFailover(configSettings.CancelOnHaFailover)
-                                 .WithExpires(configSettings.Expires)
-                                 .WithPrefetchCount(configSettings.PrefetchCount)
-                                 .WithPriority(configSettings.Priority);
+
+                    if (configSettings.Expires > 0 )
+                        configuration.WithExpires(configSettings.Expires);
+
+                    configuration
+                        .WithAutoDelete(configSettings.AutoDelete)
+                        .WithCancelOnHaFailover(configSettings.CancelOnHaFailover)
+                        .WithPriority(configSettings.Priority);
                 };
         }
 

--- a/Source/EasyNetQ/AutoSubscribe/SubscriptionConfigurationAttribute.cs
+++ b/Source/EasyNetQ/AutoSubscribe/SubscriptionConfigurationAttribute.cs
@@ -6,15 +6,10 @@ namespace EasyNetQ.AutoSubscribe
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
     public class SubscriptionConfigurationAttribute : Attribute
     {
-        public SubscriptionConfigurationAttribute()
-        {
-            Expires = int.MaxValue;
-        }
-
         public bool AutoDelete { get;  set; }
         public int Priority { get;  set; }
         public bool CancelOnHaFailover { get;  set; }
         public ushort PrefetchCount { get;  set; }
-        public int Expires { get;  set; }
+        public int Expires { get; set; }
     }
 }

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.52.0.0")]
+[assembly: AssemblyVersion("0.53.0.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.53.0.0 fix expires default behavior of subscription configuration attribute
 // 0.52.0.0 Added synchronous callback on Consume(byte[]) methods of the advaced api
 // 0.51.0.0 Brand new sync/async implementation, a lot of changes in publish mechanisms. Should be used with care  
 // 0.50.12.0 Added Serilog nuget package 


### PR DESCRIPTION
I ran into an issue where wanting to change the prefetch count of a subscription, so I applied the ConfigurationSubscriptionAttribute:

    [SubscriptionConfiguration(PrefetchCount = 1)]
    public void Consume(MessageA message)

Additionally, this set the 'expires' property of the queue to `int.MaxValue`, which I think is counter intuitive (and causes problems for queues that were already declared before).

To solve this there are now 2 properties on the SubscriptionConfigurationAttribute, if anyone has suggestions for better ways/naming please let me know.