### PR TITLE
Message priority in IBus

### DIFF
--- a/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
+++ b/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
@@ -113,6 +113,7 @@
     <Compile Include="ConsumeTests\When_a_message_is_received.cs" />
     <Compile Include="ConsumeTests\When_a_polymorphic_message_is_delivered_to_the_consumer.cs" />
     <Compile Include="ConsumeTests\When_consume_is_called.cs" />
+    <Compile Include="FluentConfiguration\PublishConfigurationTests.cs" />
     <Compile Include="Integration\AdvancedBusTests.cs" />
     <Compile Include="Integration\PolymorphicRpc.cs" />
     <Compile Include="Integration\Scheduling\DeadLetterExchangeAndMessageTtlSchedulerTests.cs" />

--- a/Source/EasyNetQ.Tests/FluentConfiguration/PublishConfigurationTests.cs
+++ b/Source/EasyNetQ.Tests/FluentConfiguration/PublishConfigurationTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using EasyNetQ.FluentConfiguration;
+using NUnit.Framework;
+
+namespace EasyNetQ.Tests.FluentConfiguration
+{
+    [TestFixture]
+    public class PublishConfigurationTests
+    {
+        [Test]
+        public void Should_throw_if_default_topic_is_null()
+        {
+            Assert.That(() => new PublishConfiguration(null), Throws.InstanceOf<ArgumentNullException>());
+        }
+
+        [Test]
+        public void Should_return_default_topic()
+        {
+            var configuration = new PublishConfiguration("default");
+
+            configuration.WithTopic(null);
+
+            Assert.AreEqual(configuration.Topic, "default");
+        }
+
+        [Test]
+        public void Should_return_custom_topic()
+        {
+            var configuration = new PublishConfiguration("default");
+
+            configuration.WithTopic("custom");
+
+            Assert.AreEqual(configuration.Topic, "custom");
+        }
+    }
+}

--- a/Source/EasyNetQ.Tests/Integration/PublishSubscribeTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/PublishSubscribeTests.cs
@@ -1,10 +1,10 @@
 // ReSharper disable InconsistentNaming
 
 using System;
-using System.Text;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using EasyNetQ.Loggers;
-using EasyNetQ.Topology;
 using NUnit.Framework;
 
 namespace EasyNetQ.Tests.Integration
@@ -236,6 +236,48 @@ namespace EasyNetQ.Tests.Integration
             publishBus.Dispose();
             subscribeBus1.Dispose();
             subscribeBus2.Dispose();
+        }
+
+        // The test sends multiple messages with different priorities and expects that messages with higher priority will be received first.
+        [Test, Explicit("Needs a Rabbit instance on localhost to work")]
+        public void Should_respect_message_priority()
+        {
+            var testLocalBus = RabbitHutch.CreateBus("host=localhost;prefetchcount=1");
+            const int eachPriorityNumber = 20;
+            const int totalNumber = eachPriorityNumber * 3;
+            var expected = new List<string>();
+            expected.AddRange(Enumerable.Repeat("2", eachPriorityNumber));
+            expected.AddRange(Enumerable.Repeat("1", eachPriorityNumber));
+            expected.AddRange(Enumerable.Repeat("0", eachPriorityNumber));
+
+            using (testLocalBus.Subscribe<MyMessage>("messagePriorityTest", message => { }, c => c.WithMaxPriority(10)))
+            {
+                // Create the queue at the very first run
+            }
+
+            for (int i = 0; i < eachPriorityNumber; i++)
+            {
+                testLocalBus.Publish(new MyMessage { Text = "0" }, x => x.WithPriority(0));
+                testLocalBus.Publish(new MyMessage { Text = "1" }, x => x.WithPriority(1));
+                testLocalBus.Publish(new MyMessage { Text = "2" }, x => x.WithPriority(2));
+            }
+
+            var autoResetEvent = new AutoResetEvent(false);
+            var received = new List<string>();
+
+            testLocalBus.Subscribe<MyMessage>("messagePriorityTest", message =>
+            {
+                received.Add(message.Text);
+                if (received.Count == totalNumber)
+                    autoResetEvent.Set();
+            }, c => c.WithMaxPriority(10));
+
+            var done = autoResetEvent.WaitOne(1000);
+
+            Assert.IsTrue(done);
+            CollectionAssert.AreEqual(received, expected);
+
+            testLocalBus.Dispose();
         }
     }
 }

--- a/Source/EasyNetQ/EasyNetQ.projitems
+++ b/Source/EasyNetQ/EasyNetQ.projitems
@@ -73,6 +73,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Events\ReturnedMessageEvent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Events\StoppedConsumingEvent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FluentConfiguration\IPublishConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FluentConfiguration\ISubscriptionConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IAdvancedBus.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IBus.cs" />

--- a/Source/EasyNetQ/FluentConfiguration/IPublishConfiguration.cs
+++ b/Source/EasyNetQ/FluentConfiguration/IPublishConfiguration.cs
@@ -1,0 +1,74 @@
+﻿namespace EasyNetQ.FluentConfiguration
+{
+    /// <summary>
+    /// Allows publish configuration to be fluently extended without adding overloads to IBus
+    /// 
+    /// e.g.
+    /// x => x.WithTopic("*.brighton").WithPriority(2)
+    /// </summary>
+    public interface IPublishConfiguration
+    {
+        /// <summary>
+        /// Sets a priority of the message
+        /// </summary>
+        /// <param name="priority">The priority to set</param>
+        /// <returns>IPublishConfiguration</returns>
+        IPublishConfiguration WithPriority(byte priority);
+
+        /// <summary>
+        /// Sets a topic for the message
+        /// </summary>
+        /// <param name="topic">The topic to set</param>
+        /// <returns>IPublishConfiguration</returns>
+        IPublishConfiguration WithTopic(string topic);
+
+        /// <summary>
+        /// Sets a TTL for the message
+        /// </summary>
+        /// <param name="expires">The TTL to set in milliseconds</param>
+        /// <returns>IPublishConfiguration</returns>
+        IPublishConfiguration WithExpires(int expires);
+    }
+
+    public class PublishConfiguration : IPublishConfiguration
+    {
+        private readonly string defaultTopic;
+
+        public PublishConfiguration(string defaultTopic)
+        {
+            Preconditions.CheckNotNull(defaultTopic, "defaultTopic");
+
+            this.defaultTopic = defaultTopic;
+        }
+
+        public IPublishConfiguration WithPriority(byte priority)
+        {
+            Priority = priority;
+            return this;
+        }
+
+        public IPublishConfiguration WithTopic(string topic)
+        {
+            Topic = topic;
+            return this;
+        }
+
+        public IPublishConfiguration WithExpires(int expires)
+        {
+            Expires = expires;
+            return this;
+        }
+
+        public byte? Priority { get; private set; }
+
+        private string topic;
+
+        public string Topic
+        {
+            get { return topic ?? defaultTopic; }
+            private set { topic = value; }
+        }
+
+        public int? Expires { get; private set; }
+    }
+}

--- a/Source/EasyNetQ/FluentConfiguration/ISubscriptionConfiguration.cs
+++ b/Source/EasyNetQ/FluentConfiguration/ISubscriptionConfiguration.cs
@@ -62,6 +62,12 @@ namespace EasyNetQ.FluentConfiguration
         /// </summary>
         /// <returns></returns>
         ISubscriptionConfiguration AsExclusive();
+
+        /// <summary>
+        /// Configures the queue's maxPriority
+        /// </summary>
+        /// <returns></returns>
+        ISubscriptionConfiguration WithMaxPriority(byte priority);
     }
 
     public class SubscriptionConfiguration : ISubscriptionConfiguration
@@ -74,7 +80,8 @@ namespace EasyNetQ.FluentConfiguration
         public int? Expires { get; private set; }
 
         public bool IsExclusive { get; private set; }
-         
+        public byte? MaxPriority { get; private set; }
+
         public SubscriptionConfiguration(ushort defaultPrefetchCount)
         {
             Topics = new List<string>();
@@ -124,6 +131,12 @@ namespace EasyNetQ.FluentConfiguration
         public ISubscriptionConfiguration AsExclusive()
         {
             IsExclusive = true;
+            return this;
+        }
+
+        public ISubscriptionConfiguration WithMaxPriority(byte priority)
+        {
+            MaxPriority = priority;
             return this;
         }
     }

--- a/Source/EasyNetQ/IBus.cs
+++ b/Source/EasyNetQ/IBus.cs
@@ -19,6 +19,16 @@ namespace EasyNetQ
         void Publish<T>(T message) where T : class;
 
         /// <summary>
+        /// Publishes a message.
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="message">The message to publish</param>
+        /// <param name="configure">
+        /// Fluent configuration e.g. x => x.WithTopic("*.brighton").WithPriority(2)
+        /// </param>
+        void Publish<T>(T message, Action<IPublishConfiguration> configure) where T : class;
+
+        /// <summary>
         /// Publishes a message with a topic
         /// </summary>
         /// <typeparam name="T">The message type</typeparam>
@@ -35,6 +45,19 @@ namespace EasyNetQ
         /// <param name="message">The message to publish</param>
         /// <returns></returns>
         Task PublishAsync<T>(T message) where T : class;
+
+        /// <summary>
+        /// Publishes a message.
+        /// When used with publisher confirms the task completes when the publish is confirmed.
+        /// Task will throw an exception if the confirm is NACK'd or times out.
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="message">The message to publish</param>
+        /// <param name="configure">
+        /// Fluent configuration e.g. x => x.WithTopic("*.brighton").WithPriority(2)
+        /// </param>
+        /// <returns></returns>
+        Task PublishAsync<T>(T message, Action<IPublishConfiguration> configure) where T : class;
 
         /// <summary>
         /// Publishes a message with a topic.

--- a/Source/EasyNetQ/RabbitBus.cs
+++ b/Source/EasyNetQ/RabbitBus.cs
@@ -55,6 +55,18 @@ namespace EasyNetQ
         {
             Preconditions.CheckNotNull(message, "message");
             Preconditions.CheckNotNull(topic, "topic");
+
+            Publish(message, c => c.WithTopic(topic));
+        }
+
+        public virtual void Publish<T>(T message, Action<IPublishConfiguration> configure) where T : class
+        {
+            Preconditions.CheckNotNull(message, "message");
+            Preconditions.CheckNotNull(configure, "configure");
+
+            var configuration = new PublishConfiguration(conventions.TopicNamingConvention(typeof(T)));
+            configure(configuration);
+
             var messageType = typeof(T);
             var easyNetQMessage = new Message<T>(message)
             {
@@ -63,8 +75,13 @@ namespace EasyNetQ
                     DeliveryMode = messageDeliveryModeStrategy.GetDeliveryMode(messageType)
                 }
             };
+            if (configuration.Priority != null)
+                easyNetQMessage.Properties.Priority = configuration.Priority.Value;
+            if (configuration.Expires != null)
+                easyNetQMessage.Properties.Expiration = configuration.Expires.ToString();
+
             var exchange = publishExchangeDeclareStrategy.DeclareExchange(advancedBus, messageType, ExchangeType.Topic);
-            advancedBus.Publish(exchange, topic, false, easyNetQMessage); 
+            advancedBus.Publish(exchange, configuration.Topic, false, easyNetQMessage);
         }
 
         public virtual Task PublishAsync<T>(T message) where T : class
@@ -74,11 +91,23 @@ namespace EasyNetQ
             return PublishAsync(message, conventions.TopicNamingConvention(typeof(T)));
         }
 
-        public virtual async Task PublishAsync<T>(T message, string topic) where T : class
+        public virtual Task PublishAsync<T>(T message, string topic) where T : class
         {
             Preconditions.CheckNotNull(message, "message");
             Preconditions.CheckNotNull(topic, "topic");
-            var messageType = typeof (T);
+
+            return PublishAsync(message, c => c.WithTopic(topic));
+        }
+
+        public virtual async Task PublishAsync<T>(T message, Action<IPublishConfiguration> configure) where T : class
+        {
+            Preconditions.CheckNotNull(message, "message");
+            Preconditions.CheckNotNull(configure, "configure");
+
+            var configuration = new PublishConfiguration(conventions.TopicNamingConvention(typeof(T)));
+            configure(configuration);
+
+            var messageType = typeof(T);
             var easyNetQMessage = new Message<T>(message)
             {
                 Properties =
@@ -86,8 +115,13 @@ namespace EasyNetQ
                     DeliveryMode = messageDeliveryModeStrategy.GetDeliveryMode(messageType)
                 }
             };
+            if (configuration.Priority != null)
+                easyNetQMessage.Properties.Priority = configuration.Priority.Value;
+            if (configuration.Expires != null)
+                easyNetQMessage.Properties.Expiration = configuration.Expires.ToString();
+
             var exchange = await publishExchangeDeclareStrategy.DeclareExchangeAsync(advancedBus, messageType, ExchangeType.Topic).ConfigureAwait(false);
-            await advancedBus.PublishAsync(exchange, topic, false, easyNetQMessage).ConfigureAwait(false); 
+            await advancedBus.PublishAsync(exchange, configuration.Topic, false, easyNetQMessage).ConfigureAwait(false);
         }
 
         public virtual ISubscriptionResult Subscribe<T>(string subscriptionId, Action<T> onMessage) where T : class

--- a/Source/EasyNetQ/RabbitBus.cs
+++ b/Source/EasyNetQ/RabbitBus.cs
@@ -155,7 +155,7 @@ namespace EasyNetQ
             var queueName = conventions.QueueNamingConvention(typeof(T), subscriptionId);
             var exchangeName = conventions.ExchangeNamingConvention(typeof(T));
 
-            var queue = advancedBus.QueueDeclare(queueName, autoDelete: configuration.AutoDelete, expires: configuration.Expires);
+            var queue = advancedBus.QueueDeclare(queueName, autoDelete: configuration.AutoDelete, expires: configuration.Expires, maxPriority: configuration.MaxPriority);
             var exchange = advancedBus.ExchangeDeclare(exchangeName, ExchangeType.Topic);
 
             foreach (var topic in configuration.Topics.DefaultIfEmpty("#"))

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 [assembly: CLSCompliant(false)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
+// 0.59.0.0 Support of priority queues to IBus publish methods
 // 0.58.0.0 added IErrorMessageSerializer and 2 implementations (UTF8 and Base64) 
 // 0.57.2.0 Removed from the hosepipe library the useless dependency on easynetq management client
 // 0.57.1.0 Fix hosepipe usage description to describe the option `x`: the get (noack)

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,7 +2,7 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.58.0.0")]
+[assembly: AssemblyVersion("0.59.0.0")]
 [assembly: CLSCompliant(false)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.


### PR DESCRIPTION
Add support of [priority queues](https://www.rabbitmq.com/priority.html) to `IBus`.  Fix #494.

A failing integration test was added in ba961e7.  The test sends multiple messages with different priorities and expects that messages with higher priority will be received first.  Of course, the test doesn't actually set priorities in this commit but it does it in the final version.

A `priority` parameter was added  to `Publish` method of `IBus` in 90578e1 .

A `MaxPriority` property was added  to `SubscriptionConfiguration` in a63a4c8 .