### PR TITLE
Added support for the new properties in ScheduleMe properties in the …

### DIFF
--- a/DatabaseScripts/EasyNetQ.Scheduler/mssql/CreateWorkTables.sql
+++ b/DatabaseScripts/EasyNetQ.Scheduler/mssql/CreateWorkTables.sql
@@ -4,11 +4,16 @@ SET QUOTED_IDENTIFIER ON
 GO
 
 CREATE TABLE [dbo].[WorkItems] (
-    [WorkItemID]   INT             IDENTITY (1, 1) NOT NULL,
-    [BindingKey]   NVARCHAR (1000) NOT NULL,
+    [WorkItemID]		INT IDENTITY (1, 1) NOT NULL,
+    [BindingKey]		NVARCHAR (1000) NOT NULL,
     [CancellationKey]   NVARCHAR (255) NULL,
-    [InnerMessage] VARBINARY (MAX) NOT NULL,
-    [TextData]     NVARCHAR (MAX)  NULL
+    [InnerMessage]		VARBINARY(MAX) NOT NULL,
+    [TextData]			NVARCHAR (MAX)  NULL,
+	[InstanceName]		NVARCHAR (100) NOT NULL default(''),
+	[Exchange]			NVARCHAR (256) NULL,
+	[ExchangeType]		NVARCHAR (16) NULL,
+	[RoutingKey]		NVARCHAR (256) NULL,
+	[MessageProperties] NVARCHAR (max) NULL
 );
 
 GO
@@ -35,7 +40,12 @@ GO
 
 CREATE NONCLUSTERED INDEX [IX_workItems_cancellationKey] 
 ON [dbo].[WorkItems] 
-	([CancellationKey] ASC)
+	([InstanceName], [CancellationKey] ASC)
+WITH (PAD_INDEX  = OFF, STATISTICS_NORECOMPUTE  = OFF, SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS  = ON, ALLOW_PAGE_LOCKS  = ON)
+
+CREATE NONCLUSTERED INDEX [IX_workItems_instanceName] 
+ON [dbo].[WorkItems] 
+	([InstanceName], [WorkItemID] ASC)
 WITH (PAD_INDEX  = OFF, STATISTICS_NORECOMPUTE  = OFF, SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS  = ON, ALLOW_PAGE_LOCKS  = ON)
 
 CREATE NONCLUSTERED INDEX [IX_workItemStatus_purgeDate] 

--- a/DatabaseScripts/EasyNetQ.Scheduler/mssql/uspAddNewMessageToSchedule.sql
+++ b/DatabaseScripts/EasyNetQ.Scheduler/mssql/uspAddNewMessageToSchedule.sql
@@ -12,20 +12,38 @@ GO
 
 PRINT 'Creating procedure [dbo].[uspAddNewMessageToScheduler]'
 GO
-
 CREATE PROCEDURE [dbo].[uspAddNewMessageToScheduler] 
 	@WakeTime DATETIME,
 	@BindingKey NVARCHAR(1000),
-	@CancellationKey NVARCHAR(255) = NULL,
-	@Message VARBINARY(MAX)
+	@Message VARBINARY(MAX),
+	@CancellationKey NVARCHAR(256) = null,
+	@Exchange NVARCHAR(256) = null,
+	@ExchangeType NVARCHAR(16) = null,
+	@RoutingKey NVARCHAR(256) = null,
+	@MessageProperties NVARCHAR(max) = null,
+	@InstanceName NVARCHAR(100) = ''
 AS
-
 DECLARE @NewID INT
-
 BEGIN TRANSACTION
-
-INSERT INTO WorkItems (BindingKey, CancellationKey, InnerMessage)
-VALUES (@BindingKey, @CancellationKey, @Message)
+INSERT INTO WorkItems (
+	BindingKey, 
+	InnerMessage, 
+	CancellationKey,
+	Exchange,
+	ExchangeType,
+	RoutingKey,
+	MessageProperties,
+	InstanceName
+) VALUES (
+	@BindingKey, 
+	@Message, 
+	@CancellationKey,
+	@Exchange,
+	@ExchangeType,
+	@RoutingKey,
+	@MessageProperties,
+	@InstanceName
+)
 -- get the ID of the inserted record for use in the child table
 SELECT @NewID = SCOPE_IDENTITY()
 IF @@ERROR > 0
@@ -44,3 +62,4 @@ ELSE
 				 COMMIT TRANSACTION
 			END 
 	END
+

--- a/DatabaseScripts/EasyNetQ.Scheduler/mssql/uspGetNextBatchOfMessages.sql
+++ b/DatabaseScripts/EasyNetQ.Scheduler/mssql/uspGetNextBatchOfMessages.sql
@@ -16,31 +16,42 @@ GO
 CREATE PROCEDURE [dbo].[uspGetNextBatchOfMessages]
  @rows INT = 1000, 
  @status TINYINT = 0,
- @WakeTime DATETIME
-
+ @WakeTime DATETIME,
+ @InstanceName nvarchar(100) = ''
 AS
-
 -- NB: WITH statements require a ';' on the statement immediately previous
 BEGIN TRANSACTION;
-
-
 -- Uses a CTE to allow ORDER BY WakeTime, and to throttle by @rows
 -- (because you cannot ORDER BY an UPDATE statement)
 WITH Results as
 (
-SELECT TOP (@rows) WorkItemID, WakeTime 
-FROM WorkItemStatus ws with (UPDLOCK)
-WHERE ws.Status = @status and ws.Waketime <= @WakeTime
-ORDER BY ws.WakeTime ASC
+	SELECT TOP (@rows) ws.WorkItemID, ws.WakeTime 
+	FROM [dbo].WorkItemStatus ws with (UPDLOCK)
+	JOIN [dbo].WorkItems wi on wi.WorkItemId = ws.WorkItemId
+	WHERE ws.Status = @status 
+		and ws.Waketime <= @WakeTime
+		and wi.InstanceName = @InstanceName
+	ORDER BY ws.WakeTime ASC
 )
 -- Performs the UPDATE and OUTPUTs the INSERTED. fields to the calling app
-UPDATE WorkItemStatus
-SET Status = 2
-OUTPUT INSERTED.WorkItemID, 2 as Status, INSERTED.WakeTime, wi.BindingKey, wi.InnerMessage
+UPDATE 
+	[dbo].WorkItemStatus 
+	SET Status = 2
+OUTPUT 
+	INSERTED.WorkItemID as WorkItemId, 
+	2 as Status, 
+	INSERTED.WakeTime as WakeTime, 
+	wi.BindingKey as BindingKey, 
+	wi.InnerMessage as InnerMessage,
+	wi.CancellationKey as CancellationKey,
+	wi.Exchange as Exchange,
+	wi.ExchangeType as ExchangeType,
+	wi.RoutingKey as RoutingKey,
+	wi.MessageProperties as MessageProperties
 FROM WorkItemStatus ws
-INNER JOIN Results r       -- this JOIN filters our UPDATE to the @rows SELECTed
+	INNER JOIN Results r       -- this JOIN filters our UPDATE to the @rows SELECTed
 ON r.WorkItemID = ws.WorkItemID
-INNER JOIN WorkItems wi    -- this JOIN is purely to allow OUTPUT of Bindingkey and InnerMessage
+	INNER JOIN WorkItems wi    -- this JOIN is purely to allow OUTPUT of Bindingkey and InnerMessage
 ON ws.WorkItemID = wi.WorkItemID
 
 IF @@ERROR > 0 

--- a/Source/EasyNetQ.Scheduler/EasyNetQ.Scheduler.csproj
+++ b/Source/EasyNetQ.Scheduler/EasyNetQ.Scheduler.csproj
@@ -42,6 +42,10 @@
       <HintPath>..\packages\log4net.2.0.0\lib\net40-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />

--- a/Source/EasyNetQ.Scheduler/ScheduleRepository.cs
+++ b/Source/EasyNetQ.Scheduler/ScheduleRepository.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.Data.Common;
 using System.Threading;
 using EasyNetQ.SystemMessages;
+using Newtonsoft.Json;
 
 namespace EasyNetQ.Scheduler
 {
@@ -36,6 +37,11 @@ namespace EasyNetQ.Scheduler
                 AddParameter(command, dialect.BindingKeyParameterName, scheduleMe.BindingKey, DbType.String);
                 AddParameter(command, dialect.CancellationKeyParameterName, scheduleMe.CancellationKey, DbType.String);
                 AddParameter(command, dialect.MessageParameterName, scheduleMe.InnerMessage, DbType.Binary);
+                AddParameter(command, dialect.ExchangeParameterName, scheduleMe.Exchange, DbType.String);
+                AddParameter(command, dialect.ExchangeTypeParameterName, scheduleMe.ExchangeType, DbType.String);
+                AddParameter(command, dialect.RoutingKeyParameterName, scheduleMe.RoutingKey, DbType.String);
+                AddParameter(command, dialect.MessagePropertiesParameterName, SerializeToString(scheduleMe.MessageProperties), DbType.String);
+                AddParameter(command, dialect.InstanceNameParameterName, configuration.InstanceName, DbType.String);
 
                 command.ExecuteNonQuery();
             });
@@ -60,9 +66,11 @@ namespace EasyNetQ.Scheduler
 
             WithStoredProcedureCommand(dialect.SelectProcedureName, command =>
             {
+                var dateTime = now();
                 AddParameter(command, dialect.RowsParameterName, configuration.MaximumScheduleMessagesToReturn, DbType.Int32);
                 AddParameter(command, dialect.StatusParameterName, 0, DbType.Int16);
-                AddParameter(command, dialect.WakeTimeParameterName, now(), DbType.DateTime);
+                AddParameter(command, dialect.WakeTimeParameterName, dateTime, DbType.DateTime);
+                AddParameter(command, dialect.InstanceNameParameterName, configuration.InstanceName ?? "", DbType.String);
 
                 using (var reader = command.ExecuteReader())
                 {
@@ -70,12 +78,17 @@ namespace EasyNetQ.Scheduler
                     {
                         scheduledMessages.Add(new ScheduleMe
                         {
-                            WakeTime = reader.GetDateTime(2),
-                            BindingKey = reader.GetString(3),
-                            InnerMessage = (byte[])reader.GetValue(4)
+                            WakeTime = (DateTime) reader["WakeTime"],
+                            BindingKey = reader["BindingKey"].ToString(),
+                            InnerMessage = (byte[])reader["InnerMessage"],
+                            CancellationKey = reader["CancellationKey"].ToString(),
+                            Exchange = reader["Exchange"].ToString(),
+                            ExchangeType = reader["ExchangeType"].ToString(),
+                            RoutingKey = reader["RoutingKey"].ToString(),
+                            MessageProperties = DeserializeToMessageProperties(reader["MessageProperties"].ToString()),
                         });
 
-                        scheduleMessageIds.Add(reader.GetInt32(0));
+                        scheduleMessageIds.Add((int)reader["WorkItemId"]);
                     }
                 }
             });
@@ -103,6 +116,21 @@ namespace EasyNetQ.Scheduler
                     }
                 })
             );
+        }
+
+        private static MessageProperties DeserializeToMessageProperties(string properties)
+        {
+            // backwards compatibility with older messages
+            if (string.IsNullOrWhiteSpace(properties))
+                return null;
+            return JsonConvert.DeserializeObject<MessageProperties>(properties);
+        }
+
+        private static string SerializeToString(MessageProperties properties)
+        {
+            if (properties == null)
+                throw new ArgumentNullException("properties");
+            return JsonConvert.SerializeObject(properties);
         }
 
         public void Purge()

--- a/Source/EasyNetQ.Scheduler/ScheduleRepositoryConfiguration.cs
+++ b/Source/EasyNetQ.Scheduler/ScheduleRepositoryConfiguration.cs
@@ -4,9 +4,15 @@ namespace EasyNetQ.Scheduler
 {
     public class ScheduleRepositoryConfiguration : ConfigurationBase
     {
+        public ScheduleRepositoryConfiguration()
+        {
+            MaximumScheduleMessagesToReturn = 100;
+        }
+
         private const string connectionStringKey = "scheduleDb";
         private const string connectionStringNameKey = "scheduleDbConnectionStringName";
         private const string schemaNameKey = "SchemaName";
+        private const string instanceNameKey = "InstanceName";
 
         public string ProviderName { get; set; }
         public string ConnectionString { get; set; }
@@ -21,6 +27,11 @@ namespace EasyNetQ.Scheduler
         /// </summary>
         public int PurgeDelayDays { get; set; }
 
+        /// <summary>
+        /// Allows to create a 'discriminator' for different environment (like a VHOST for rabbitMQ, or to use the same database for different branches, environments or developer machines)
+        /// </summary>
+        public string InstanceName { get; set; }
+
         public static ScheduleRepositoryConfiguration FromConfigFile()
         {
             var connectionStringName = ConfigurationManager.AppSettings[connectionStringNameKey] ?? connectionStringKey;
@@ -33,8 +44,10 @@ namespace EasyNetQ.Scheduler
                 PurgeBatchSize = GetShortAppSetting("PurgeBatchSize"),
                 PurgeDelayDays = GetIntAppSetting("PurgeDelayDays"),
                 MaximumScheduleMessagesToReturn = GetIntAppSetting("MaximumScheduleMessagesToReturn"),
-                SchemaName = ConfigurationManager.AppSettings[schemaNameKey]
+                SchemaName = ConfigurationManager.AppSettings[schemaNameKey],
+                InstanceName = ConfigurationManager.AppSettings[instanceNameKey] ?? ""
             };
         }
+
     }
 }

--- a/Source/EasyNetQ.Scheduler/SqlDialect.cs
+++ b/Source/EasyNetQ.Scheduler/SqlDialect.cs
@@ -19,6 +19,11 @@ namespace EasyNetQ.Scheduler
         string RowsParameterName { get; }
         string IdParameterName { get; }
         string StatusParameterName { get; }
+        string ExchangeParameterName { get; }
+        string ExchangeTypeParameterName { get; }
+        string RoutingKeyParameterName { get; }
+        string MessagePropertiesParameterName { get; }
+        string InstanceNameParameterName { get; }
     }
 
     public class SqlDialectResolver
@@ -55,6 +60,11 @@ namespace EasyNetQ.Scheduler
             RowsParameterName = "@rows";
             IdParameterName = "@ID";
             StatusParameterName = "@status";
+            InstanceNameParameterName = "@InstanceName";
+            ExchangeParameterName = "@Exchange";
+            ExchangeTypeParameterName = "@ExchangeType";
+            RoutingKeyParameterName = "@RoutingKey";
+            MessagePropertiesParameterName = "@MessageProperties";
         }
 
         public bool IsDialectFor(string providerName)
@@ -75,6 +85,11 @@ namespace EasyNetQ.Scheduler
         public string RowsParameterName { get; private set; }
         public string IdParameterName { get; private set; }
         public string StatusParameterName { get; private set; }
+        public string ExchangeParameterName { get; private set; }
+        public string ExchangeTypeParameterName { get; private set; }
+        public string RoutingKeyParameterName { get; private set; }
+        public string MessagePropertiesParameterName { get; private set; }
+        public string InstanceNameParameterName { get; private set; }
     }
 
     public class PostgreSqlDialect : ISqlDialect
@@ -94,6 +109,11 @@ namespace EasyNetQ.Scheduler
             RowsParameterName = "p_rows";
             IdParameterName = "p_id";
             StatusParameterName = "p_status";
+            InstanceNameParameterName = "p_instanceName";
+            ExchangeParameterName = "p_exchange";
+            ExchangeTypeParameterName = "p_exchangeType";
+            RoutingKeyParameterName = "p_routingKey";
+            MessagePropertiesParameterName = "p_messageProperties";
         }
 
         public bool IsDialectFor(string providerName)
@@ -116,5 +136,10 @@ namespace EasyNetQ.Scheduler
         public string RowsParameterName { get; private set; }
         public string IdParameterName { get; private set; }
         public string StatusParameterName { get; private set; }
+        public string InstanceNameParameterName { get; private set; }
+        public string ExchangeParameterName { get; private set; }
+        public string ExchangeTypeParameterName { get; private set; }
+        public string RoutingKeyParameterName { get; private set; }
+        public string MessagePropertiesParameterName { get; private set; }
     }
 }

--- a/Source/EasyNetQ.Scheduler/packages.config
+++ b/Source/EasyNetQ.Scheduler/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.0" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net4" />
   <package id="TopShelf" version="3.1.0" targetFramework="net40" />
 </packages>

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.50.10.0")]
+[assembly: AssemblyVersion("0.50.11.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.50.11.0 Updated Scheduler for MSSQL to support all properties of the ScheduleMe message 
 // 0.50.10.0 Updated RabbitMQ client to 3.5.6 
 // 0.50.9.0 Updated RabbitMQ client to 3.5.5 
 // 0.50.8.0 Allow SubscriptionConfigurationAttribute on class


### PR DESCRIPTION
…MSSQL schedule repository (while maintaining backwards compatibility with the old BindingKey property for now)

Added a try/catch in the PurgeTimerTick as it caused to stop the service in some occasions (deadlock, timeout, temporary connection error, etc)

Added support for an InstanceName for the scheduler, which allows you to create a 'discriminator' for different environments using the same database (like a VHOST for rabbitMQ, to use the same database for different branches, environments or developer machines)

Not sure what the TextData property in the SQL table is supposed to do, but I just left it there (not using it to serialize the message properties)

NOTE: Postgres implementation is not yet updated in this pull