### PR TITLE
added SimpleTypeNameSerializer for better generic typename handling

### DIFF
--- a/Source/EasyNetQ NET45/EasyNetQ NET45.csproj
+++ b/Source/EasyNetQ NET45/EasyNetQ NET45.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Internals\AsyncSemaphore.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Internals\TaskHelpers.cs" />
+    <Compile Include="SimpleTypeNameSerializer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Source/EasyNetQ NET45/SimpleTypeNameSerializer.cs
+++ b/Source/EasyNetQ NET45/SimpleTypeNameSerializer.cs
@@ -1,0 +1,225 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EasyNetQ
+{
+    public class SimpleTypeNameSerializer : ITypeNameSerializer
+    {
+        private readonly ConcurrentDictionary<string, Type> _deserializedTypes = new ConcurrentDictionary<string, Type>();
+        private readonly ConcurrentDictionary<Type, string> _serializedTypes = new ConcurrentDictionary<Type, string>();
+
+        public Type DeSerialize(string typeName)
+        {
+            return _deserializedTypes.GetOrAdd(typeName, SimpleTypeStringParser.Parse);
+        }
+
+        public string Serialize(Type type)
+        {
+            return _serializedTypes.GetOrAdd(type, t =>
+            {
+                var ns = String.Join(".", type.Namespace);
+                var tn = type.Name;
+
+                var typeName = new StringBuilder();
+                typeName.Append(ns).Append(".").Append(tn);
+
+                if (type.GenericTypeArguments.Length > 0)
+                {
+                    typeName.Append("[");
+                    var needSep = false;
+                    foreach (var genericTypeArgument in type.GenericTypeArguments)
+                    {
+                        if (needSep)
+                        {
+                            typeName.Append(", ");
+                        }
+                        typeName.Append("[");
+                        typeName.Append(Serialize(genericTypeArgument));
+                        typeName.Append("]");
+                        needSep = true;
+                    }
+                    typeName.Append("]");
+                }
+
+                typeName.Append(", ").Append(type.Assembly.GetName().Name);
+
+                var ret = typeName.ToString();
+                if (typeName.Length > 255)
+                {
+                    throw new EasyNetQException("The serialized name of type '{0}' exceeds the AMQP " +
+                                                "maximum short string length of 255 characters.", t.Name);
+                }
+                return ret;
+            });
+        }
+
+        #region Type String Parser
+
+        private class SimpleTypeStringParser
+        {
+            private enum Token
+            {
+                BracketLeft,
+                BracketRight,
+                Comma,
+                String,
+                EOT
+            }
+
+            private readonly string _typeString;
+            private int _pos;
+            private Token _token;
+            private string _tokenValue;
+
+            public SimpleTypeStringParser(string typeString)
+            {
+                _typeString = typeString;
+                _pos = 0;
+            }
+
+            public static Type Parse(string typeString)
+            {
+                var parser = new SimpleTypeStringParser(typeString);
+                return parser.Parse();
+            }
+
+            private Type Parse()
+            {
+                ReadNextToken();
+                var ret = ReadType();
+                if (_token != Token.EOT)
+                {
+                    throw new ArgumentException("invalid type string. unexpected input");
+                }
+                return ret;
+            }
+
+            private Type ReadType()
+            {
+                if (_token != Token.String)
+                {
+                    throw new ArgumentException("invalid type string. expecting type string.");
+                }
+
+                var typeName = _tokenValue;
+                var typeArguments = new List<Type>();
+                ReadNextToken();
+
+                if (_token == Token.BracketLeft)
+                {
+                    ReadNextToken(); // read away [
+
+                    do
+                    {
+                        if (_token == Token.Comma)
+                        {
+                            ReadNextToken(); // read away ,
+                        }
+
+                        if (_token != Token.BracketLeft)
+                        {
+                            throw new ArgumentException("invalid type string. expecting [");
+                        }
+
+                        ReadNextToken(); // read away [
+                        typeArguments.Add(ReadType());
+
+                        if (_token != Token.BracketRight)
+                        {
+                            throw new ArgumentException("invalid type string. expecting ]");
+                        }
+                        ReadNextToken(); // read away ]
+                    } while (_token == Token.Comma);
+
+                    if (_token != Token.BracketRight)
+                    {
+                        throw new ArgumentException("invalid type string. expecting ]");
+                    }
+                    ReadNextToken(); // read away ]
+                }
+                if (_token != Token.Comma)
+                {
+                    throw new ArgumentException("invalid type string. expecting ,");
+                }
+                ReadNextToken(); // read away ,
+                if (_token != Token.String)
+                {
+                    throw new ArgumentException("invalid type string. expecting assembly string");
+                }
+                var assemblyName = _tokenValue;
+                ReadNextToken(); // read away string
+                var type = Type.GetType(typeName + ", " + assemblyName);
+                if (typeArguments.Count > 0)
+                {
+                    type = type.MakeGenericType(typeArguments.ToArray());
+                }
+                return type;
+            }
+
+            private Token ReadNextToken()
+            {
+                _token = ReadNextTokenHelper();
+                return _token;
+            }
+
+            private Token ReadNextTokenHelper()
+            {
+                if (_pos >= _typeString.Length)
+                {
+                    return Token.EOT;
+                }
+
+                while (Char.IsWhiteSpace(_typeString[_pos]))
+                {
+                    ++_pos;
+                }
+
+                var ch = _typeString[_pos];
+
+                if (ch == '[')
+                {
+                    ++_pos;
+                    return Token.BracketLeft;
+                }
+                if (ch == ']')
+                {
+                    ++_pos;
+                    return Token.BracketRight;
+                }
+                if (ch == ',')
+                {
+                    ++_pos;
+                    return Token.Comma;
+                }
+
+                _tokenValue = ReadString();
+                return Token.String;
+            }
+
+            private string ReadString()
+            {
+                var ret = "";
+                while (_pos < _typeString.Length)
+                {
+                    var ch = _typeString[_pos];
+                    if (Char.IsLetterOrDigit(ch) ||
+                        ch == '.' || ch == '`')
+                    {
+                        ret += ch;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                    ++_pos;
+                }
+
+                return ret;
+            }
+        }
+
+        #endregion Type String Parser
+    }
+}

--- a/Source/EasyNetQ NET45/SimpleTypeNameSerializer.cs
+++ b/Source/EasyNetQ NET45/SimpleTypeNameSerializer.cs
@@ -12,7 +12,14 @@ namespace EasyNetQ
 
         public Type DeSerialize(string typeName)
         {
-            return _deserializedTypes.GetOrAdd(typeName, SimpleTypeStringParser.Parse);
+            try
+            {
+                return _deserializedTypes.GetOrAdd(typeName, SimpleTypeStringParser.Parse);
+            }
+            catch (ArgumentNullException ex)
+            {
+                throw new ArgumentException(ex.Message, ex);
+            }
         }
 
         public string Serialize(Type type)
@@ -91,7 +98,7 @@ namespace EasyNetQ
                 var ret = ReadType();
                 if (_token != Token.EOT)
                 {
-                    throw new ArgumentException("invalid type string. unexpected input");
+                    throw new EasyNetQException("invalid type string. unexpected input");
                 }
                 return ret;
             }
@@ -100,7 +107,7 @@ namespace EasyNetQ
             {
                 if (_token != Token.String)
                 {
-                    throw new ArgumentException("invalid type string. expecting type string.");
+                    throw new EasyNetQException("invalid type string. expecting type string.");
                 }
 
                 var typeName = _tokenValue;
@@ -120,7 +127,7 @@ namespace EasyNetQ
 
                         if (_token != Token.BracketLeft)
                         {
-                            throw new ArgumentException("invalid type string. expecting [");
+                            throw new EasyNetQException("invalid type string. expecting [");
                         }
 
                         ReadNextToken(); // read away [
@@ -128,25 +135,25 @@ namespace EasyNetQ
 
                         if (_token != Token.BracketRight)
                         {
-                            throw new ArgumentException("invalid type string. expecting ]");
+                            throw new EasyNetQException("invalid type string. expecting ]");
                         }
                         ReadNextToken(); // read away ]
                     } while (_token == Token.Comma);
 
                     if (_token != Token.BracketRight)
                     {
-                        throw new ArgumentException("invalid type string. expecting ]");
+                        throw new EasyNetQException("invalid type string. expecting ]");
                     }
                     ReadNextToken(); // read away ]
                 }
                 if (_token != Token.Comma)
                 {
-                    throw new ArgumentException("invalid type string. expecting ,");
+                    throw new EasyNetQException("invalid type string. expecting ,");
                 }
                 ReadNextToken(); // read away ,
                 if (_token != Token.String)
                 {
-                    throw new ArgumentException("invalid type string. expecting assembly string");
+                    throw new EasyNetQException("invalid type string. expecting assembly string");
                 }
                 var assemblyName = _tokenValue;
                 ReadNextToken(); // read away string

--- a/Source/EasyNetQ.Tests.NET45/EasyNetQ.Tests.NET45.csproj
+++ b/Source/EasyNetQ.Tests.NET45/EasyNetQ.Tests.NET45.csproj
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5F7C2CC2-654D-4A8F-8BAB-031585F03905}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>EasyNetQ.Tests.NET45</RootNamespace>
+    <AssemblyName>EasyNetQ.Tests.NET45</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SimpleTypeNameSerializerTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\EasyNetQ NET45\EasyNetQ NET45.csproj">
+      <Project>{4543da42-9c4d-4895-a174-ba1582331de5}</Project>
+      <Name>EasyNetQ NET45</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\EasyNetQ.Tests\EasyNetQ.Tests.csproj">
+      <Project>{640dec15-3a17-4e85-b38a-cfb379426dc2}</Project>
+      <Name>EasyNetQ.Tests</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Source/EasyNetQ.Tests.NET45/Properties/AssemblyInfo.cs
+++ b/Source/EasyNetQ.Tests.NET45/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("EasyNetQ.Tests.NET45")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("EasyNetQ.Tests.NET45")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("5f7c2cc2-654d-4a8f-8bab-031585f03905")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/EasyNetQ.Tests.NET45/SimpleTypeNameSerializerTests.cs
+++ b/Source/EasyNetQ.Tests.NET45/SimpleTypeNameSerializerTests.cs
@@ -1,23 +1,24 @@
 // ReSharper disable InconsistentNaming
+
 using System;
 using EasyNetQ.Tests.ProducerTests.Very.Long.Namespace.Certainly.Longer.Than.The255.Char.Length.That.RabbitMQ.Likes.That.Will.Certainly.Cause.An.AMQP.Exception.If.We.Dont.Do.Something.About.It.And.Stop.It.From.Happening;
 using NUnit.Framework;
 
-namespace EasyNetQ.Tests
+namespace EasyNetQ.Tests.NET45
 {
     [TestFixture]
-    public class TypeNameSerializerTests
+    public class SimpleTypeNameSerializerTests
     {
-        private const string expectedTypeName = "System.String:mscorlib";
-        private const string expectedCustomTypeName = "EasyNetQ.Tests.SomeRandomClass:EasyNetQ.Tests";
-        private const string expectedCustomGenericTypeName = "EasyNetQ.Tests.SomeRandomGenericClass`1[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]:EasyNetQ.Tests";
+        private const string expectedTypeName = "System.String, mscorlib";
+        private const string expectedCustomTypeName = "EasyNetQ.Tests.NET45.SomeRandomClass, EasyNetQ.Tests.NET45";
+        private const string expectedCustomGenericTypeName = "EasyNetQ.Tests.NET45.SomeRandomGenericClass`1[[System.String, mscorlib]], EasyNetQ.Tests.NET45";
 
         private ITypeNameSerializer typeNameSerializer;
 
         [SetUp]
         public void SetUp()
         {
-            typeNameSerializer = new TypeNameSerializer();
+            typeNameSerializer = new SimpleTypeNameSerializer();
         }
 
         [Test]

--- a/Source/EasyNetQ.Tests.NET45/packages.config
+++ b/Source/EasyNetQ.Tests.NET45/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.3" targetFramework="net45" />
+</packages>

--- a/Source/EasyNetQ.Tests/TypeNameSerializerTests.cs
+++ b/Source/EasyNetQ.Tests/TypeNameSerializerTests.cs
@@ -10,6 +10,7 @@ namespace EasyNetQ.Tests
     {
         const string expectedTypeName = "System.String:mscorlib";
         private const string expectedCustomTypeName = "EasyNetQ.Tests.SomeRandomClass:EasyNetQ.Tests";
+        private const string expectedCustomGenericTypeName = "EasyNetQ.Tests.SomeRandomGenericClass`1[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]:EasyNetQ.Tests";
 
         private ITypeNameSerializer typeNameSerializer;
 
@@ -34,6 +35,13 @@ namespace EasyNetQ.Tests
         }
 
         [Test]
+        public void Should_serialize_a_custom_generic_type()
+        {
+            var typeName = typeNameSerializer.Serialize(typeof(SomeRandomGenericClass<string>));
+            typeName.ShouldEqual(expectedCustomGenericTypeName);
+        }
+
+        [Test]
         public void Should_deserialize_a_type_name()
         {
             var type = typeNameSerializer.DeSerialize(expectedTypeName);
@@ -45,6 +53,13 @@ namespace EasyNetQ.Tests
         {
             var type = typeNameSerializer.DeSerialize(expectedCustomTypeName);
             type.ShouldEqual(typeof(SomeRandomClass));
+        }
+
+        [Test]
+        public void Should_deserialize_a_custom_generic_type()
+        {
+            var type = typeNameSerializer.DeSerialize(expectedCustomGenericTypeName);
+            type.ShouldEqual(typeof(SomeRandomGenericClass<string>));
         }
 
         [Test]
@@ -87,6 +102,10 @@ namespace EasyNetQ.Tests
     public class SomeRandomClass
     {
         
+    }
+
+    public class SomeRandomGenericClass<T>
+    {
     }
 }
 // ReSharper restore InconsistentNaming

--- a/Source/EasyNetQ.sln
+++ b/Source/EasyNetQ.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ NET4", "EasyNetQ NET4\EasyNetQ NET4.csproj", "{B8DEF709-5168-48F1-B8D3-AD44E4A4A22B}"
 EndProject
@@ -97,6 +97,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ.Serilog", "EasyNetQ.Serilog\EasyNetQ.Serilog.csproj", "{01B7E76D-DF00-4F84-8DF4-1B8508FEFEA8}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "EasyNetQ", "EasyNetQ\EasyNetQ.shproj", "{6A038745-6B26-437B-9524-71F9CA2971F4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ.Tests.NET45", "EasyNetQ.Tests.NET45\EasyNetQ.Tests.NET45.csproj", "{5F7C2CC2-654D-4A8F-8BAB-031585F03905}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -205,6 +207,10 @@ Global
 		{01B7E76D-DF00-4F84-8DF4-1B8508FEFEA8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{01B7E76D-DF00-4F84-8DF4-1B8508FEFEA8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{01B7E76D-DF00-4F84-8DF4-1B8508FEFEA8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F7C2CC2-654D-4A8F-8BAB-031585F03905}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F7C2CC2-654D-4A8F-8BAB-031585F03905}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F7C2CC2-654D-4A8F-8BAB-031585F03905}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F7C2CC2-654D-4A8F-8BAB-031585F03905}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Hi,

since I had a problem with queue names of generic types getting too long, I wrote a custom type name serializer. Maybe you find it useful, too.

Example typename:
Shared.Command.ControlServer.Location.ProxyCommandPayload`1[[Shared.Command.Generic.Reflection.ReflectCommandPayload, Shared]], Shared
