### PR TITLE
Fix #448 Process may not exit if handler throws Exception

### DIFF
--- a/Source/EasyNetQ.Tests/ConnectionConfigurationTests.cs
+++ b/Source/EasyNetQ.Tests/ConnectionConfigurationTests.cs
@@ -1,6 +1,9 @@
 ﻿// ReSharper disable InconsistentNaming
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using EasyNetQ.ConnectionString;
 using NUnit.Framework;
 

--- a/Source/EasyNetQ.Tests/Integration/DefaultConsumerErrorStrategyTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/DefaultConsumerErrorStrategyTests.cs
@@ -99,6 +99,46 @@ namespace EasyNetQ.Tests
                 }
             }
         }
+
+        [Test]
+        public void Should_not_reconnect_if_has_been_disposed()
+        {
+            const string originalMessage = "{ Text:\"Hello World\"}";
+            var originalMessageBody = Encoding.UTF8.GetBytes(originalMessage);
+
+            var exception = new Exception("I just threw!");
+
+            var context = new ConsumerExecutionContext(
+                (bytes, properties, arg3) => null,
+                new MessageReceivedInfo("consumertag", 0, false, "orginalExchange", "originalRoutingKey", "queue"),
+                new MessageProperties
+                {
+                    CorrelationId = "123",
+                    AppId = "456"
+                },
+                originalMessageBody,
+                MockRepository.GenerateStub<IBasicConsumer>()
+                );
+
+            var logger = MockRepository.GenerateMock<IEasyNetQLogger>();
+            connectionFactory = MockRepository.GenerateMock<IConnectionFactory>();
+
+            consumerErrorStrategy = new DefaultConsumerErrorStrategy(
+                connectionFactory,
+                MockRepository.GenerateStub<ISerializer>(),
+                logger,
+                MockRepository.GenerateStub<IConventions>(),
+                MockRepository.GenerateStub<ITypeNameSerializer>());
+
+            consumerErrorStrategy.Dispose();
+
+            var ackStrategy = consumerErrorStrategy.HandleConsumerError(context, exception);
+
+            connectionFactory.AssertWasNotCalled(f => f.CreateConnection());
+            logger.AssertWasCalled(l => l.ErrorWrite(Arg.Text.Contains("DefaultConsumerErrorStrategy was already disposed"), Arg<Object>.Is.Anything));
+
+            Assert.AreEqual(AckStrategies.NackWithRequeue, ackStrategy);
+        }
     }
 }
 

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.53.1.0")]
+[assembly: AssemblyVersion("0.53.2.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.53.2.0 Bug fix, process did not always exit if bus disposal caused message handlers to error
 // 0.53.1.0 Removed separate test applications in favor of a single task runner
 // 0.53.0.0 fix expires default behavior of subscription configuration attribute
 // 0.52.0.0 Added synchronous callback on Consume(byte[]) methods of the advaced api


### PR DESCRIPTION
For #448 Process will not always exit when handler throws error
Fix #448 Process hang when handler throws and bump version.cs
Refine fix #448

Clarify in unit test, what is stub (exists only to support the test) and
what is mock (something on which you assert expectations).

Fix #448 Process may not exit if handler throws

Fix further race conditions in DefaultConsumerErrorStrategy disposal.
Ensure all modifications to the connection variable are within locks.
If Connect() method holds lock, Dispose() will now let it finish making
connection, then Dispose() it.  If Dispose() method holds-then-releases
lock, when Connect() method acquires lock, it checks again if class is
disposing, before establishing a connection.

Refine fix #448 Process may hang if handler throws

Refine fix #448.  Update commit 2127447 to remove lock from Dispose()
method. Since we cannot lock in Dispose() method, compensate in
Connect() method, to ensure that any connections created (due to race
condition) after Dispose() has run, are always disposed.

Allow config SslOptions from string via CreateBus

Adds an SslOptionsStringParser to allow SslOptions to be configured from
a string (eg drawn from a config file) rather than having to hand-craft
SslOption and ConnectionConfiguration objects.
Add RabbitHutch.CreateBus(...) overloads with sslOptionsString
parameter.
