### PR TITLE
Fix #512 Process may hang due to extra AMQP connection

### DIFF
--- a/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
+++ b/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Internals\AsyncSemaphoreTest.cs" />
     <Compile Include="MessageFactoryTests.cs" />
     <Compile Include="PersistentChannelTests\When_a_ConnectionCreatedEvent_is_published.cs" />
+    <Compile Include="PersistentConnectionTests.cs" />
     <Compile Include="ProducerTests\PublishConfirmationListenerTest.cs" />
     <Compile Include="Scheduling\SchedulingExtensionsTests.cs" />
     <Compile Include="TimeoutStrategyTest.cs" />

--- a/Source/EasyNetQ.Tests/PersistentConnectionTests.cs
+++ b/Source/EasyNetQ.Tests/PersistentConnectionTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using RabbitMQ.Client;
+using Rhino.Mocks;
+
+namespace EasyNetQ.Tests
+{
+    [TestFixture]
+    public class PersistentConnectionTests
+    {
+        [Test]
+        public void If_connects_after_disposal_should_redispose_underlying_connection()
+        {
+            var logger = MockRepository.GenerateMock<IEasyNetQLogger>();
+            var eventBus = MockRepository.GenerateMock<IEventBus>();
+            var connectionFactory = MockRepository.GenerateMock<IConnectionFactory>();
+            var mockConnection = MockRepository.GenerateMock<IConnection>();
+            PersistentConnection mockPersistentConnection = MockRepository.GenerateMock<PersistentConnection>(connectionFactory, logger, eventBus);
+
+            // This test is constructed using small delays, such that the IConnectionFactory will return a connection just _after the IPersistentConnection has been disposed.
+            TimeSpan shimDelay = TimeSpan.FromSeconds(0.5); 
+            connectionFactory.Expect(cf => cf.CreateConnection()).WhenCalled(a =>
+            {
+                Thread.Sleep(shimDelay.Double());
+                a.ReturnValue = mockConnection;
+            }).Repeat.Once();
+
+            Task.Factory.StartNew(() => { mockPersistentConnection.Initialize(); }); // Start the persistent connection attempting to connect.
+
+            Thread.Sleep(shimDelay); // Allow some time for the persistent connection code to try to create a connection.
+
+            // First call to dispose.  Because CreateConnection() is stubbed to delay for shimDelay.Double(), it will not yet have returned a connection.  So when the PersistentConnection is disposed, no underlying IConnection should yet be disposed.
+            mockPersistentConnection.Dispose();
+            mockConnection.AssertWasNotCalled(underlyingConnection => underlyingConnection.Dispose());
+
+            Thread.Sleep(shimDelay.Double()); // Allow time for persistent connection code to _return its connection ...
+
+            // Assert that the connection returned from connectionFactory.CreateConnection() (_after the PersistentConnection was disposed), still gets disposed.
+            mockConnection.AssertWasCalled(latedCreatedUnderlyingConnection => latedCreatedUnderlyingConnection.Dispose());
+
+            // Ensure that PersistentConnection also did not flag (eg to IPersistentChannel) the late-made connection as successful.
+            connectionFactory.AssertWasNotCalled(c => c.Success());
+            // Ensure that PersistentConnection does not retry after was disposed.
+            connectionFactory.AssertWasNotCalled(c => c.Next());
+
+        }
+    }
+}

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.53.2.0")]
+[assembly: AssemblyVersion("0.53.3.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.53.3.0 Bug fix, process did not always exit if persistentconnection reconnected after disposal
 // 0.53.2.0 Bug fix, process did not always exit if bus disposal caused message handlers to error
 // 0.53.1.0 Removed separate test applications in favor of a single task runner
 // 0.53.0.0 fix expires default behavior of subscription configuration attribute


### PR DESCRIPTION
Fix #512 Process may hang due to PersistentConnection having the
potential to create a further AMQP connection, after it has been
disposed.