### PR TITLE
Adds support for LightInject DI

### DIFF
--- a/Build/EasyNetQ.proj
+++ b/Build/EasyNetQ.proj
@@ -18,7 +18,7 @@
 
     <Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Targets"/>
 
-    <Target Name="Default" DependsOnTargets="Version; Build; Test; Merge; Package; PackageDiWindsor; PackageDiNinject; PackageDiStructureMap; PackageDiAutofac; PackageSerilog" />
+    <Target Name="Default" DependsOnTargets="Version; Build; Test; Merge; Package; PackageDiWindsor; PackageDiNinject; PackageDILightInject; PackageDiStructureMap; PackageDiAutofac; PackageSerilog" />
 
     <Target Name="Version">
         <FileUpdate Files="$(Source)\Version.cs"
@@ -181,6 +181,36 @@
         Value="%(AsmInfo.Version)" />
 
     <Exec WorkingDirectory="$(Package)\EasyNetQ.DI.Ninject" Command="$(NuGet)\NuGet.exe pack $(Package)\EasyNetQ.DI.Ninject\EasyNetQ.DI.Ninject.nuspec" />
+
+  </Target>
+
+  <Target Name="PackageDiLightInject" DependsOnTargets="Build">
+
+    <ItemGroup>
+      <FilesToDelete Include="$(Package)\EasyNetQ.DI.LightInject\*.nupkg"  />
+    </ItemGroup>
+
+    <Delete Files="@(FilesToDelete)" />
+
+    <Copy SourceFiles="$(Source)\EasyNetQ.DI.LightInject\bin\Release\EasyNetQ.DI.LightInject.dll" DestinationFolder="$(Package)\EasyNetQ.DI.LightInject\lib\net45" />
+
+    <GetAssemblyIdentity AssemblyFiles="$(Source)\EasyNetQ.DI.LightInject\bin\Release\EasyNetQ.DI.LightInject.dll">
+      <Output TaskParameter="Assemblies" ItemName="AsmInfo" />
+    </GetAssemblyIdentity>
+
+    <XmlUpdate
+        Namespace="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"
+        XmlFileName="$(Package)\EasyNetQ.DI.LightInject\EasyNetQ.DI.LightInject.nuspec"
+        XPath="/package/metadata/version"
+        Value="%(AsmInfo.Version)" />
+
+    <XmlUpdate
+        Namespace="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"
+        XmlFileName="$(Package)\EasyNetQ.DI.LightInject\EasyNetQ.Di.LightInject.nuspec"
+        XPath="/package/metadata/dependencies/dependency[@id='EasyNetQ']/@version"
+        Value="%(AsmInfo.Version)" />
+
+    <Exec WorkingDirectory="$(Package)\EasyNetQ.DI.LightInject" Command="$(NuGet)\NuGet.exe pack $(Package)\EasyNetQ.DI.LightInject\EasyNetQ.DI.LightInject.nuspec" />
 
   </Target>
 

--- a/Package/EasyNetQ.DI.LightInject/EasyNetQ.DI.LightInject.nuspec
+++ b/Package/EasyNetQ.DI.LightInject/EasyNetQ.DI.LightInject.nuspec
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+    <id>EasyNetQ.DI.LightInject</id>
+    <!-- Version gets updated from EasyNetQ.dll version number during the build's packaging process -->
+    <version>0.53.6.0</version>
+    <title>EasyNetQ.DI.LightInject</title>
+    <authors>Jeff Doolittle, Mike Hadlow</authors>
+    <owners>Mike Hadlow</owners>
+    <licenseUrl>https://github.com/EasyNetQ/EasyNetQ/blob/master/licence.txt</licenseUrl>
+    <projectUrl>https://github.com/EasyNetQ/EasyNetQ/wiki/Using-Alternative-DI-Containers</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/gh-pages/design/logo_design.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>An adaptor to allow EasyNetQ to use LightInject as its internal IoC container</description>
+    <releaseNotes>
+    </releaseNotes>
+    <copyright>Copyright Mike Hadlow 2016</copyright>
+    <tags>RabbitMQ Messaging AMQP REST API LightInject</tags>
+    <dependencies>
+      <dependency id="EasyNetQ" version="0.53.6.0" />
+      <dependency id="LightInject" version="3.0.2.7" />
+    </dependencies>
+  </metadata>
+</package>

--- a/Source/EasyNetQ.DI.LightInject/EasyNetQ.DI.LightInject.csproj
+++ b/Source/EasyNetQ.DI.LightInject/EasyNetQ.DI.LightInject.csproj
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3AD2CD4A-8969-4C2D-8EAA-9FC800585678}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>EasyNetQ.DI</RootNamespace>
+    <AssemblyName>EasyNetQ.DI.LightInject</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="LightInject, Version=3.0.2.7, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\LightInject.3.0.2.7\lib\net45\LightInject.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Version.cs">
+      <Link>Properties\Version.cs</Link>
+    </Compile>
+    <Compile Include="InjectionExtensions.cs" />
+    <Compile Include="LightInjectAdapter.cs" />
+    <Compile Include="LightInjectMessageDispatcher.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\EasyNetQ NET45\EasyNetQ NET45.csproj">
+      <Project>{4543da42-9c4d-4895-a174-ba1582331de5}</Project>
+      <Name>EasyNetQ NET45</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Source/EasyNetQ.DI.LightInject/InjectionExtensions.cs
+++ b/Source/EasyNetQ.DI.LightInject/InjectionExtensions.cs
@@ -1,0 +1,12 @@
+﻿using LightInject;
+
+namespace EasyNetQ.DI
+{
+    public static class InjectionExtensions
+    {
+        public static void RegisterAsEasyNetQContainerFactory(this IServiceContainer container)
+        {
+            RabbitHutch.SetContainerFactory(() => new LightInjectAdapter(container));
+        }
+    }
+}

--- a/Source/EasyNetQ.DI.LightInject/LightInjectAdapter.cs
+++ b/Source/EasyNetQ.DI.LightInject/LightInjectAdapter.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using LightInject;
+
+namespace EasyNetQ.DI
+{    
+    public class LightInjectAdapter : IContainer, IDisposable
+    {
+        private readonly IServiceContainer _lightInjectContainer;
+
+        public LightInjectAdapter(IServiceContainer lightInjectContainer)
+        {
+            if (lightInjectContainer == null)
+            {
+                throw new ArgumentNullException("lightInjectContainer");
+            }
+
+            _lightInjectContainer = lightInjectContainer;
+        }
+
+        public TService Resolve<TService>() where TService : class
+        {
+            return _lightInjectContainer.GetInstance<TService>();
+        }
+
+        public IServiceRegister Register<TService>(Func<IServiceProvider, TService> serviceCreator) where TService : class
+        {
+            if (!_lightInjectContainer.CanGetInstance(typeof(TService), string.Empty))
+            {
+                _lightInjectContainer.Register<TService>(ctx => serviceCreator(this), new PerContainerLifetime());
+            }
+            return this;
+        }
+
+        public IServiceRegister Register<TService, TImplementation>()
+            where TService : class
+            where TImplementation : class, TService
+        {
+            if (!_lightInjectContainer.CanGetInstance(typeof(TService), string.Empty))
+            {
+                _lightInjectContainer.Register<TService, TImplementation>(new PerContainerLifetime());
+            }
+            return this;
+        }
+
+        public void Dispose()
+        {
+            // Intentionally empty
+        }
+    }
+}

--- a/Source/EasyNetQ.DI.LightInject/LightInjectMessageDispatcher.cs
+++ b/Source/EasyNetQ.DI.LightInject/LightInjectMessageDispatcher.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Threading.Tasks;
+using EasyNetQ.AutoSubscribe;
+using LightInject;
+
+namespace EasyNetQ.DI
+{
+	public class LightInjectMessageDispatcher : IAutoSubscriberMessageDispatcher
+	{
+		private readonly IServiceContainer _container;
+
+		public LightInjectMessageDispatcher(IServiceContainer container)
+		{
+            if (container == null)
+            {
+                throw new ArgumentNullException("container");
+            }
+
+			this._container = container;
+		}
+
+		public void Dispatch<TMessage, TConsumer>(TMessage message)
+			where TMessage : class
+			where TConsumer : IConsume<TMessage>
+		{
+			_container.GetInstance<TConsumer>().Consume(message);
+		}
+
+		public Task DispatchAsync<TMessage, TConsumer>(TMessage message)
+			where TMessage : class
+			where TConsumer : IConsumeAsync<TMessage>
+		{
+			var consumer = _container.GetInstance<TConsumer>();
+			var tsc = new TaskCompletionSource<object>();
+			consumer
+				.Consume(message)
+				.ContinueWith(task =>
+				{
+					if (task.IsFaulted && task.Exception != null)
+					{
+						tsc.SetException(task.Exception);
+					}
+					else
+					{
+						tsc.SetResult(null);
+					}
+				});
+
+			return tsc.Task;
+		}
+	}
+}

--- a/Source/EasyNetQ.DI.LightInject/Properties/AssemblyInfo.cs
+++ b/Source/EasyNetQ.DI.LightInject/Properties/AssemblyInfo.cs
@@ -1,0 +1,22 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("EasyNetQ.DI.LightInject")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("EasyNetQ")]
+[assembly: AssemblyProduct("EasyNetQ.DI.LightInject")]
+[assembly: AssemblyCopyright("Copyright © EasyNetQ 2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("3ad2cd4a-8969-4c2d-8eaa-9fc800585678")]

--- a/Source/EasyNetQ.DI.LightInject/app.config
+++ b/Source/EasyNetQ.DI.LightInject/app.config
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/Source/EasyNetQ.DI.LightInject/packages.config
+++ b/Source/EasyNetQ.DI.LightInject/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="LightInject" version="3.0.2.7" targetFramework="net45" />
+</packages>

--- a/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
+++ b/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
@@ -50,6 +50,10 @@
       <HintPath>..\packages\Castle.Windsor.3.2.1\lib\net45\Castle.Windsor.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="LightInject, Version=3.0.2.7, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\LightInject.3.0.2.7\lib\net45\LightInject.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Ninject, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
       <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>
       <Private>True</Private>
@@ -79,6 +83,7 @@
       <Link>Properties\Version.cs</Link>
     </Compile>
     <Compile Include="AutofacAdapterTests.cs" />
+    <Compile Include="LightInjectAdapterTests.cs" />
     <Compile Include="NinjectAdapterTests.cs" />
     <Compile Include="StructureMapAdapterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -93,6 +98,10 @@
     <ProjectReference Include="..\EasyNetQ.DI.Autofac\EasyNetQ.DI.Autofac.csproj">
       <Project>{74fb0a3d-2c72-462c-b498-15c0ae615d35}</Project>
       <Name>EasyNetQ.DI.Autofac</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\EasyNetQ.DI.LightInject\EasyNetQ.DI.LightInject.csproj">
+      <Project>{3ad2cd4a-8969-4c2d-8eaa-9fc800585678}</Project>
+      <Name>EasyNetQ.DI.LightInject</Name>
     </ProjectReference>
     <ProjectReference Include="..\EasyNetQ.DI.Ninject\EasyNetQ.DI.Ninject.csproj">
       <Project>{c76da6ea-78f0-4918-8e0a-7a1cad31e702}</Project>

--- a/Source/EasyNetQ.DI.Tests/LightInjectAdapterTests.cs
+++ b/Source/EasyNetQ.DI.Tests/LightInjectAdapterTests.cs
@@ -1,0 +1,59 @@
+﻿using EasyNetQ.Tests.Mocking;
+using NUnit.Framework;
+using LightInject;
+
+namespace EasyNetQ.DI.Tests
+{
+    /// <summary>
+    /// EasyNetQ expects that the DI container will follow a first-to-register-wins
+    /// policy. The internal DefaultServiceProvider works this way, as does Windsor.
+    /// However, Ninject & LightInject don't allow more than one registration of a
+    /// service, they throw an exception, and StructureMap has a last-to-register-wins
+    /// policy.
+    /// </summary>    
+    [TestFixture]    
+    public class LightInjectAdapterTests
+    {
+        private IServiceContainer container;
+        private IBus bus;
+
+        [SetUp]
+        public void SetUp()
+        {
+            container = new ServiceContainer();
+
+            container.RegisterAsEasyNetQContainerFactory();
+
+            bus = new MockBuilder(register =>
+                register.Register<IConventions>(r => new TestConventions(new TypeNameSerializer())
+            )).Bus;
+        }
+
+        [Test]
+        public void Should_create_bus_with_lightinject_adapter()
+        {
+            Assert.IsNotNull(bus);
+        }
+
+        [Test]
+        public void Should_resolve_test_conventions()
+        {
+            Assert.IsNotNull(bus);
+
+            var rabbitBus = (RabbitBus)bus;
+
+            Assert.IsTrue(rabbitBus.Advanced.Conventions is TestConventions);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (bus != null)
+            {
+                bus.Dispose();
+                ((LightInjectAdapter)bus.Advanced.Container).Dispose();
+            }
+            RabbitHutch.SetContainerFactory(() => new DefaultServiceProvider());
+        }
+    }
+}

--- a/Source/EasyNetQ.DI.Tests/packages.config
+++ b/Source/EasyNetQ.DI.Tests/packages.config
@@ -3,6 +3,7 @@
   <package id="Autofac" version="3.5.2" targetFramework="net45" />
   <package id="Castle.Core" version="3.2.0" targetFramework="net45" />
   <package id="Castle.Windsor" version="3.2.1" targetFramework="net45" />
+  <package id="LightInject" version="3.0.2.7" targetFramework="net45" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net45" />

--- a/Source/EasyNetQ.sln
+++ b/Source/EasyNetQ.sln
@@ -8,6 +8,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6301F5B7-5B36-4EDA-8E37-6C970155F8B4}"
 	ProjectSection(SolutionItems) = preProject
 		..\Package\EasyNetQ.DI.Autofac\EasyNetQ.DI.Autofac.nuspec = ..\Package\EasyNetQ.DI.Autofac\EasyNetQ.DI.Autofac.nuspec
+		..\Package\EasyNetQ.DI.LightInject\EasyNetQ.DI.LightInject.nuspec = ..\Package\EasyNetQ.DI.LightInject\EasyNetQ.DI.LightInject.nuspec
 		..\Package\EasyNetQ.DI.Ninject\EasyNetQ.DI.Ninject.nuspec = ..\Package\EasyNetQ.DI.Ninject\EasyNetQ.DI.Ninject.nuspec
 		..\Package\EasyNetQ.DI.StructureMap\EasyNetQ.DI.StructureMap.nuspec = ..\Package\EasyNetQ.DI.StructureMap\EasyNetQ.DI.StructureMap.nuspec
 		..\Package\EasyNetQ.DI.Windsor\EasyNetQ.DI.Windsor.nuspec = ..\Package\EasyNetQ.DI.Windsor\EasyNetQ.DI.Windsor.nuspec
@@ -89,6 +90,8 @@ EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "EasyNetQ", "EasyNetQ\EasyNetQ.shproj", "{6A038745-6B26-437B-9524-71F9CA2971F4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ.Tests.Tasks", "EasyNetQ.Tests.Tasks\EasyNetQ.Tests.Tasks.csproj", "{A5CF1B2C-E390-4BFF-BB1A-0F171DB0D6BD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ.DI.LightInject", "EasyNetQ.DI.LightInject\EasyNetQ.DI.LightInject.csproj", "{3AD2CD4A-8969-4C2D-8EAA-9FC800585678}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -180,6 +183,10 @@ Global
 		{A5CF1B2C-E390-4BFF-BB1A-0F171DB0D6BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A5CF1B2C-E390-4BFF-BB1A-0F171DB0D6BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A5CF1B2C-E390-4BFF-BB1A-0F171DB0D6BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3AD2CD4A-8969-4C2D-8EAA-9FC800585678}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3AD2CD4A-8969-4C2D-8EAA-9FC800585678}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3AD2CD4A-8969-4C2D-8EAA-9FC800585678}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3AD2CD4A-8969-4C2D-8EAA-9FC800585678}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.54.0.0")]
+[assembly: AssemblyVersion("0.54.1.0")]
 [assembly: CLSCompliant(false)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.54.1.0 Added LightInject DI support
 // 0.54.0.0 Updated RabbitMQ client to 3.6.0 
 // 0.53.6.0 set CLSCompliant to false
 // 0.53.5.0 Added custom queue-name support to 'err' and 'retry' commands

--- a/hall_of_fame.md
+++ b/hall_of_fame.md
@@ -57,3 +57,4 @@ No particular order. Don't forget to add your name with your pull request.
 * Jeff Huntsman
 * Mathieu Leenhardt
 * Steven Bone
+* Matt Davey


### PR DESCRIPTION
Adds LightInject as a supported DI container (http://www.lightinject.net/). The code is mostly derived from the existing Ninject adapter.

I've also added a nuspec file and amended the build proj to package it. I wasn't sure if I was supposed to bump Version.cs, let me know if you want me to do this :)

This is using version 3.x of LightInject. Version 4.x targets .NET Core so would be dependent on #508 