### PR TITLE
Fix for #522

### DIFF
--- a/Source/EasyNetQ.Tests/ModelCleanupTests.cs
+++ b/Source/EasyNetQ.Tests/ModelCleanupTests.cs
@@ -20,12 +20,12 @@ namespace EasyNetQ.Tests
         }
 
         [Test]
-        public void Should_cleanup_publish_model()
+        public void Should_not_cleanup_publish_model()
         {
             bus.Publish(new TestMessage());
             bus.Dispose();
 
-            mockBuilder.Channels[0].AssertWasCalled(x => x.Dispose());
+            mockBuilder.Channels[0].AssertWasNotCalled(x => x.Dispose());
         }
 
         [Test]

--- a/Source/EasyNetQ/Producer/PersistentChannel.cs
+++ b/Source/EasyNetQ/Producer/PersistentChannel.cs
@@ -169,8 +169,6 @@ namespace EasyNetQ.Producer
                     internalChannel.BasicNacks -= OnNack;
                 }
                 internalChannel.BasicReturn -= OnReturn;
-                // Fix me: use Dispose instead of SafeDispose after update of Rabbitmq.Client to 3.5.5
-                internalChannel.SafeDispose();
                 internalChannel = null;
             }
 

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,7 +2,7 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.54.1.0")]
+[assembly: AssemblyVersion("0.54.2.0")]
 [assembly: CLSCompliant(false)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.


### PR DESCRIPTION
Fixes #522. Removed call to `internalChannel.SafeDispose()` in `PersistentChannel`, since it occasionally causes blocking on broker reconnect. I have verified with RMQ developer @michaelklishin: https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/154 that Disposing channel is not required.

For further details, see discussion on issue #522.