### PR TITLE
Use RPC exchange instead of default exchange for RPC reponses

### DIFF
--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
 
+// 0.57.0.0 RPC responses go through the dedicated RPC exchange (easy_net_q_rpc by default) instead of the default exchange
 // 0.56.0.0 Updated to StructreMap 4, Note: this is only a breaking change for users of 'EasyNetQ.DI.StructureMap'
 // 0.55.1.0 Marked Rpc.Respond overload as virtual
 // 0.55.0.0 Bug fix, DefaultConsumerErrorStrategy does not decode header values

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,7 +2,7 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.55.0.0")]
+[assembly: AssemblyVersion("0.57.0.0")]
 [assembly: CLSCompliant(false)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.


### PR DESCRIPTION
The RabbitMQ documentation on [federations](https://www.rabbitmq.com/federated-exchanges.html) states that the _default_ exchange can't be federated. The pull request uses the RPC exchange, declared by EasyNetQ, as a response exchange, which enables the usage of RPC over federated brokers.