### PR TITLE
[WIP] Implementing auto recovery in rabbtimq cluster, where the underlying queues are nondurable

### DIFF
--- a/Source/EasyNetQ/Consumer/ConsumerFactory.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerFactory.cs
@@ -58,7 +58,7 @@ namespace EasyNetQ.Consumer
             IPersistentConnection connection,
             IConsumerConfiguration configuration)
         {
-            if (queue.IsExclusive)
+            if (queue.IsExclusive && configuration.RecoveryAction == null)
             {
                 return new TransientConsumer(queue, onMessage, connection, configuration, internalConsumerFactory, eventBus);
             }

--- a/Source/EasyNetQ/Consumer/IConsumerConfiguration.cs
+++ b/Source/EasyNetQ/Consumer/IConsumerConfiguration.cs
@@ -1,4 +1,6 @@
-﻿namespace EasyNetQ.Consumer
+﻿using System;
+
+namespace EasyNetQ.Consumer
 {
     public interface IConsumerConfiguration
     {
@@ -6,11 +8,13 @@
         bool CancelOnHaFailover { get; }
         ushort PrefetchCount { get; }
         bool IsExclusive { get; }
+        Action RecoveryAction { get; }
 
         IConsumerConfiguration WithPriority(int priority);
         IConsumerConfiguration WithCancelOnHaFailover(bool cancelOnHaFailover = true);
         IConsumerConfiguration WithPrefetchCount(ushort prefetchCount);
         IConsumerConfiguration AsExclusive();
+        IConsumerConfiguration WithRecoveryAction(Action recoveryAction);
     }
 
     public class ConsumerConfiguration : IConsumerConfiguration
@@ -27,6 +31,7 @@
         public bool IsExclusive { get; private set; }
         public bool CancelOnHaFailover { get; private set; }
         public ushort PrefetchCount { get; private set; }
+        public Action RecoveryAction { get; private set; }
 
         public IConsumerConfiguration WithPriority(int priority)
         {
@@ -49,6 +54,12 @@
         public IConsumerConfiguration AsExclusive()
         {
             IsExclusive = true;
+            return this;
+        }
+
+        public IConsumerConfiguration WithRecoveryAction(Action recoveryAction)
+        {
+            RecoveryAction = recoveryAction;
             return this;
         }
     }

--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -125,7 +125,7 @@ namespace EasyNetQ.Consumer
             if(consumerCancelled != null) consumerCancelled(this, new ConsumerEventArgs(ConsumerTag));
         }
 
-        private void FireConsumerLost()
+        private void OnConsumerLost()
         {
             // copy to temp variable to be thread safe.
             var consumerLost = ConsumerLost;
@@ -151,7 +151,7 @@ namespace EasyNetQ.Consumer
         {
             logger.InfoWrite("BasicCancel(Consumer Cancel Notification from broker) event received. " +
                              "Consumer tag: " + consumerTag);
-            FireConsumerLost();
+            OnConsumerLost();
         }
 
         public void HandleModelShutdown(object model, ShutdownEventArgs reason)

--- a/Source/EasyNetQ/EasyNetQ.shproj
+++ b/Source/EasyNetQ/EasyNetQ.shproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>6a038745-6b26-437b-9524-71f9ca2971f4</ProjectGuid>
-    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />

--- a/Source/EasyNetQ/Producer/IResponderConfiguration.cs
+++ b/Source/EasyNetQ/Producer/IResponderConfiguration.cs
@@ -11,6 +11,7 @@
         public ResponderConfiguration(ushort defaultPrefetchCount)
         {
             PrefetchCount = defaultPrefetchCount;
+            Durable = true; //this is the non-breaking default value.
         }
 
         public ushort PrefetchCount { get; private set; }

--- a/Source/EasyNetQ/Producer/IResponderConfiguration.cs
+++ b/Source/EasyNetQ/Producer/IResponderConfiguration.cs
@@ -3,6 +3,7 @@
     public interface IResponderConfiguration
     {
         IResponderConfiguration WithPrefetchCount(ushort prefetchCount);
+        IResponderConfiguration WithDurable(bool durable);
     }
 
     public class ResponderConfiguration : IResponderConfiguration
@@ -13,10 +14,17 @@
         }
 
         public ushort PrefetchCount { get; private set; }
+        public bool Durable { get; private set; }
 
         public IResponderConfiguration WithPrefetchCount(ushort prefetchCount)
         {
             PrefetchCount = prefetchCount;
+            return this;
+        }
+
+        public IResponderConfiguration WithDurable(bool durable)
+        {
+            Durable = durable;
             return this;
         }
     }

--- a/Source/EasyNetQ/RabbitBus.cs
+++ b/Source/EasyNetQ/RabbitBus.cs
@@ -136,7 +136,17 @@ namespace EasyNetQ
                     {
                         x.WithPriority(configuration.Priority)
                          .WithCancelOnHaFailover(configuration.CancelOnHaFailover)
-                         .WithPrefetchCount(configuration.PrefetchCount);
+                         .WithPrefetchCount(configuration.PrefetchCount).WithRecoveryAction(
+                          () =>
+                          {
+                              var q = advancedBus.QueueDeclare(queueName, autoDelete: configuration.AutoDelete, expires: configuration.Expires);
+                              var exc = advancedBus.ExchangeDeclare(exchangeName, ExchangeType.Topic);
+
+                              foreach (var topic in configuration.Topics.DefaultIfEmpty("#"))
+                              {
+                                  advancedBus.Bind(exc, q, topic);
+                              }
+                          });
                         if (configuration.IsExclusive)
                         {
                             x.AsExclusive();


### PR DESCRIPTION
This is a starter implementation, which went through an endurance test, though in an earlier version of easynetq. I've changed shproj tool version to 12 (VS 2013), as it is also working with it from upgrade 4. In the version we use, there is no ExclusiveConsumer, so the change didn't take it int account. Issue for this PR fixes #560 .

As I noticed, there is break change, as we use mainly nondurable queues, and ResponderConfiguration now contains Durable = false, as the default. It should be changed to keep backward compatibility.
