### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ A Nice .NET API for RabbitMQ
 Initial development was sponsored by travel industry experts [15below](http://15below.com/)
 
 * **[Homepage](http://easynetq.com)**
-* **[Documentation](https://github.com/mikehadlow/EasyNetQ/wiki/Introduction)**
-* **[NuGet](http://nuget.org/List/Packages/EasyNetQ)**
+* **[Documentation](https://github.com/EasyNetQ/EasyNetQ/wiki/Introduction)**
+* **[NuGet](http://www.nuget.org/packages/EasyNetQ)**
 * **[Discussion Group](https://groups.google.com/group/easynetq)**
 
 Goals:
@@ -48,7 +48,7 @@ EasyNetQ also has a client-side library for the RabbitMQ Management HTTP API. Th
 RabbitMQ broker from .NET code, including creating virtual hosts and users; setting permissions; monitoring queues, 
 connections and channels; and setting up exchanges, queues and bindings. 
 
-See the **[documentation](https://github.com/mikehadlow/EasyNetQ/wiki/Management-API-Introduction)**.
+See the **[documentation](https://github.com/EasyNetQ/EasyNetQ/wiki/Management-API-Introduction)**.
 
 The annoucement blog post is [here](http://mikehadlow.blogspot.co.uk/2012/11/a-c-net-client-proxy-for-rabbitmq.html)
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/mikehadlow/EasyNetQ/wiki/Introduction | https://github.com/EasyNetQ/EasyNetQ/wiki/Introduction 
https://github.com/mikehadlow/EasyNetQ/wiki/Management-API-Introduction | https://github.com/EasyNetQ/EasyNetQ/wiki/Management-API-Introduction 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://nuget.org/List/Packages/EasyNetQ | http://www.nuget.org/packages/EasyNetQ