### PR TITLE
Added ability to configure RPC Exchange names based on request or response type.

### DIFF
--- a/Source/EasyNetQ.DI.Tests/StructureMapAdapterWithRegistryTests.cs
+++ b/Source/EasyNetQ.DI.Tests/StructureMapAdapterWithRegistryTests.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using StructureMap;
-using StructureMap.Configuration.DSL;
+using System;
 
 namespace EasyNetQ.DI.Tests
 {
@@ -105,7 +104,8 @@ namespace EasyNetQ.DI.Tests
             public RpcRoutingKeyNamingConvention RpcRoutingKeyNamingConvention { get; set; }
             public ErrorQueueNameConvention ErrorQueueNamingConvention { get; set; }
             public ErrorExchangeNameConvention ErrorExchangeNamingConvention { get; set; }
-            public RpcExchangeNameConvention RpcExchangeNamingConvention { get; set; }
+            public RpcExchangeNameConvention RpcRequestExchangeNamingConvention { get; set; }
+            public RpcExchangeNameConvention RpcResponseExchangeNamingConvention { get; set; }
             public RpcReturnQueueNamingConvention RpcReturnQueueNamingConvention { get; set; }
             public ConsumerTagConvention ConsumerTagConvention { get; set; }
 

--- a/Source/EasyNetQ.Tests.Messages/Messages.cs
+++ b/Source/EasyNetQ.Tests.Messages/Messages.cs
@@ -32,6 +32,30 @@ namespace EasyNetQ.Tests
         public string Text { get; set; }
     }
 
+    public class TestModifiedRequestExhangeRequestMessage
+    {
+        public string Text { get; set; }
+    }
+
+    [Serializable]
+    public class TestModifiedRequestExhangeResponseMessage
+    {
+        public string Text { get; set; }
+    }
+
+    [Serializable]
+    public class TestModifiedResponseExhangeRequestMessage
+    {
+        public string Text { get; set; }
+    }
+
+    [Serializable]
+    public class TestModifiedResponseExhangeResponseMessage
+    {
+        public string Text { get; set; }
+    }
+
+    [Serializable]
     public class StartMessage
     {
         public string Text { get; set; }

--- a/Source/EasyNetQ.Tests/ConventionsTests.cs
+++ b/Source/EasyNetQ.Tests/ConventionsTests.cs
@@ -1,17 +1,17 @@
 // ReSharper disable InconsistentNaming
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using EasyNetQ.Consumer;
 using EasyNetQ.Tests.Mocking;
 using NUnit.Framework;
 using RabbitMQ.Client;
 using Rhino.Mocks;
+using System;
+using System.Collections.Generic;
+using System.Text;
 
 namespace EasyNetQ.Tests
 {
-	[TestFixture]
+    [TestFixture]
 	public class When_using_default_conventions
 	{
 		private Conventions conventions;
@@ -63,9 +63,16 @@ namespace EasyNetQ.Tests
         }
 
         [Test]
-        public void The_default_rpc_exchange_name_should_be()
+        public void The_default_rpc_request_exchange_name_should_be()
         {
-            var result = conventions.RpcExchangeNamingConvention();
+            var result = conventions.RpcRequestExchangeNamingConvention(typeof (object));
+            result.ShouldEqual("easy_net_q_rpc");
+        }
+
+        [Test]
+        public void The_default_rpc_reply_exchange_name_should_be()
+        {
+            var result = conventions.RpcResponseExchangeNamingConvention(typeof(object));
             result.ShouldEqual("easy_net_q_rpc");
         }
 
@@ -74,7 +81,7 @@ namespace EasyNetQ.Tests
         {
             var result = conventions.RpcRoutingKeyNamingConvention(typeof(TestMessage));
             result.ShouldEqual(typeNameSerializer.Serialize(typeof(TestMessage)));
-        }
+        }        
 	}
 
     [TestFixture]
@@ -203,7 +210,7 @@ namespace EasyNetQ.Tests
         {
             var customConventions = new Conventions(new TypeNameSerializer())
             {
-                RpcExchangeNamingConvention = () => "CustomRpcExchangeName",
+                RpcRequestExchangeNamingConvention = messageType => "CustomRpcExchangeName",
                 RpcRoutingKeyNamingConvention = messageType => "CustomRpcRoutingKeyName"
             };
 

--- a/Source/EasyNetQ/Conventions.cs
+++ b/Source/EasyNetQ/Conventions.cs
@@ -10,7 +10,7 @@ namespace EasyNetQ
 
     public delegate string ErrorQueueNameConvention();
     public delegate string ErrorExchangeNameConvention(MessageReceivedInfo info);
-    public delegate string RpcExchangeNameConvention();
+    public delegate string RpcExchangeNameConvention(Type messageType);
 
     public delegate string RpcReturnQueueNamingConvention();
 
@@ -25,7 +25,8 @@ namespace EasyNetQ
 
         ErrorQueueNameConvention ErrorQueueNamingConvention { get; set; }
         ErrorExchangeNameConvention ErrorExchangeNamingConvention { get; set; }
-        RpcExchangeNameConvention RpcExchangeNamingConvention { get; set; }
+        RpcExchangeNameConvention RpcRequestExchangeNamingConvention { get; set; }
+        RpcExchangeNameConvention RpcResponseExchangeNamingConvention { get; set; }
         RpcReturnQueueNamingConvention RpcReturnQueueNamingConvention { get; set; }
 
         ConsumerTagConvention ConsumerTagConvention { get; set; }
@@ -71,8 +72,9 @@ namespace EasyNetQ
 
             ErrorQueueNamingConvention = () => "EasyNetQ_Default_Error_Queue";
 		    ErrorExchangeNamingConvention = info => "ErrorExchange_" + info.RoutingKey;
-            RpcExchangeNamingConvention = () => "easy_net_q_rpc";
-		    RpcReturnQueueNamingConvention = () => "easynetq.response." + Guid.NewGuid().ToString();
+            RpcRequestExchangeNamingConvention = (type) => "easy_net_q_rpc";
+		    RpcResponseExchangeNamingConvention = (type) => "easy_net_q_rpc";
+            RpcReturnQueueNamingConvention = () => "easynetq.response." + Guid.NewGuid();
 
             ConsumerTagConvention = () => Guid.NewGuid().ToString();
 		}
@@ -89,7 +91,8 @@ namespace EasyNetQ
 
         public ErrorQueueNameConvention ErrorQueueNamingConvention { get; set; }
         public ErrorExchangeNameConvention ErrorExchangeNamingConvention { get; set; }
-        public RpcExchangeNameConvention RpcExchangeNamingConvention { get; set; }
+        public RpcExchangeNameConvention RpcRequestExchangeNamingConvention { get; set; }
+        public RpcExchangeNameConvention RpcResponseExchangeNamingConvention { get; set; }
         public RpcReturnQueueNamingConvention RpcReturnQueueNamingConvention { get; set; }
 
         public ConsumerTagConvention ConsumerTagConvention { get; set; }

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,10 +2,11 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.61.0.0")]
+[assembly: AssemblyVersion("0.61.1.0")]
 [assembly: CLSCompliant(false)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
+// 0.61.1.0 Added support for configuring RPC exchange (request and response) names via conventions
 // 0.61.0.0 Added support for EXTERNAL authentication mechanism
 // 0.60.1.0 Added SimpleInjector DI support
 // 0.60.0.0 Remove [Serializable] attribute from messages and exceptions


### PR DESCRIPTION
As discussed here : https://groups.google.com/forum/#!topic/easynetq/BOlFOM3NZDo , here is the PR.

Added to convensions RpcRequest and RpcResponse naming conventions, so that you can configure them as needed.

The default for both has not changed thus this is not breaking change. I've created some tests (just say if the naming of the test messages is confusing).

