### PR TITLE
Allow use of EXTERNAL authentication mechanism

### DIFF
--- a/Source/EasyNetQ.Tests/ConnectionConfigurationTests.cs
+++ b/Source/EasyNetQ.Tests/ConnectionConfigurationTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using EasyNetQ.ConnectionString;
 using NUnit.Framework;
+using RabbitMQ.Client;
 
 namespace EasyNetQ.Tests
 {
@@ -22,6 +23,15 @@ namespace EasyNetQ.Tests
             connectionConfiguration.Hosts.Count().ShouldEqual(1);
             connectionConfiguration.Hosts.Single().Host.ShouldEqual("amqphost");
             connectionConfiguration.Hosts.Single().Port.ShouldEqual(1234);
+        }
+
+        [Test]
+        public void The_AuthMechanisms_property_should_default_to_PlainMechanism()
+        {
+            ConnectionConfiguration connectionConfiguration = new ConnectionConfiguration();
+
+            connectionConfiguration.AuthMechanisms.Count.ShouldEqual(1);
+            connectionConfiguration.AuthMechanisms.Single().ShouldBeOfType<PlainMechanismFactory>();
         }
     }
 }

--- a/Source/EasyNetQ/ConnectionConfiguration.cs
+++ b/Source/EasyNetQ/ConnectionConfiguration.cs
@@ -34,6 +34,7 @@ namespace EasyNetQ
         public string Product { get; set; }
         public string Platform { get; set; }
         public bool UseBackgroundThreads { get; set; }
+        public IList<AuthMechanismFactory> AuthMechanisms { get; set; }
 
         public ConnectionConfiguration()
         {
@@ -53,6 +54,7 @@ namespace EasyNetQ
             // set to 50 based on this blog post:
             // http://www.rabbitmq.com/blog/2012/04/25/rabbitmq-performance-measurements-part-2/
             PrefetchCount = 50;
+            AuthMechanisms = new AuthMechanismFactory[] {new PlainMechanismFactory()};
             
             Hosts = new List<HostConfiguration>();
 

--- a/Source/EasyNetQ/IConnectionFactory.cs
+++ b/Source/EasyNetQ/IConnectionFactory.cs
@@ -64,6 +64,7 @@ namespace EasyNetQ
 
                 connectionFactory.RequestedHeartbeat = Configuration.RequestedHeartbeat;
                 connectionFactory.ClientProperties = Configuration.ClientProperties;
+                connectionFactory.AuthMechanisms = Configuration.AuthMechanisms;
                 clusterHostSelectionStrategy.Add(new ConnectionFactoryInfo(connectionFactory, hostConfiguration));
             }
         }

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,10 +2,11 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.60.1.0")]
+[assembly: AssemblyVersion("0.61.0.0")]
 [assembly: CLSCompliant(false)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
+// 0.61.0.0 Added support for EXTERNAL authentication mechanism
 // 0.60.1.0 Added SimpleInjector DI support
 // 0.60.0.0 Remove [Serializable] attribute from messages and exceptions
 // 0.59.0.0 Support of priority queues to IBus publish methods


### PR DESCRIPTION
Authentication via client certificates requires setting the ConnectionFactory AuthMechanism property. This PR adds an AuthMechanism property to the ConnectionConfiguration and passes it through to the ConnectionFactory.
The default AuthMechanism is set to PlainMechanism so it should not effect any existing users\code.

This will resolve #563 (without the additional documentation).
