### PR TITLE
Add support for topic based routing future publish messages

### DIFF
--- a/Source/EasyNetQ/Scheduling/BusExtensions.cs
+++ b/Source/EasyNetQ/Scheduling/BusExtensions.cs
@@ -30,11 +30,40 @@ namespace EasyNetQ.Scheduling
         /// <typeparam name="T">The message type</typeparam>
         /// <param name="bus">The IBus instance to publish on</param>
         /// <param name="futurePublishDate">The time at which the message should be sent (UTC)</param>
+        /// <param name="message">The message to response with</param>
+        /// <param name="topic">The topic string</param>
+        public static void FuturePublish<T>(this IBus bus, DateTime futurePublishDate, T message, string topic) where T : class
+        {
+            bus.Scheduler().FuturePublishAsync(futurePublishDate, message, topic: topic).Wait();
+        }
+
+        /// <summary>
+        /// Schedule a message to be published at some time in the future.
+        /// This required the EasyNetQ.Scheduler service to be running.
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="bus">The IBus instance to publish on</param>
+        /// <param name="futurePublishDate">The time at which the message should be sent (UTC)</param>
         /// <param name="cancellationKey">An identifier that can be used with CancelFuturePublish to cancel the sending of this message at a later time</param>
         /// <param name="message">The message to response with</param>
         public static void FuturePublish<T>(this IBus bus, DateTime futurePublishDate, string cancellationKey, T message) where T : class
         {
             bus.Scheduler().FuturePublishAsync(futurePublishDate, message, cancellationKey).Wait();
+        }
+
+        /// <summary>
+        /// Schedule a message to be published at some time in the future.
+        /// This required the EasyNetQ.Scheduler service to be running.
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="bus">The IBus instance to publish on</param>
+        /// <param name="futurePublishDate">The time at which the message should be sent (UTC)</param>
+        /// <param name="cancellationKey">An identifier that can be used with CancelFuturePublish to cancel the sending of this message at a later time</param>
+        /// <param name="message">The message to response with</param>
+        /// <param name="topic">The topic string</param>
+        public static void FuturePublish<T>(this IBus bus, DateTime futurePublishDate, string topic, string cancellationKey, T message) where T : class
+        {
+            bus.Scheduler().FuturePublishAsync(futurePublishDate, message, topic, cancellationKey).Wait();
         }
 
         /// <summary>
@@ -47,6 +76,19 @@ namespace EasyNetQ.Scheduling
         public static void FuturePublish<T>(this IBus bus, TimeSpan messageDelay, T message) where T : class
         {
             bus.Scheduler().FuturePublishAsync(messageDelay, message).Wait();
+        }
+
+        /// <summary>
+        /// Schedule a message to be published at some time in the future, using bare RabbitMQ's capabilites (message time-to-live and dead letter exchange).
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="bus">The IBus instance to publish on</param>
+        /// <param name="messageDelay">The delay time for message to publish in future</param>
+        /// <param name="message">The message to response with</param>
+        /// <param name="topic">The topic string</param>
+        public static void FuturePublish<T>(this IBus bus, TimeSpan messageDelay, T message, string topic) where T : class
+        {
+            bus.Scheduler().FuturePublishAsync(messageDelay, message, topic:topic).Wait();
         }
 
         /// <summary>
@@ -79,11 +121,40 @@ namespace EasyNetQ.Scheduling
         /// <typeparam name="T">The message type</typeparam>
         /// <param name="bus">The IBus instance to publish on</param>
         /// <param name="futurePublishDate">The time at which the message should be sent (UTC)</param>
+        /// <param name="message">The message to response with</param>
+        /// <param name="topic">The topic string</param>
+        public static Task FuturePublishAsync<T>(this IBus bus, DateTime futurePublishDate, T message, string topic) where T : class
+        {
+            return bus.Scheduler().FuturePublishAsync(futurePublishDate, message, topic:topic);
+        }
+
+        /// <summary>
+        /// Schedule a message to be published at some time in the future.
+        /// This required the EasyNetQ.Scheduler service to be running.
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="bus">The IBus instance to publish on</param>
+        /// <param name="futurePublishDate">The time at which the message should be sent (UTC)</param>
         /// <param name="cancellationKey">An identifier that can be used with CancelFuturePublish to cancel the sending of this message at a later time</param>
         /// <param name="message">The message to response with</param>
         public static Task FuturePublishAsync<T>(this IBus bus, DateTime futurePublishDate, string cancellationKey, T message) where T : class
         {
             return bus.Scheduler().FuturePublishAsync(futurePublishDate, message, cancellationKey);
+        }
+
+        /// <summary>
+        /// Schedule a message to be published at some time in the future.
+        /// This required the EasyNetQ.Scheduler service to be running.
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="bus">The IBus instance to publish on</param>
+        /// <param name="futurePublishDate">The time at which the message should be sent (UTC)</param>
+        /// <param name="cancellationKey">An identifier that can be used with CancelFuturePublish to cancel the sending of this message at a later time</param>
+        /// <param name="message">The message to response with</param>
+        /// <param name="topic">The topic string</param>
+        public static Task FuturePublishAsync<T>(this IBus bus, DateTime futurePublishDate, string cancellationKey, T message, string topic) where T : class
+        {
+            return bus.Scheduler().FuturePublishAsync(futurePublishDate, message, topic, cancellationKey);
         }
 
         /// <summary>
@@ -96,6 +167,19 @@ namespace EasyNetQ.Scheduling
         public static Task FuturePublishAsync<T>(this IBus bus, TimeSpan messageDelay, T message) where T : class
         {
             return bus.Scheduler().FuturePublishAsync(messageDelay, message);
+        }
+
+        /// <summary>
+        /// Schedule a message to be published at some time in the future, using bare RabbitMQ's capabilites (message time-to-live and dead letter exchange).
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="bus">The IBus instance to publish on</param>
+        /// <param name="messageDelay">The delay time for message to publish in future</param>
+        /// <param name="message">The message to response with</param>
+        /// <param name="topic">The topic string</param>
+        public static Task FuturePublishAsync<T>(this IBus bus, TimeSpan messageDelay, T message, string topic) where T : class
+        {
+            return bus.Scheduler().FuturePublishAsync(messageDelay, message, topic:topic);
         }
 
         /// <summary>

--- a/Source/EasyNetQ/Scheduling/DelayedExchangeScheduler.cs
+++ b/Source/EasyNetQ/Scheduling/DelayedExchangeScheduler.cs
@@ -29,22 +29,39 @@ namespace EasyNetQ.Scheduling
 
         public Task FuturePublishAsync<T>(DateTime futurePublishDate, T message, string cancellationKey = null) where T : class
         {
-            return FuturePublishInternalAsync(futurePublishDate - DateTime.UtcNow, message, cancellationKey);
+            return FuturePublishAsync(futurePublishDate, message, "#", cancellationKey);
         }
 
+        public Task FuturePublishAsync<T>(DateTime futurePublishDate, T message, string topic, string cancellationKey = null) where T : class
+        {
+            return FuturePublishInternalAsync(futurePublishDate - DateTime.UtcNow, message, topic, cancellationKey);
+        }
         public void FuturePublish<T>(DateTime futurePublishDate, T message, string cancellationKey = null) where T : class
         {
-            FuturePublishInternal(futurePublishDate - DateTime.UtcNow, message, cancellationKey);
+            FuturePublish(futurePublishDate, message, "#", cancellationKey);
         }
 
-        public Task FuturePublishAsync<T>(TimeSpan messageDelay, T message, string cancellationKey = null) where T : class
+        public void FuturePublish<T>(DateTime futurePublishDate, T message, string topic, string cancellationKey = null) where T : class
         {
-            return FuturePublishInternalAsync(messageDelay, message, cancellationKey);
+            FuturePublishInternal(futurePublishDate - DateTime.UtcNow, message, topic, cancellationKey);
+        }
+
+        public Task FuturePublishAsync<T>(TimeSpan messageDelay, T message,, string cancellationKey = null) where T : class
+        {
+            return FuturePublishAsync(messageDelay, message, "#", cancellationKey);
+        }
+        public Task FuturePublishAsync<T>(TimeSpan messageDelay, T message, string topic, string cancellationKey = null) where T : class
+        {
+            return FuturePublishInternalAsync(messageDelay, message, topic, cancellationKey);
         }
 
         public void FuturePublish<T>(TimeSpan messageDelay, T message, string cancellationKey = null) where T : class
         {
-            FuturePublishInternal(messageDelay, message, cancellationKey);
+            FuturePublish(messageDelay, message, "#", cancellationKey);
+        }
+        public void FuturePublish<T>(TimeSpan messageDelay, T message, string topic, string cancellationKey = null) where T : class
+        {
+            FuturePublishInternal(messageDelay, message, topic, cancellationKey);
         }
 
         public Task CancelFuturePublishAsync(string cancellationKey)
@@ -57,7 +74,7 @@ namespace EasyNetQ.Scheduling
             throw new NotImplementedException("Cancellation is not supported");
         }
 
-        private async Task FuturePublishInternalAsync<T>(TimeSpan messageDelay, T message, string cancellationKey = null) where T : class
+        private async Task FuturePublishInternalAsync<T>(TimeSpan messageDelay, T message, string topic, string cancellationKey = null) where T : class
         {
             Preconditions.CheckNotNull(message, "message");
             Preconditions.CheckLess(messageDelay, MaxMessageDelay, "messageDelay");
@@ -68,9 +85,9 @@ namespace EasyNetQ.Scheduling
             var queueName = conventions.QueueNamingConvention(typeof (T), null);
             var futureExchange = await advancedBus.ExchangeDeclareAsync(futureExchangeName, ExchangeType.Direct, delayed: true).ConfigureAwait(false);
             var exchange = await advancedBus.ExchangeDeclareAsync(exchangeName, ExchangeType.Topic).ConfigureAwait(false);
-            await advancedBus.BindAsync(futureExchange, exchange, "#").ConfigureAwait(false);
+            await advancedBus.BindAsync(futureExchange, exchange, topic).ConfigureAwait(false);
             var queue = await advancedBus.QueueDeclareAsync(queueName).ConfigureAwait(false);
-            await advancedBus.BindAsync(exchange, queue, "#").ConfigureAwait(false);
+            await advancedBus.BindAsync(exchange, queue, topic).ConfigureAwait(false);
             var easyNetQMessage = new Message<T>(message)
             {
                 Properties =
@@ -79,10 +96,10 @@ namespace EasyNetQ.Scheduling
                     Headers = new Dictionary<string, object> {{"x-delay", (int) messageDelay.TotalMilliseconds}}
                 }
             };
-            await advancedBus.PublishAsync(futureExchange, "#", false, easyNetQMessage).ConfigureAwait(false);
+            await advancedBus.PublishAsync(futureExchange, topic, false, easyNetQMessage).ConfigureAwait(false);
         }
 
-        private void FuturePublishInternal<T>(TimeSpan messageDelay, T message, string cancellationKey = null) where T : class
+        private void FuturePublishInternal<T>(TimeSpan messageDelay, T message, string topic, string cancellationKey = null) where T : class
         {
             Preconditions.CheckNotNull(message, "message");
             Preconditions.CheckLess(messageDelay, MaxMessageDelay, "messageDelay");
@@ -93,9 +110,9 @@ namespace EasyNetQ.Scheduling
             var queueName = conventions.QueueNamingConvention(typeof(T), null);
             var futureExchange = advancedBus.ExchangeDeclare(futureExchangeName, ExchangeType.Direct, delayed: true);
             var exchange = advancedBus.ExchangeDeclare(exchangeName, ExchangeType.Topic);
-            advancedBus.Bind(futureExchange, exchange, "#");
+            advancedBus.Bind(futureExchange, exchange, topic);
             var queue = advancedBus.QueueDeclare(queueName);
-            advancedBus.Bind(exchange, queue, "#");
+            advancedBus.Bind(exchange, queue, topic);
             var easyNetQMessage = new Message<T>(message)
             {
                 Properties =
@@ -104,7 +121,8 @@ namespace EasyNetQ.Scheduling
                     Headers = new Dictionary<string, object> { { "x-delay", (int)messageDelay.TotalMilliseconds } }
                 }
             };
-            advancedBus.Publish(futureExchange, "#", false, easyNetQMessage);
+            advancedBus.Publish(futureExchange, topic, false, easyNetQMessage);
         }
+
     }
 }

--- a/Source/EasyNetQ/Scheduling/DelayedExchangeScheduler.cs
+++ b/Source/EasyNetQ/Scheduling/DelayedExchangeScheduler.cs
@@ -46,7 +46,7 @@ namespace EasyNetQ.Scheduling
             FuturePublishInternal(futurePublishDate - DateTime.UtcNow, message, topic, cancellationKey);
         }
 
-        public Task FuturePublishAsync<T>(TimeSpan messageDelay, T message,, string cancellationKey = null) where T : class
+        public Task FuturePublishAsync<T>(TimeSpan messageDelay, T message, string cancellationKey = null) where T : class
         {
             return FuturePublishAsync(messageDelay, message, "#", cancellationKey);
         }

--- a/Source/EasyNetQ/Scheduling/IScheduler.cs
+++ b/Source/EasyNetQ/Scheduling/IScheduler.cs
@@ -25,8 +25,30 @@ namespace EasyNetQ.Scheduling
         /// <typeparam name="T">The message type</typeparam>
         /// <param name="futurePublishDate">The time at which the message should be sent (UTC)</param>
         /// <param name="message">The message to response with</param>
+        /// <param name="topic">The topic string</param>
+        /// <param name="cancellationKey">An identifier that can be used with CancelFuturePublish to cancel the sending of this message at a later time</param>
+        Task FuturePublishAsync<T>(DateTime futurePublishDate, T message, string topic, string cancellationKey = null) where T : class;
+
+        /// <summary>
+        /// Schedule a message to be published at some time in the future.
+        /// This required the EasyNetQ.Scheduler service to be running.
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="futurePublishDate">The time at which the message should be sent (UTC)</param>
+        /// <param name="message">The message to response with</param>
         /// <param name="cancellationKey">An identifier that can be used with CancelFuturePublish to cancel the sending of this message at a later time</param>
         void FuturePublish<T>(DateTime futurePublishDate, T message, string cancellationKey = null) where T : class;
+
+        /// <summary>
+        /// Schedule a message to be published at some time in the future.
+        /// This required the EasyNetQ.Scheduler service to be running.
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="futurePublishDate">The time at which the message should be sent (UTC)</param>
+        /// <param name="message">The message to response with</param>
+        /// <param name="topic">The topic string</param>
+        /// <param name="cancellationKey">An identifier that can be used with CancelFuturePublish to cancel the sending of this message at a later time</param>
+        void FuturePublish<T>(DateTime futurePublishDate, T message, string topic, string cancellationKey = null) where T : class;
 
 
         /// <summary>
@@ -39,6 +61,16 @@ namespace EasyNetQ.Scheduling
         /// <param name="cancellationKey">An identifier that can be used with CancelFuturePublish to cancel the sending of this message at a later time</param>
         Task FuturePublishAsync<T>(TimeSpan messageDelay, T message, string cancellationKey = null) where T : class;
 
+        /// <summary>
+        /// Schedule a message to be published at some time in the future.
+        /// This required the EasyNetQ.Scheduler service to be running.
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="messageDelay">The delay time for message to publish in future</param>
+        /// <param name="message">The message to response with</param>
+        /// <param name="topic">The topic string</param>
+        /// <param name="cancellationKey">An identifier that can be used with CancelFuturePublish to cancel the sending of this message at a later time</param>
+        Task FuturePublishAsync<T>(TimeSpan messageDelay, T message, string topic, string cancellationKey = null) where T : class;
 
 
         /// <summary>
@@ -51,6 +83,16 @@ namespace EasyNetQ.Scheduling
         /// <param name="cancellationKey">An identifier that can be used with CancelFuturePublish to cancel the sending of this message at a later time</param>
         void FuturePublish<T>(TimeSpan messageDelay, T message, string cancellationKey = null) where T : class;
 
+        /// <summary>
+        /// Schedule a message to be published at some time in the future.
+        /// This required the EasyNetQ.Scheduler service to be running.
+        /// </summary>
+        /// <typeparam name="T">The message type</typeparam>
+        /// <param name="messageDelay">The delay time for message to publish in future</param>
+        /// <param name="message">The message to response with</param>
+        /// <param name="topic">The topic string</param>
+        /// <param name="cancellationKey">An identifier that can be used with CancelFuturePublish to cancel the sending of this message at a later time</param>
+        void FuturePublish<T>(TimeSpan messageDelay, T message, string topic, string cancellationKey = null) where T : class;
         /// <summary>
         /// Unschedule all messages matching the cancellationKey.
         /// </summary>

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,10 +2,11 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.61.0.0")]
+[assembly: AssemblyVersion("0.62.0.0")]
 [assembly: CLSCompliant(false)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
+// 0.62.0.0 Completed support for topic based routing in future publish
 // 0.61.0.0 Added support for EXTERNAL authentication mechanism
 // 0.60.1.0 Added SimpleInjector DI support
 // 0.60.0.0 Remove [Serializable] attribute from messages and exceptions


### PR DESCRIPTION
Cannot see why routing key was hardcoded to # for all futurepublish implementations.