### PR TITLE
Bug fix: QueueDeclare does not allow an empty dead letter exchange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ packages
 
 # Ignore NuGet binary
 Source/.nuget/NuGet.exe
+/Source/.vs/config

--- a/Source/EasyNetQ.Tests/Integration/AdvancedApiExamples.cs
+++ b/Source/EasyNetQ.Tests/Integration/AdvancedApiExamples.cs
@@ -171,6 +171,50 @@ namespace EasyNetQ.Tests.Integration
             uint messageCount = advancedBus.MessageCount(queue);
             Console.WriteLine("{0} messages in queue", messageCount);
         }
+
+        [Test, Explicit]
+        public void Should_be_able_to_dead_letter_to_fixed_queue()
+        {
+            // create a main queue and a retry queue with retry queue dead lettering messages directly
+            // to main queue
+            var queue = advancedBus.QueueDeclare("main_queue");
+            var exchange = advancedBus.ExchangeDeclare("my_exchange", ExchangeType.Topic);
+            var retryQueue = advancedBus.QueueDeclare("retry_queue", deadLetterExchange: "", deadLetterRoutingKey: "main_queue");
+            advancedBus.Bind(exchange, retryQueue, "routing_key");
+
+            // consume from main queue to see if dead lettering is working as expected
+            advancedBus.Consume<MyMessage>(queue, (message, info) =>
+                Task.Factory.StartNew(() =>
+                    Console.WriteLine("Got message {0}", message.Body.Text)));
+
+            // publish the message to retry queue which should end up in the main queue after expiration
+            advancedBus.Publish(exchange, "routing_key", false, new Message<MyMessage>(new MyMessage() { Text = "My Message" }, new MessageProperties { Expiration = "50" }));
+
+            Thread.Sleep(1000);
+        }
+
+        [Test, Explicit]
+        public void Should_be_able_to_dead_letter_to_given_exchange()
+        {
+            // create a main queue and a retry queue both binding to the same topic exchange with 
+            // different routing keys. Retry queue is dead lettering to the exchange with routing key
+            // of main queue binding.
+            var queue = advancedBus.QueueDeclare("main_queue");
+            var exchange = advancedBus.ExchangeDeclare("my_exchange", ExchangeType.Topic);
+            advancedBus.Bind(exchange, queue, "main_routing_key");
+            var retryQueue = advancedBus.QueueDeclare("my_retry_queue", deadLetterExchange: "my_exchange", deadLetterRoutingKey: "main_routing_key");
+            advancedBus.Bind(exchange, retryQueue, "retry_routing_key");
+
+            // consume messages from main queue
+            advancedBus.Consume<MyMessage>(queue, (message, info) =>
+                Task.Factory.StartNew(() =>
+                    Console.WriteLine("Got message {0}", message.Body.Text)));
+
+            // publish message to the retry queue which should dead letter to main queue after expiration
+            advancedBus.Publish(exchange, "retry_routing_key", false, new Message<MyMessage>(new MyMessage() { Text = "My Message" }, new MessageProperties { Expiration = "50" }));
+
+            Thread.Sleep(1000);
+        }
     }
 }
 

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -380,7 +380,11 @@ namespace EasyNetQ
             {
                 arguments.Add("x-max-priority", maxPriority.Value);
             }
-            if (!string.IsNullOrEmpty(deadLetterExchange))
+            // Allow empty dead-letter-exchange as it represents the default rabbitmq exchange
+            // and thus is a valid value. To dead-letter a message directly to a queue, you
+            // would set dead-letter-exchange to empty and dead-letter-routing-key to name of the
+            // queue since every queue has a direct binding with default exchange.
+            if (deadLetterExchange != null)
             {
                 arguments.Add("x-dead-letter-exchange", deadLetterExchange);
             }
@@ -437,7 +441,11 @@ namespace EasyNetQ
             {
                 arguments.Add("x-max-priority", maxPriority.Value);
             }
-            if (!string.IsNullOrEmpty(deadLetterExchange))
+            // Allow empty dead-letter-exchange as it represents the default rabbitmq exchange
+            // and thus is a valid value. To dead-letter a message directly to a queue, you
+            // would set dead-letter-exchange to empty and dead-letter-routing-key to name of the
+            // queue since every queue has a direct binding with default exchange.
+            if (deadLetterExchange != null)
             {
                 arguments.Add("x-dead-letter-exchange", deadLetterExchange);
             }

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,10 +2,11 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.61.0.0")]
+[assembly: AssemblyVersion("0.61.1.0")]
 [assembly: CLSCompliant(false)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
+// 0.61.1.0 Bug Fix: QueueDeclare does not allow an empty dead letter exchange thus preventing directly publishing to a queue
 // 0.61.0.0 Added support for EXTERNAL authentication mechanism
 // 0.60.1.0 Added SimpleInjector DI support
 // 0.60.0.0 Remove [Serializable] attribute from messages and exceptions


### PR DESCRIPTION
Bug fix: QueueDeclare does not allow an empty dead letter exchange. Because of this there is no straightforward way to configure a queue so that it dead letters messages to another fixed queue. Empty exchange name is a valid value and represents default RabbitMQ exchange and is used to target messages directly to a queue since all queues by default have a direct binding with this exchange.

fixes #602 