### PR TITLE
ConsumerTag can now be set from IConsumerConfiguration

### DIFF
--- a/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
@@ -51,7 +51,7 @@ namespace EasyNetQ.Tests.ConsumeTests
 
         protected abstract void AdditionalSetUp();
 
-        protected void StartConsumer(Action<byte[], MessageProperties, MessageReceivedInfo> handler)
+        protected void StartConsumer(Action<byte[], MessageProperties, MessageReceivedInfo> handler, Action<IConsumerConfiguration> configure)
         {
             ConsumerWasInvoked = false;
             var queue = new Queue("my_queue", false);
@@ -63,7 +63,7 @@ namespace EasyNetQ.Tests.ConsumeTests
 
                     handler(body, properties, messageInfo);
                     ConsumerWasInvoked = true;
-                }, Cancellation.Token));
+                }, Cancellation.Token), configure);
         }
 
         protected void DeliverMessage()

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_delivered_to_the_consumer.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_delivered_to_the_consumer.cs
@@ -9,7 +9,7 @@ namespace EasyNetQ.Tests.ConsumeTests
     {
         protected override void AdditionalSetUp()
         {
-            StartConsumer((body, properties, info) => { });
+            StartConsumer((body, properties, info) => { }, c => { });
             DeliverMessage();
         }
 

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_an_error_occurs_in_the_message_handler.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_an_error_occurs_in_the_message_handler.cs
@@ -22,7 +22,7 @@ namespace EasyNetQ.Tests.ConsumeTests
             StartConsumer((body, properties, info) =>
                 {
                     throw exception;
-                });
+                }, c => { });
             DeliverMessage();
         }
 

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_cancellation_of_message_handler_occurs.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_cancellation_of_message_handler_occurs.cs
@@ -20,7 +20,7 @@ namespace EasyNetQ.Tests.ConsumeTests
                 {
                     Cancellation.Cancel();
                     Cancellation.Token.ThrowIfCancellationRequested();
-                });
+                }, c => { });
             DeliverMessage();
         }
 

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_consume_is_called.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_consume_is_called.cs
@@ -12,7 +12,7 @@ namespace EasyNetQ.Tests.ConsumeTests
     {
         protected override void AdditionalSetUp()
         {
-            StartConsumer((body, properties, info) => { });
+            StartConsumer((body, properties, info) => { }, c => { });
         }
 
         [Test]

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_consume_is_called_with_consumer_configuration.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_consume_is_called_with_consumer_configuration.cs
@@ -1,0 +1,43 @@
+﻿// ReSharper disable InconsistentNaming
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using RabbitMQ.Client;
+using Rhino.Mocks;
+
+namespace EasyNetQ.Tests.ConsumeTests
+{
+    [TestFixture]
+    public class When_consume_is_called_with_consumer_configuration : ConsumerTestBase
+    {
+        private string _consumerTag;
+
+        protected override void AdditionalSetUp()
+        {
+            _consumerTag = DateTime.Now.Ticks.ToString();
+            StartConsumer((body, properties, info) => { }, c => c.WithConsuemrTag(_consumerTag));
+        }
+
+        [Test]
+        public void Should_invoke_basic_consume_on_channel_with_provided_consumer_tag()
+        {
+            MockBuilder.Channels[0].AssertWasCalled(x => x.BasicConsume(
+                Arg<string>.Is.Anything,
+                Arg<bool>.Is.Anything, // NoAck
+                Arg<string>.Is.Equal(_consumerTag),
+                Arg<bool>.Is.Anything,
+                Arg<bool>.Is.Anything,
+                Arg<IDictionary<string, object>>.Is.Anything,
+                Arg<IBasicConsumer>.Is.Same(MockBuilder.Consumers[0])));
+        }
+
+        [Test]
+        public void Should_have_convention_provided_consumer_tag_by_default()
+        {
+            string consumerTag = null;
+            StartConsumer((body, properties, info) => { }, c => consumerTag = c.ConsumerTag);
+            Assert.AreEqual(ConsumerTag, consumerTag);
+        }
+    }
+}

--- a/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
+++ b/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
@@ -113,6 +113,7 @@
     <Compile Include="ConsumeTests\When_a_message_is_received.cs" />
     <Compile Include="ConsumeTests\When_a_polymorphic_message_is_delivered_to_the_consumer.cs" />
     <Compile Include="ConsumeTests\When_consume_is_called.cs" />
+    <Compile Include="ConsumeTests\When_consume_is_called_with_consumer_configuration.cs" />
     <Compile Include="FluentConfiguration\PublishConfigurationTests.cs" />
     <Compile Include="Integration\AdvancedBusTests.cs" />
     <Compile Include="Integration\PolymorphicRpc.cs" />

--- a/Source/EasyNetQ.Tests/PersistentConsumerTests/Given_a_PersistentConsumer.cs
+++ b/Source/EasyNetQ.Tests/PersistentConsumerTests/Given_a_PersistentConsumer.cs
@@ -50,7 +50,7 @@ namespace EasyNetQ.Tests.PersistentConsumerTests
                     createConsumerCalled++;
                     x.ReturnValue = internalConsumer;
                 }).Repeat.Any();
-            configuration = new ConsumerConfiguration(0);
+            configuration = new ConsumerConfiguration(0, Guid.NewGuid().ToString());
             consumer = new PersistentConsumer(
                 queue,
                 onMessage,

--- a/Source/EasyNetQ/Consumer/IConsumerConfiguration.cs
+++ b/Source/EasyNetQ/Consumer/IConsumerConfiguration.cs
@@ -6,8 +6,10 @@
         bool CancelOnHaFailover { get; }
         ushort PrefetchCount { get; }
         bool IsExclusive { get; }
+        string ConsumerTag { get; }
 
         IConsumerConfiguration WithPriority(int priority);
+        IConsumerConfiguration WithConsuemrTag(string consumerTag);
         IConsumerConfiguration WithCancelOnHaFailover(bool cancelOnHaFailover = true);
         IConsumerConfiguration WithPrefetchCount(ushort prefetchCount);
         IConsumerConfiguration AsExclusive();
@@ -15,18 +17,20 @@
 
     public class ConsumerConfiguration : IConsumerConfiguration
     {
-        public ConsumerConfiguration(ushort defaultPrefetchCount)
+        public ConsumerConfiguration(ushort defaultPrefetchCount, string consumerTag)
         {
             Priority = 0;
             CancelOnHaFailover = false;
             PrefetchCount = defaultPrefetchCount;
             IsExclusive = false;
+            ConsumerTag = consumerTag;
         }
 
         public int Priority { get; private set; }
         public bool IsExclusive { get; private set; }
         public bool CancelOnHaFailover { get; private set; }
         public ushort PrefetchCount { get; private set; }
+        public string ConsumerTag { get; private set; }
 
         public IConsumerConfiguration WithPriority(int priority)
         {
@@ -43,6 +47,12 @@
         public IConsumerConfiguration WithPrefetchCount(ushort prefetchCount)
         {
             PrefetchCount = prefetchCount;
+            return this;
+        }
+
+        public IConsumerConfiguration WithConsuemrTag(string consumerTag)
+        {
+            ConsumerTag = consumerTag;
             return this;
         }
 

--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -75,7 +75,7 @@ namespace EasyNetQ.Consumer
 
             this.queue = queue;
             this.onMessage = onMessage;
-            var consumerTag = conventions.ConsumerTagConvention();
+            var consumerTag = configuration.ConsumerTag;
             IDictionary<string, object> arguments = new Dictionary<string, object>
                 {
                     {"x-priority", configuration.Priority},

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -174,7 +174,7 @@ namespace EasyNetQ
             if (disposed)
                 throw new EasyNetQException("This bus has been disposed");
             
-            var consumerConfiguration = new ConsumerConfiguration(connectionConfiguration.PrefetchCount);
+            var consumerConfiguration = new ConsumerConfiguration(connectionConfiguration.PrefetchCount, conventions.ConsumerTagConvention());
             configure(consumerConfiguration);
             var consumer = consumerFactory.CreateConsumer(queue, (body, properties, receviedInfo) =>
                 {


### PR DESCRIPTION
The consumer tag can explicitly be set by using IConsumerConfiguration.WithConsuemrTag which allows users to specify unique consumer tags per subscription and override the convention. If not specified, the convention generated consumer tag is used,
