### PR TITLE
Make SimpleInjectorMessageDispatcher public so it can be used with AutoSubscriber

### DIFF
--- a/Source/EasyNetQ.DI.SimpleInjector/SimpleInjectorMessageDispatcher.cs
+++ b/Source/EasyNetQ.DI.SimpleInjector/SimpleInjectorMessageDispatcher.cs
@@ -4,7 +4,7 @@ using SimpleInjector;
 
 namespace EasyNetQ.DI
 {
-    class SimpleInjectorMessageDispatcher : IAutoSubscriberMessageDispatcher
+    public class SimpleInjectorMessageDispatcher : IAutoSubscriberMessageDispatcher
     {
         private readonly Container _container;
 

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 [assembly: CLSCompliant(false)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
+// 0.63.2.0 Make SimpleInjectorMessageDispatcher public so it can be used with AutoSubscriber
 // 0.63.1.0 Set upper bound of supported rabbitmq client version
 // 0.63.0.0 Make ConnectIntervalAttempt for PersistentConnection configurable on ConnectionConfiguration
 // 0.62.1.0 Bug Fix: QueueDeclare does not allow an empty dead letter exchange thus preventing directly publishing to a queue

--- a/hall_of_fame.md
+++ b/hall_of_fame.md
@@ -61,3 +61,4 @@ No particular order. Don't forget to add your name with your pull request.
 * Dan Barua
 * Alex Wiese
 * Georg Pfeiffer
+* Thomas T


### PR DESCRIPTION
In Autofac this is possible. This is not possible with SimpleInjectorMessageDispatcher because it's private.

var subscriber = new AutoSubscriber(_bus, "prefix")
            {
                AutoSubscriberMessageDispatcher = new AutofacMessageDispatcher(container)
            };