### PR TITLE
Add RabbitMQ broker custome port support to hosepipe.

### DIFF
--- a/Source/EasyNetQ.Hosepipe/HosepipeConnection.cs
+++ b/Source/EasyNetQ.Hosepipe/HosepipeConnection.cs
@@ -12,7 +12,8 @@ namespace EasyNetQ.Hosepipe
                 HostName = parameters.HostName,
                 VirtualHost = parameters.VHost,
                 UserName = parameters.Username,
-                Password = parameters.Password
+                Password = parameters.Password,
+                Port = parameters.HostPort
             };
             try
             {
@@ -21,10 +22,11 @@ namespace EasyNetQ.Hosepipe
             catch (BrokerUnreachableException)
             {
                 throw new EasyNetQHosepipeException(string.Format(
-                    "The broker at '{0}', VirtualHost '{1}', is unreachable. This message can also be caused " + 
+                    "The broker at '{0}{2}' VirtualHost '{1}', is unreachable. This message can also be caused " + 
                     "by incorrect credentials.",
                     parameters.HostName,
-                    parameters.VHost));
+                    parameters.VHost,
+                    parameters.HostPort == -1 ? string.Empty: ":" + parameters.HostPort));
             }
         } 
     }

--- a/Source/EasyNetQ.Hosepipe/Program.cs
+++ b/Source/EasyNetQ.Hosepipe/Program.cs
@@ -81,7 +81,8 @@ namespace EasyNetQ.Hosepipe
             var arguments = argParser.Parse(args);
 
             var parameters = new QueueParameters();
-            arguments.WithKey("s", a => parameters.HostName = a.Value);
+            arguments.WithKey("s", a => parameters.HostName = a.Value.Split(new [] {':'}, 2)[0]);
+            arguments.WithKey("s", a => parameters.HostPort = GetHostPort(a.Value));
             arguments.WithKey("v", a => parameters.VHost = a.Value);
             arguments.WithKey("u", a => parameters.Username = a.Value);
             arguments.WithKey("p", a => parameters.Password = a.Value);
@@ -124,6 +125,14 @@ namespace EasyNetQ.Hosepipe
                 Console.WriteLine();
                 PrintUsage();
             }
+        }
+
+        private int GetHostPort(string fullHostName)
+        {
+            var parts = fullHostName.Split(new[] {':'}, 2);
+            if (parts.Length == 2)
+                return int.Parse(parts[1]);
+            return -1;
         }
 
         private void Dump(QueueParameters parameters)

--- a/Source/EasyNetQ.Hosepipe/QueueParameters.cs
+++ b/Source/EasyNetQ.Hosepipe/QueueParameters.cs
@@ -5,6 +5,7 @@ namespace EasyNetQ.Hosepipe
     public class QueueParameters
     {
         public string HostName { get; set; }
+        public int HostPort { get; set; }
         public string VHost { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }

--- a/Source/EasyNetQ.Hosepipe/Usage.txt
+++ b/Source/EasyNetQ.Hosepipe/Usage.txt
@@ -34,7 +34,7 @@ Commands
 	?	Output this usage message
 
 Options
-	s	the RabbitMQ broker (server) to connect to. Default is 'localhost'
+	s	the RabbitMQ broker (server) to connect to. If the RabbitMQ brokers port is different from default, specify custom port value after ':' character. Default is 'localhost'
 	v	the virtual host. Default is '/'
 	u	the username to connect with. Default is 'guest'
 	p	the password to connect with. Default is 'guest'

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -3,10 +3,11 @@ using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
 // Note: until version 1.0 expect breaking changes on 0.X versions.
-[assembly: AssemblyVersion("0.63.0.0")]
+[assembly: AssemblyVersion("0.64.0.0")]
 [assembly: CLSCompliant(false)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
+// 0.64.0.0 Added RabbitMQ broker custom port support to hosepipe
 // 0.63.0.0 Make ConnectIntervalAttempt for PersistentConnection configurable on ConnectionConfiguration
 // 0.62.1.0 Bug Fix: QueueDeclare does not allow an empty dead letter exchange thus preventing directly publishing to a queue
 // 0.62.0.0 Completed support for topic based routing in future publish


### PR DESCRIPTION
Hosepipe tool uses default port for connection to RabbitMQ broker.
Added support for custom port. 
Now it's possible to execute tool with host name and port **s:HostName:123** like this.

