### PR TITLE
Hosepipe custom broker port configuration by separate parameter

### DIFF
--- a/Source/EasyNetQ.Hosepipe/ArgParser.cs
+++ b/Source/EasyNetQ.Hosepipe/ArgParser.cs
@@ -6,7 +6,7 @@ namespace EasyNetQ.Hosepipe
 {
     public class ArgParser
     {
-        readonly Regex argRegex = new Regex(@"([a-z])\:(.*)");
+        readonly Regex argRegex = new Regex(@"([a-z]{1,2})\:(.*)");
 
         public Arguments Parse(string[] args)
         {

--- a/Source/EasyNetQ.Hosepipe/ErrorRetry.cs
+++ b/Source/EasyNetQ.Hosepipe/ErrorRetry.cs
@@ -32,7 +32,7 @@ namespace EasyNetQ.Hosepipe
 
         public void RepublishError(Error error, QueueParameters parameters)
         {
-            using (var connection = HosepipeConnection.FromParamters(parameters))
+            using (var connection = HosepipeConnection.FromParameters(parameters))
             using (var model = connection.CreateModel())
             {
                 try

--- a/Source/EasyNetQ.Hosepipe/HosepipeConnection.cs
+++ b/Source/EasyNetQ.Hosepipe/HosepipeConnection.cs
@@ -5,7 +5,7 @@ namespace EasyNetQ.Hosepipe
 {
     public class HosepipeConnection
     {
-        public static IConnection FromParamters(QueueParameters parameters)
+        public static IConnection FromParameters(QueueParameters parameters)
         {
             var connectionFactory = new ConnectionFactory
             {

--- a/Source/EasyNetQ.Hosepipe/Program.cs
+++ b/Source/EasyNetQ.Hosepipe/Program.cs
@@ -81,8 +81,8 @@ namespace EasyNetQ.Hosepipe
             var arguments = argParser.Parse(args);
 
             var parameters = new QueueParameters();
-            arguments.WithKey("s", a => parameters.HostName = a.Value.Split(new [] {':'}, 2)[0]);
-            arguments.WithKey("s", a => parameters.HostPort = GetHostPort(a.Value));
+            arguments.WithKey("s", a => parameters.HostName = a.Value);
+            arguments.WithKey("sp", a => parameters.HostPort = Convert.ToInt32(a.Value));
             arguments.WithKey("v", a => parameters.VHost = a.Value);
             arguments.WithKey("u", a => parameters.Username = a.Value);
             arguments.WithKey("p", a => parameters.Password = a.Value);
@@ -125,14 +125,6 @@ namespace EasyNetQ.Hosepipe
                 Console.WriteLine();
                 PrintUsage();
             }
-        }
-
-        private int GetHostPort(string fullHostName)
-        {
-            var parts = fullHostName.Split(new[] {':'}, 2);
-            if (parts.Length == 2)
-                return int.Parse(parts[1]);
-            return -1;
         }
 
         private void Dump(QueueParameters parameters)

--- a/Source/EasyNetQ.Hosepipe/QueueInsertion.cs
+++ b/Source/EasyNetQ.Hosepipe/QueueInsertion.cs
@@ -17,7 +17,7 @@ namespace EasyNetQ.Hosepipe
 
         public void PublishMessagesToQueue(IEnumerable<HosepipeMessage> messages, QueueParameters parameters)
         {
-            using (var connection = HosepipeConnection.FromParamters(parameters))
+            using (var connection = HosepipeConnection.FromParameters(parameters))
             using (var channel = connection.CreateModel())
             {
                 foreach (var message in messages)

--- a/Source/EasyNetQ.Hosepipe/QueueParameters.cs
+++ b/Source/EasyNetQ.Hosepipe/QueueParameters.cs
@@ -18,6 +18,7 @@ namespace EasyNetQ.Hosepipe
         {
             // set some defaults
             HostName = "localhost";
+            HostPort = -1;
             VHost = "/";
             Username = "guest";
             Password = "guest";

--- a/Source/EasyNetQ.Hosepipe/QueueRetrieval.cs
+++ b/Source/EasyNetQ.Hosepipe/QueueRetrieval.cs
@@ -22,7 +22,7 @@ namespace EasyNetQ.Hosepipe
 
         public IEnumerable<HosepipeMessage> GetMessagesFromQueue(QueueParameters parameters)
         {
-            using (var connection = HosepipeConnection.FromParamters(parameters))
+            using (var connection = HosepipeConnection.FromParameters(parameters))
             using (var channel = connection.CreateModel())
             {
                 try

--- a/Source/EasyNetQ.Hosepipe/Usage.txt
+++ b/Source/EasyNetQ.Hosepipe/Usage.txt
@@ -34,7 +34,8 @@ Commands
 	?	Output this usage message
 
 Options
-	s	the RabbitMQ broker (server) to connect to. If the RabbitMQ brokers port is different from default, specify custom port value after ':' character. Default is 'localhost'
+	s	the RabbitMQ broker (server) to connect to. Default is 'localhost'
+	sp  the RabbitMQ broker server port to connect to. Default is '-1' 
 	v	the virtual host. Default is '/'
 	u	the username to connect with. Default is 'guest'
 	p	the password to connect with. Default is 'guest'

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -3,10 +3,11 @@ using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
 // Note: until version 1.0 expect breaking changes on 0.X versions.
-[assembly: AssemblyVersion("0.64.0.0")]
+[assembly: AssemblyVersion("0.64.1.0")]
 [assembly: CLSCompliant(false)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
+// 0.64.1.0 Hosepipe custom broker port configuration by separate parameter
 // 0.64.0.0 Added RabbitMQ broker custom port support to hosepipe
 // 0.63.0.0 Make ConnectIntervalAttempt for PersistentConnection configurable on ConnectionConfiguration
 // 0.62.1.0 Bug Fix: QueueDeclare does not allow an empty dead letter exchange thus preventing directly publishing to a queue


### PR DESCRIPTION
Refactored hosepipe broker customer port configuration. Now it's a new command line parameter 'sp' (server port).