### PR TITLE
Fix Client Command Dispatcher Thread hijacking

### DIFF
--- a/Source/EasyNetQ.Tests/ClientCommandDispatcherTests/When_an_action_is_invoked.cs
+++ b/Source/EasyNetQ.Tests/ClientCommandDispatcherTests/When_an_action_is_invoked.cs
@@ -1,7 +1,9 @@
 ﻿// ReSharper disable InconsistentNaming
 
 using System;
-using System.Threading;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using EasyNetQ.ConnectionString;
 using EasyNetQ.Producer;
 using NUnit.Framework;
@@ -22,7 +24,6 @@ namespace EasyNetQ.Tests.ClientCommandDispatcherTests
         public void SetUp()
         {
             actionWasInvoked = false;
-            actionThreadName = "Not set";
 
             var parser = new ConnectionStringParser();
             var configuration = parser.Parse("host=localhost");
@@ -33,7 +34,6 @@ namespace EasyNetQ.Tests.ClientCommandDispatcherTests
             Action<IModel> action = x =>
                 {
                     actionWasInvoked = true;
-                    actionThreadName = Thread.CurrentThread.Name;
                 };
 
             channelFactory.Stub(x => x.CreatePersistentChannel(connection)).Return(channel);
@@ -64,9 +64,22 @@ namespace EasyNetQ.Tests.ClientCommandDispatcherTests
         }
 
         [Test]
-        public void Should_invoke_the_action_on_the_dispatcher_thread()
+        public void Should_call_actions_concurrently()
         {
-            actionThreadName.ShouldEqual("Client Command Dispatcher Thread");
+            const int numberOfCalls = 1000;
+            var actionsWereInvoked = new Dictionary<int, bool>();
+            var actions = (from key in Enumerable.Range(0, numberOfCalls)
+                let action = new Action<IModel>(x => actionsWereInvoked[key] = true)
+                select new {Key = key, Action = action}).ToArray();
+
+            Task.WhenAll(actions.Select(x => dispatcher.InvokeAsync(x.Action))).Wait();
+
+            foreach (var action in actions)
+            {
+                var failMessage = string.Format("Action with key {0} was not invoked", action.Key);
+                var wasInvoked = actionsWereInvoked.ContainsKey(action.Key) && actionsWereInvoked[action.Key];
+                Assert.True(wasInvoked, failMessage);
+            }
         }
     }
 }

--- a/Source/EasyNetQ.Tests/ClientCommandDispatcherTests/When_an_action_is_invoked_that_throws.cs
+++ b/Source/EasyNetQ.Tests/ClientCommandDispatcherTests/When_an_action_is_invoked_that_throws.cs
@@ -58,6 +58,26 @@ namespace EasyNetQ.Tests.ClientCommandDispatcherTests
             }
         }
 
+        [Test]
+        public void Should_call_action_when_previous_throwed_an_exception()
+        {
+            Action<IModel> errorAction = x => { throw new Exception(); };
+            var goodActionWasInvoked = false;
+            Action<IModel> goodAction = x => { goodActionWasInvoked = true; };
+
+            try
+            {
+                dispatcher.InvokeAsync(errorAction).Wait();
+            }
+            catch
+            {
+                // ignore exception
+            }
+
+            dispatcher.InvokeAsync(goodAction).Wait();
+            goodActionWasInvoked.ShouldBeTrue();
+        }
+
         private class CrazyTestOnlyException : Exception { }
     }
 }

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
 // Note: until version 1.0 expect breaking changes on 0.X versions.
-[assembly: AssemblyVersion("0.63.5.0")]
+[assembly: AssemblyVersion("0.63.6.0")]
 [assembly: CLSCompliant(false)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.


### PR DESCRIPTION
Fix #623

Replace Client Command Dispatched Thread with critical section around `persistentChannel`.  I'm afraid that there was a special reason why the Client Command Dispatched Thread was implemented instead of critical section which I can't understand.
