### PR TITLE
Remove on Core the methods that read the application config file

### DIFF
--- a/Source/EasyNetQ/ConnectionConfiguration.cs
+++ b/Source/EasyNetQ/ConnectionConfiguration.cs
@@ -71,10 +71,8 @@ namespace EasyNetQ
             var version = this.GetType().GetTypeInfo().Assembly.GetName().Version.ToString();
 #else
             var version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-            applicationNameAndPath = Environment.GetCommandLineArgs()[0];
 #endif
-
-
+            applicationNameAndPath = Environment.GetCommandLineArgs()[0];
 
             var applicationName = "unknown";
             var applicationPath = "unknown";

--- a/Source/EasyNetQ/RabbitHutch.cs
+++ b/Source/EasyNetQ/RabbitHutch.cs
@@ -26,6 +26,7 @@ namespace EasyNetQ
             createContainerInternal = createContainer;
         }
 
+#if NETFX
         /// <summary>
         /// Creates a new instance of <see cref="RabbitBus"/>.
         /// The RabbitMQ broker is defined in the connection string named 'rabbit'.
@@ -74,7 +75,6 @@ namespace EasyNetQ
         public static IBus CreateBus(AdvancedBusEventHandlers advancedBusEventHandlers, Action<IServiceRegister> registerServices)
         {
             string rabbitConnectionString;
-#if NETFX
             var rabbitConnection = ConfigurationManager.ConnectionStrings["rabbit"];
             if (rabbitConnection == null)
             {
@@ -85,9 +85,6 @@ namespace EasyNetQ
                     "<add name=\"rabbit\" connectionString=\"host=localhost\" />");
             }
             rabbitConnectionString = rabbitConnection.ConnectionString;
-#else
-            rabbitConnectionString = "host=localhost"; // TODO: get from configuration in net core 
-#endif
 
             return CreateBus(rabbitConnectionString, advancedBusEventHandlers, registerServices);
         }
@@ -109,6 +106,7 @@ namespace EasyNetQ
         {
             return CreateBus(advancedBusEventHandlers, c => {});
         }
+#endif
 
         /// <summary>
         /// Creates a new instance of <see cref="RabbitBus"/>.


### PR DESCRIPTION
On Core, remove the CreateBus API's that read the application config file. The user will need to pass in the connection string when creating a bus.