### PR TITLE
Migrates remaining projects to .NET Core or xproj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ Source/.nuget/NuGet.exe
 
 # VS2015
 .vs/
+
+# NuGet v3's project.json files produces more ignoreable files
+*.nuget.props
+*.nuget.targets

--- a/Source/EasyNetQ.DI.Autofac/project.json
+++ b/Source/EasyNetQ.DI.Autofac/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.3-netcore0001",
+  "version": "99.0.0-dev",
   "description": "An adaptor to allow EasyNetQ to use Autofac as its internal IoC container",
   "title": "EasyNetQ.DI.Autofac",
   "name": "EasyNetQ.DI.Autofac",
@@ -36,7 +36,7 @@
 
   "dependencies": {
     "Autofac": "4.0.0",
-    "EasyNetQ": "2.0.2-netcore0001"
+    "EasyNetQ": "99.0.0-dev"
   },
 
   "tools": {

--- a/Source/EasyNetQ.DI.Autofac/project.json
+++ b/Source/EasyNetQ.DI.Autofac/project.json
@@ -27,10 +27,18 @@
     "Wiebe Tijsma",
     "Contributors (see GitHub repo) "
   ],
+
+  "buildOptions": {
+    "compile": {
+      "includeFiles": "..\\Version.cs"
+    }
+  },
+
   "dependencies": {
     "Autofac": "4.0.0",
     "EasyNetQ": "2.0.2-netcore0001"
   },
+
   "tools": {
     "dotnet-gitversion": {
       "version": "1.0.0",

--- a/Source/EasyNetQ.DI.LightInject/project.json
+++ b/Source/EasyNetQ.DI.LightInject/project.json
@@ -27,10 +27,18 @@
     "Wiebe Tijsma",
     "Contributors (see GitHub repo) "
   ],
+
+  "buildOptions": {
+    "compile": {
+      "includeFiles": "..\\Version.cs"
+    }
+  },
+
   "dependencies": {
     "LightInject": "4.0.11",
     "EasyNetQ": "2.0.2-netcore0001"
   },
+
   "tools": {
     "dotnet-gitversion": {
       "version": "1.0.0",

--- a/Source/EasyNetQ.DI.LightInject/project.json
+++ b/Source/EasyNetQ.DI.LightInject/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.3-netcore0001",
+  "version": "99.0.0-dev",
   "description": "An adaptor to allow EasyNetQ to use LightInject as its internal IoC container",
   "title": "EasyNetQ.DI.LightInject",
   "name": "EasyNetQ.DI.LightInject",
@@ -36,7 +36,7 @@
 
   "dependencies": {
     "LightInject": "4.0.11",
-    "EasyNetQ": "2.0.2-netcore0001"
+    "EasyNetQ": "99.0.0-dev"
   },
 
   "tools": {

--- a/Source/EasyNetQ.DI.Ninject/project.json
+++ b/Source/EasyNetQ.DI.Ninject/project.json
@@ -27,10 +27,18 @@
     "Wiebe Tijsma",
     "Contributors (see GitHub repo) "
   ],
+
+  "buildOptions": {
+    "compile": {
+      "includeFiles": "..\\Version.cs"
+    }
+  },
+
   "dependencies": {
     "Ninject": "4.0.0-beta-0134",
     "EasyNetQ": "2.0.2-netcore0001"
   },
+
   "tools": {
     "dotnet-gitversion": {
       "version": "1.0.0",

--- a/Source/EasyNetQ.DI.Ninject/project.json
+++ b/Source/EasyNetQ.DI.Ninject/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.3-netcore0001",
+  "version": "99.0.0-dev",
   "description": "An adaptor to allow EasyNetQ to use Ninject as its internal IoC container",
   "title": "EasyNetQ.DI.Ninject",
   "name": "EasyNetQ.DI.Ninject",
@@ -36,7 +36,7 @@
 
   "dependencies": {
     "Ninject": "4.0.0-beta-0134",
-    "EasyNetQ": "2.0.2-netcore0001"
+    "EasyNetQ": "99.0.0-dev"
   },
 
   "tools": {

--- a/Source/EasyNetQ.DI.SimpleInjector/project.json
+++ b/Source/EasyNetQ.DI.SimpleInjector/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.3-netcore0001",
+  "version": "99.0.0-dev",
   "description": "An adaptor to allow EasyNetQ to use SimpleInjector as its internal IoC container",
   "title": "EasyNetQ.DI.SimpleInjector",
   "name": "EasyNetQ.DI.SimpleInjector",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "SimpleInjector": "3.2.7",
-    "EasyNetQ": "2.0.2-netcore0001"
+    "EasyNetQ": "99.0.0-dev"
   },
 
   "tools": {

--- a/Source/EasyNetQ.DI.StructureMap/project.json
+++ b/Source/EasyNetQ.DI.StructureMap/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.3-netcore0001",
+  "version": "99.0.0-dev",
   "description": "An adaptor to allow EasyNetQ to use StructureMap as its internal IoC container",
   "title": "EasyNetQ.DI.StructureMap",
   "name": "EasyNetQ.DI.StructureMap",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "structuremap": "4.4.0",
-    "EasyNetQ": "2.0.2-netcore0001"
+    "EasyNetQ": "99.0.0-dev"
   },
 
   "tools": {

--- a/Source/EasyNetQ.DI.StructureMap/project.json
+++ b/Source/EasyNetQ.DI.StructureMap/project.json
@@ -27,10 +27,17 @@
     "Wiebe Tijsma",
     "Contributors (see GitHub repo) "
   ],
+
+  "buildOptions": {
+    "compile": {
+      "includeFiles": "..\\Version.cs"
+    }
+  },
   "dependencies": {
     "structuremap": "4.4.0",
     "EasyNetQ": "2.0.2-netcore0001"
   },
+
   "tools": {
     "dotnet-gitversion": {
       "version": "1.0.0",

--- a/Source/EasyNetQ.DI.Tests/project.json
+++ b/Source/EasyNetQ.DI.Tests/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.2-netcore0001",
+  "version": "99.0.0-dev",
   "description": "EasyNetQ.DI.Tests",
   "title": "EasyNetQ.DI.Tests",
   "name": "EasyNetQ.DI.Tests",
@@ -10,21 +10,21 @@
     }
   },
   "dependencies": {
-    "NUnit": "3.5.0",
-    "NSubstitute": "2.0.0-rc",
-    "Newtonsoft.Json": "9.0.1",
-    "dotnet-test-nunit": "3.4.0-beta-3",
-    "RabbitMQ.Client": "4.1.1",
-    "EasyNetQ": "2.0.2-netcore0001",
     "Autofac": "4.0.0",
+    "dotnet-test-nunit": "3.4.0-beta-3",
+    "EasyNetQ": "99.0.0-dev",
+    "EasyNetQ.DI.Autofac": "99.0.0-dev",
+    "EasyNetQ.DI.LightInject": "99.0.0-dev",
+    "EasyNetQ.DI.Ninject": "99.0.0-dev",
+    "EasyNetQ.DI.SimpleInjector": "99.0.0-dev",
+    "EasyNetQ.DI.StructureMap": "99.0.0-dev",
     "LightInject": "4.0.11",
+    "Newtonsoft.Json": "9.0.1",
     "Ninject": "4.0.0-beta-0134",
-    "SimpleInjector": "3.2.7",
-    "EasyNetQ.DI.Autofac": "2.0.2-netcore0001",
-    "EasyNetQ.DI.LightInject": "2.0.2-netcore0001",
-    "EasyNetQ.DI.Ninject": "2.0.2-netcore0001",
-    "EasyNetQ.DI.SimpleInjector": "2.0.2-netcore0001",
-    "EasyNetQ.DI.StructureMap": "2.0.2-netcore0001"
+    "NSubstitute": "2.0.0-rc",
+    "NUnit": "3.5.0",
+    "RabbitMQ.Client": "4.1.1",
+    "SimpleInjector": "3.2.7"
   },
 
   "testRunner": "nunit",
@@ -48,7 +48,7 @@
       "dependencies": {
         "Castle.Core": "3.3.3",
         "Castle.Windsor": "3.3.0",
-        "EasyNetQ.DI.Windsor": "2.0.2-netcore0001"
+        "EasyNetQ.DI.Windsor": "99.0.0-dev"
       }
     }
   }

--- a/Source/EasyNetQ.DI.Tests/project.json
+++ b/Source/EasyNetQ.DI.Tests/project.json
@@ -3,53 +3,53 @@
   "description": "EasyNetQ.DI.Tests",
   "title": "EasyNetQ.DI.Tests",
   "name": "EasyNetQ.DI.Tests",
+
   "buildOptions": {
     "compile": {
       "includeFiles": "..\\Version.cs"
+    }
+  },
+  "dependencies": {
+    "NUnit": "3.5.0",
+    "NSubstitute": "2.0.0-rc",
+    "Newtonsoft.Json": "9.0.1",
+    "dotnet-test-nunit": "3.4.0-beta-3",
+    "RabbitMQ.Client": "4.1.1",
+    "EasyNetQ": "2.0.2-netcore0001",
+    "Autofac": "4.0.0",
+    "LightInject": "4.0.11",
+    "Ninject": "4.0.0-beta-0134",
+    "SimpleInjector": "3.2.7",
+    "EasyNetQ.DI.Autofac": "2.0.2-netcore0001",
+    "EasyNetQ.DI.LightInject": "2.0.2-netcore0001",
+    "EasyNetQ.DI.Ninject": "2.0.2-netcore0001",
+    "EasyNetQ.DI.SimpleInjector": "2.0.2-netcore0001",
+    "EasyNetQ.DI.StructureMap": "2.0.2-netcore0001"
+  },
+
+  "testRunner": "nunit",
+
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": "portable-net45+win8",
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.1",
+          "type": "platform"
+        }
       }
     },
-   "dependencies": {
-      "NUnit": "3.5.0",
-      "NSubstitute": "2.0.0-rc",
-      "Newtonsoft.Json": "9.0.1",
-      "dotnet-test-nunit": "3.4.0-beta-3",
-      "RabbitMQ.Client": "4.1.1",
-      "EasyNetQ": "2.0.2-netcore0001",
-      "Autofac": "4.0.0",
-      "LightInject": "4.0.11",
-      "Ninject": "4.0.0-beta-0134",
-      "SimpleInjector": "3.2.7",
-      "EasyNetQ.DI.Autofac": "2.0.2-netcore0001",
-      "EasyNetQ.DI.LightInject": "2.0.2-netcore0001",
-      "EasyNetQ.DI.Ninject": "2.0.2-netcore0001",
-      "EasyNetQ.DI.SimpleInjector": "2.0.2-netcore0001",
-      "EasyNetQ.DI.StructureMap": "2.0.2-netcore0001"
-    },
-
-    "testRunner": "nunit",
-
-    "frameworks": {
-      "netcoreapp1.0": {
-        "imports": "portable-net45+win8",
-        "dependencies": {
-          "Microsoft.NETCore.App": {
-            "version": "1.0.0-*",
-            "type": "platform"
-          }
-        }
+    "net451": {
+      "buildOptions": {
+        "define": [
+          "NETFX"
+        ]
       },
-      "net451": {
-        "buildOptions": {
-          "define": [
-            "NETFX"
-          ]
-        },
-        "dependencies": {
-          "Castle.Core": "3.3.3",
-          "Castle.Windsor": "3.3.0",
-          "EasyNetQ.DI.Windsor": "2.0.2-netcore0001"
-        }
+      "dependencies": {
+        "Castle.Core": "3.3.3",
+        "Castle.Windsor": "3.3.0",
+        "EasyNetQ.DI.Windsor": "2.0.2-netcore0001"
       }
-
     }
   }
+}

--- a/Source/EasyNetQ.DI.Windsor/project.json
+++ b/Source/EasyNetQ.DI.Windsor/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.3-netcore0001",
+  "version": "99.0.0-dev",
   "description": "An adaptor to allow EasyNetQ to use Castle.Windsor as its internal IoC container",
   "title": "EasyNetQ.DI.Windsor",
   "name": "EasyNetQ.DI.Windsor",
@@ -30,7 +30,7 @@
   "dependencies": {
     "Castle.Core": "3.3.3",
     "Castle.Windsor": "3.3.0",
-    "EasyNetQ": "2.0.2-netcore0001"
+    "EasyNetQ": "99.0.0-dev"
   },
   "tools": {
     "dotnet-gitversion": {

--- a/Source/EasyNetQ.Hosepipe.SetupActions/EasyNetQ.Hosepipe.SetupActions.xproj
+++ b/Source/EasyNetQ.Hosepipe.SetupActions/EasyNetQ.Hosepipe.SetupActions.xproj
@@ -1,15 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>6b86e7df-72b7-474b-9409-3c0a787bfb09</ProjectGuid>
-    <RootNamespace>EasyNetQ.Tests.Messages</RootNamespace>
+    <ProjectGuid>93F795C9-FCA3-4B9F-B7EC-19759B8E44CE</ProjectGuid>
+    <RootNamespace>EasyNetQ.Hosepipe.SetupActions</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Source/EasyNetQ.Hosepipe.SetupActions/project.json
+++ b/Source/EasyNetQ.Hosepipe.SetupActions/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.2-netcore0001",
+  "version": "99.0.0-dev",
   "description": "EasyNetQ.Hosepipe.SetupActions",
   "title": "EasyNetQ.Hosepipe.SetupActions",
   "name": "EasyNetQ.Hosepipe.SetupActions",
@@ -34,7 +34,7 @@
     }
   },
   "dependencies": {
-    "EasyNetQ": "2.0.2-netcore0001"
+    "EasyNetQ": "99.0.0-dev"
   },
   "tools": {
     "dotnet-gitversion": {

--- a/Source/EasyNetQ.Hosepipe.SetupActions/project.json
+++ b/Source/EasyNetQ.Hosepipe.SetupActions/project.json
@@ -48,16 +48,6 @@
     "dn-version": "dotnet gitversion"
   },
   "frameworks": {
-    "netstandard1.5": {
-      "buildOptions": {
-        "define": [
-          "NET_STANDARD"
-        ]
-      },
-      "dependencies": {
-
-      }
-    },
     "net451": {
       "buildOptions": {
         "define": [
@@ -65,7 +55,7 @@
         ]
       },
       "frameworkAssemblies": {
-
+        "System.Configuration.Install": "4.0.0.0"
       }
     }
   },

--- a/Source/EasyNetQ.Hosepipe.SetupActions/project.json
+++ b/Source/EasyNetQ.Hosepipe.SetupActions/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "2.0.3-netcore0001",
-  "description": "An adaptor to allow EasyNetQ to use SimpleInjector as its internal IoC container",
-  "title": "EasyNetQ.DI.SimpleInjector",
-  "name": "EasyNetQ.DI.SimpleInjector",
+  "version": "2.0.2-netcore0001",
+  "description": "EasyNetQ.Hosepipe.SetupActions",
+  "title": "EasyNetQ.Hosepipe.SetupActions",
+  "name": "EasyNetQ.Hosepipe.SetupActions",
   "packOptions": {
     "licenseUrl": "https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/master/licence.txt",
     "projectUrl": "https://github.com/EasyNetQ/EasyNetQ",
@@ -34,10 +34,8 @@
     }
   },
   "dependencies": {
-    "SimpleInjector": "3.2.7",
     "EasyNetQ": "2.0.2-netcore0001"
   },
-
   "tools": {
     "dotnet-gitversion": {
       "version": "1.0.0",
@@ -56,7 +54,9 @@
           "NET_STANDARD"
         ]
       },
-      "dependencies": {}
+      "dependencies": {
+
+      }
     },
     "net451": {
       "buildOptions": {
@@ -64,7 +64,13 @@
           "NETFX"
         ]
       },
-      "frameworkAssemblies": {}
+      "frameworkAssemblies": {
+
+      }
     }
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {}
   }
 }

--- a/Source/EasyNetQ.Hosepipe.Tests/EasyNetQ.Hosepipe.Tests.xproj
+++ b/Source/EasyNetQ.Hosepipe.Tests/EasyNetQ.Hosepipe.Tests.xproj
@@ -15,5 +15,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/Source/EasyNetQ.Hosepipe.Tests/EasyNetQ.Hosepipe.Tests.xproj
+++ b/Source/EasyNetQ.Hosepipe.Tests/EasyNetQ.Hosepipe.Tests.xproj
@@ -1,15 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>6b86e7df-72b7-474b-9409-3c0a787bfb09</ProjectGuid>
-    <RootNamespace>EasyNetQ.Tests.Messages</RootNamespace>
+    <ProjectGuid>DA597678-7873-4156-8112-8C70B164381A</ProjectGuid>
+    <RootNamespace>EasyNetQ.Hosepipe.Tests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Source/EasyNetQ.Hosepipe.Tests/FileMessageWriterTests.cs
+++ b/Source/EasyNetQ.Hosepipe.Tests/FileMessageWriterTests.cs
@@ -10,7 +10,7 @@ namespace EasyNetQ.Hosepipe.Tests
     [TestFixture]
     public class FileMessageWriterTests
     {
-        private const string tempDirectory = @"C:\temp\MessageOutput";
+        private readonly string tempDirectory = Path.Combine(Path.GetTempPath(), @"MessageOutput");
 
         [SetUp]
         public void SetUp() {}
@@ -19,9 +19,17 @@ namespace EasyNetQ.Hosepipe.Tests
         public void WriteSomeFiles()
         {
             var directory = new DirectoryInfo(tempDirectory);
-            foreach (var file in directory.EnumerateFiles())
+
+            if (!directory.Exists)
             {
-                file.Delete();
+                directory.Create();
+            }
+            else
+            {
+                foreach (var file in directory.EnumerateFiles())
+                {
+                    file.Delete();
+                }
             }
 
             var properties = new MessageProperties();

--- a/Source/EasyNetQ.Hosepipe.Tests/ProgramTests.cs
+++ b/Source/EasyNetQ.Hosepipe.Tests/ProgramTests.cs
@@ -44,7 +44,7 @@ namespace EasyNetQ.Hosepipe.Tests
         }
 
         private readonly string expectedDumpOutput =
-            "2 Messages from queue 'EasyNetQ_Default_Error_Queue'\r\noutput to directory '" + Environment.CurrentDirectory + "'\r\n";
+            "2 Messages from queue 'EasyNetQ_Default_Error_Queue'\r\noutput to directory '" + Directory.GetCurrentDirectory() + "'\r\n";
 
         [Test]
         public void Should_output_messages_to_directory_with_dump()
@@ -68,7 +68,7 @@ namespace EasyNetQ.Hosepipe.Tests
         }
 
         private readonly string expectedInsertOutput =
-            "2 Messages from directory '" + Environment.CurrentDirectory + "'\r\ninserted into queue ''\r\n";
+            "2 Messages from directory '" + Directory.GetCurrentDirectory() + "'\r\ninserted into queue ''\r\n";
 
         [Test]
         public void Should_insert_messages_with_insert()
@@ -90,7 +90,7 @@ namespace EasyNetQ.Hosepipe.Tests
         }
 
         private readonly string expectedRetryOutput =
-            "2 Error messages from directory '" + Environment.CurrentDirectory + "' republished\r\n";
+            "2 Error messages from directory '" + Directory.GetCurrentDirectory() + "' republished\r\n";
 
 
         [Test]

--- a/Source/EasyNetQ.Hosepipe.Tests/project.json
+++ b/Source/EasyNetQ.Hosepipe.Tests/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.2-netcore0001",
+  "version": "99.0.0-dev",
   "description": "EasyNetQ.Hosepipe.Tests",
   "title": "EasyNetQ.Hosepipe.Tests",
   "name": "EasyNetQ.Hosepipe.Tests",
@@ -34,8 +34,8 @@
   },
   "dependencies": {
     "dotnet-test-nunit": "3.4.0-beta-3",
-    "EasyNetQ": "2.0.2-netcore0001",
-    "EasyNetQ.Hosepipe": "2.0.2-netcore0001",
+    "EasyNetQ": "99.0.0-dev",
+    "EasyNetQ.Hosepipe": "99.0.0-dev",
     "NUnit": "3.5.0",
     "RabbitMQ.Client": "4.1.1"
   },

--- a/Source/EasyNetQ.Hosepipe.Tests/project.json
+++ b/Source/EasyNetQ.Hosepipe.Tests/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "2.0.3-netcore0001",
-  "description": "An adaptor to allow EasyNetQ to use SimpleInjector as its internal IoC container",
-  "title": "EasyNetQ.DI.SimpleInjector",
-  "name": "EasyNetQ.DI.SimpleInjector",
+  "version": "2.0.2-netcore0001",
+  "description": "EasyNetQ.Hosepipe.Tests",
+  "title": "EasyNetQ.Hosepipe.Tests",
+  "name": "EasyNetQ.Hosepipe.Tests",
   "packOptions": {
     "licenseUrl": "https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/master/licence.txt",
     "projectUrl": "https://github.com/EasyNetQ/EasyNetQ",
@@ -27,17 +27,18 @@
     "Wiebe Tijsma",
     "Contributors (see GitHub repo) "
   ],
-
   "buildOptions": {
     "compile": {
       "includeFiles": "..\\Version.cs"
     }
   },
   "dependencies": {
-    "SimpleInjector": "3.2.7",
-    "EasyNetQ": "2.0.2-netcore0001"
+    "dotnet-test-nunit": "3.4.0-beta-3",
+    "EasyNetQ": "2.0.2-netcore0001",
+    "EasyNetQ.Hosepipe": "2.0.2-netcore0001",
+    "NUnit": "3.5.0",
+    "RabbitMQ.Client": "4.1.1"
   },
-
   "tools": {
     "dotnet-gitversion": {
       "version": "1.0.0",
@@ -49,22 +50,34 @@
   "commands": {
     "dn-version": "dotnet gitversion"
   },
+
+  "testRunner": "nunit",
+
   "frameworks": {
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "buildOptions": {
         "define": [
           "NET_STANDARD"
         ]
       },
-      "dependencies": {}
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.1",
+          "type": "platform"
+        }
+      },
+      "imports": "dnxcore50"
     },
     "net451": {
       "buildOptions": {
         "define": [
           "NETFX"
         ]
-      },
-      "frameworkAssemblies": {}
+      }
     }
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {}
   }
 }

--- a/Source/EasyNetQ.Hosepipe/EasyNetQ.Hosepipe.xproj
+++ b/Source/EasyNetQ.Hosepipe/EasyNetQ.Hosepipe.xproj
@@ -1,16 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
+
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>6b86e7df-72b7-474b-9409-3c0a787bfb09</ProjectGuid>
-    <RootNamespace>EasyNetQ.Tests.Messages</RootNamespace>
+    <ProjectGuid>99A7A83D-6F75-4A1C-83E8-7C4AF881B273</ProjectGuid>
+    <RootNamespace>EasyNetQ.Hosepipe</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
+
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/Source/EasyNetQ.Hosepipe/Program.cs
+++ b/Source/EasyNetQ.Hosepipe/Program.cs
@@ -178,7 +178,7 @@ namespace EasyNetQ.Hosepipe
 
         public static void PrintUsage()
         {
-            using (var manifest = Assembly.GetExecutingAssembly().GetManifestResourceStream("EasyNetQ.Hosepipe.Usage.txt"))
+            using (var manifest = typeof(Program).GetTypeInfo().Assembly.GetManifestResourceStream("EasyNetQ.Hosepipe.Usage.txt"))
             {
                 if(manifest == null)
                 {

--- a/Source/EasyNetQ.Hosepipe/QueueParameters.cs
+++ b/Source/EasyNetQ.Hosepipe/QueueParameters.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 
 namespace EasyNetQ.Hosepipe
 {
@@ -22,7 +23,7 @@ namespace EasyNetQ.Hosepipe
             Password = "guest";
             Purge = false;
             NumberOfMessagesToRetrieve = 1000;
-            MessageFilePath = Environment.CurrentDirectory;
+            MessageFilePath = Directory.GetCurrentDirectory();
         }
     }
 }

--- a/Source/EasyNetQ.Hosepipe/project.json
+++ b/Source/EasyNetQ.Hosepipe/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.2-netcore0001",
+  "version": "99.0.0-dev",
   "description": "EasyNetQ.Hosepipe",
   "title": "EasyNetQ.Hosepipe",
   "name": "EasyNetQ.Hosepipe",
@@ -34,7 +34,7 @@
     }
   },
   "dependencies": {
-    "EasyNetQ": "2.0.2-netcore0001"
+    "EasyNetQ": "99.0.0-dev"
   },
 
   "tools": {

--- a/Source/EasyNetQ.Hosepipe/project.json
+++ b/Source/EasyNetQ.Hosepipe/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "2.0.3-netcore0001",
-  "description": "An adaptor to allow EasyNetQ to use SimpleInjector as its internal IoC container",
-  "title": "EasyNetQ.DI.SimpleInjector",
-  "name": "EasyNetQ.DI.SimpleInjector",
+  "version": "2.0.2-netcore0001",
+  "description": "EasyNetQ.Hosepipe",
+  "title": "EasyNetQ.Hosepipe",
+  "name": "EasyNetQ.Hosepipe",
   "packOptions": {
     "licenseUrl": "https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/master/licence.txt",
     "projectUrl": "https://github.com/EasyNetQ/EasyNetQ",
@@ -34,7 +34,6 @@
     }
   },
   "dependencies": {
-    "SimpleInjector": "3.2.7",
     "EasyNetQ": "2.0.2-netcore0001"
   },
 
@@ -50,21 +49,30 @@
     "dn-version": "dotnet gitversion"
   },
   "frameworks": {
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "buildOptions": {
         "define": [
           "NET_STANDARD"
         ]
       },
-      "dependencies": {}
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.1",
+          "type": "platform"
+        }
+      },
+      "imports": "dnxcore50"
     },
     "net451": {
       "buildOptions": {
         "define": [
           "NETFX"
         ]
-      },
-      "frameworkAssemblies": {}
+      }
     }
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {}
   }
 }

--- a/Source/EasyNetQ.LogReader/EasyNetQ.LogReader.xproj
+++ b/Source/EasyNetQ.LogReader/EasyNetQ.LogReader.xproj
@@ -1,15 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>6b86e7df-72b7-474b-9409-3c0a787bfb09</ProjectGuid>
-    <RootNamespace>EasyNetQ.Tests.Messages</RootNamespace>
+    <ProjectGuid>AA7F9D04-085B-4B71-8541-B838F5CAF9F2</ProjectGuid>
+    <RootNamespace>EasyNetQ.LogReader</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Source/EasyNetQ.LogReader/project.json
+++ b/Source/EasyNetQ.LogReader/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "2.0.3-netcore0001",
-  "description": "An adaptor to allow EasyNetQ to use SimpleInjector as its internal IoC container",
-  "title": "EasyNetQ.DI.SimpleInjector",
-  "name": "EasyNetQ.DI.SimpleInjector",
+  "version": "2.0.2-netcore0001",
+  "description": "EasyNetQ.LogReader",
+  "title": "EasyNetQ.LogReader",
+  "name": "EasyNetQ.LogReader",
   "packOptions": {
     "licenseUrl": "https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/master/licence.txt",
     "projectUrl": "https://github.com/EasyNetQ/EasyNetQ",
@@ -34,10 +34,8 @@
     }
   },
   "dependencies": {
-    "SimpleInjector": "3.2.7",
     "EasyNetQ": "2.0.2-netcore0001"
   },
-
   "tools": {
     "dotnet-gitversion": {
       "version": "1.0.0",
@@ -50,21 +48,26 @@
     "dn-version": "dotnet gitversion"
   },
   "frameworks": {
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "buildOptions": {
         "define": [
           "NET_STANDARD"
         ]
       },
-      "dependencies": {}
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.1",
+          "type": "platform"
+        }
+      },
+      "imports": "dnxcore50"
     },
     "net451": {
       "buildOptions": {
         "define": [
           "NETFX"
         ]
-      },
-      "frameworkAssemblies": {}
+      }
     }
   }
 }

--- a/Source/EasyNetQ.LogReader/project.json
+++ b/Source/EasyNetQ.LogReader/project.json
@@ -34,7 +34,8 @@
     }
   },
   "dependencies": {
-    "EasyNetQ": "99.0.0-dev"
+    "EasyNetQ": "99.0.0-dev",
+    "RabbitMQ.Client": "4.1.1"
   },
   "tools": {
     "dotnet-gitversion": {
@@ -48,20 +49,6 @@
     "dn-version": "dotnet gitversion"
   },
   "frameworks": {
-    "netcoreapp1.0": {
-      "buildOptions": {
-        "define": [
-          "NET_STANDARD"
-        ]
-      },
-      "dependencies": {
-        "Microsoft.NETCore.App": {
-          "version": "1.0.1",
-          "type": "platform"
-        }
-      },
-      "imports": "dnxcore50"
-    },
     "net451": {
       "buildOptions": {
         "define": [

--- a/Source/EasyNetQ.LogReader/project.json
+++ b/Source/EasyNetQ.LogReader/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.2-netcore0001",
+  "version": "99.0.0-dev",
   "description": "EasyNetQ.LogReader",
   "title": "EasyNetQ.LogReader",
   "name": "EasyNetQ.LogReader",
@@ -34,7 +34,7 @@
     }
   },
   "dependencies": {
-    "EasyNetQ": "2.0.2-netcore0001"
+    "EasyNetQ": "99.0.0-dev"
   },
   "tools": {
     "dotnet-gitversion": {

--- a/Source/EasyNetQ.Scheduler.Mongo.Core/EasyNetQ.Scheduler.Mongo.Core.xproj
+++ b/Source/EasyNetQ.Scheduler.Mongo.Core/EasyNetQ.Scheduler.Mongo.Core.xproj
@@ -1,15 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>6b86e7df-72b7-474b-9409-3c0a787bfb09</ProjectGuid>
-    <RootNamespace>EasyNetQ.Tests.Messages</RootNamespace>
+    <ProjectGuid>F444E58F-DA2A-47E8-8246-C4BDD9A192B2</ProjectGuid>
+    <RootNamespace>EasyNetQ.Scheduler.Mongo.Core</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Source/EasyNetQ.Scheduler.Mongo.Core/project.json
+++ b/Source/EasyNetQ.Scheduler.Mongo.Core/project.json
@@ -34,7 +34,9 @@
     }
   },
   "dependencies": {
-    "EasyNetQ": "99.0.0-dev"
+    "EasyNetQ": "99.0.0-dev",
+    "MongoDB.Bson": "2.3.0",
+    "mongocsharpdriver": "2.3.0"
   },
   "tools": {
     "dotnet-gitversion": {

--- a/Source/EasyNetQ.Scheduler.Mongo.Core/project.json
+++ b/Source/EasyNetQ.Scheduler.Mongo.Core/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.2-netcore0001",
+  "version": "99.0.0-dev",
   "description": "EasyNetQ.Scheduler.Mongo.Core",
   "title": "EasyNetQ.Scheduler.Mongo.Core",
   "name": "EasyNetQ.Scheduler.Mongo.Core",
@@ -34,7 +34,7 @@
     }
   },
   "dependencies": {
-    "EasyNetQ": "2.0.2-netcore0001"
+    "EasyNetQ": "99.0.0-dev"
   },
   "tools": {
     "dotnet-gitversion": {

--- a/Source/EasyNetQ.Scheduler.Mongo.Core/project.json
+++ b/Source/EasyNetQ.Scheduler.Mongo.Core/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "2.0.3-netcore0001",
-  "description": "An adaptor to allow EasyNetQ to use SimpleInjector as its internal IoC container",
-  "title": "EasyNetQ.DI.SimpleInjector",
-  "name": "EasyNetQ.DI.SimpleInjector",
+  "version": "2.0.2-netcore0001",
+  "description": "EasyNetQ.Scheduler.Mongo.Core",
+  "title": "EasyNetQ.Scheduler.Mongo.Core",
+  "name": "EasyNetQ.Scheduler.Mongo.Core",
   "packOptions": {
     "licenseUrl": "https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/master/licence.txt",
     "projectUrl": "https://github.com/EasyNetQ/EasyNetQ",
@@ -34,10 +34,8 @@
     }
   },
   "dependencies": {
-    "SimpleInjector": "3.2.7",
     "EasyNetQ": "2.0.2-netcore0001"
   },
-
   "tools": {
     "dotnet-gitversion": {
       "version": "1.0.0",
@@ -56,7 +54,9 @@
           "NET_STANDARD"
         ]
       },
-      "dependencies": {}
+      "dependencies": {
+
+      }
     },
     "net451": {
       "buildOptions": {
@@ -64,7 +64,9 @@
           "NETFX"
         ]
       },
-      "frameworkAssemblies": {}
+      "frameworkAssemblies": {
+
+      }
     }
   }
 }

--- a/Source/EasyNetQ.Scheduler.Mongo.Tests/EasyNetQ.Scheduler.Mongo.Tests.xproj
+++ b/Source/EasyNetQ.Scheduler.Mongo.Tests/EasyNetQ.Scheduler.Mongo.Tests.xproj
@@ -15,5 +15,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/Source/EasyNetQ.Scheduler.Mongo.Tests/EasyNetQ.Scheduler.Mongo.Tests.xproj
+++ b/Source/EasyNetQ.Scheduler.Mongo.Tests/EasyNetQ.Scheduler.Mongo.Tests.xproj
@@ -1,15 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>6b86e7df-72b7-474b-9409-3c0a787bfb09</ProjectGuid>
-    <RootNamespace>EasyNetQ.Tests.Messages</RootNamespace>
+    <ProjectGuid>4E7F926F-D939-4962-A7EF-112DE41B4236</ProjectGuid>
+    <RootNamespace>EasyNetQ.Scheduler.Mongo.Tests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Source/EasyNetQ.Scheduler.Mongo.Tests/project.json
+++ b/Source/EasyNetQ.Scheduler.Mongo.Tests/project.json
@@ -36,6 +36,8 @@
   "dependencies": {
     "dotnet-test-nunit": "3.4.0-beta-3",
     "EasyNetQ": "99.0.0-dev",
+    "EasyNetQ.Scheduler.Mongo": "99.0.0-dev",
+    "NSubstitute": "2.0.0-rc",
     "NUnit": "3.5.0"
   },
   "tools": {
@@ -53,26 +55,7 @@
   "testRunner": "nunit",
 
   "frameworks": {
-    "netcoreapp1.0": {
-      "buildOptions": {
-        "define": [
-          "NET_STANDARD"
-        ]
-      },
-      "dependencies": {
-        "Microsoft.NETCore.App": {
-          "version": "1.0.1",
-          "type": "platform"
-        }
-      },
-      "imports": "dnxcore50"
-    },
     "net451": {
-      "buildOptions": {
-        "define": [
-          "NETFX"
-        ]
-      }
     }
   },
   "runtimes": {

--- a/Source/EasyNetQ.Scheduler.Mongo.Tests/project.json
+++ b/Source/EasyNetQ.Scheduler.Mongo.Tests/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "2.0.3-netcore0001",
-  "description": "An adaptor to allow EasyNetQ to use SimpleInjector as its internal IoC container",
-  "title": "EasyNetQ.DI.SimpleInjector",
-  "name": "EasyNetQ.DI.SimpleInjector",
+  "version": "2.0.2-netcore0001",
+  "description": "EasyNetQ.Scheduler.Mongo.Tests",
+  "title": "EasyNetQ.Scheduler.Mongo.Tests",
+  "name": "EasyNetQ.Scheduler.Mongo.Tests",
   "packOptions": {
     "licenseUrl": "https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/master/licence.txt",
     "projectUrl": "https://github.com/EasyNetQ/EasyNetQ",
@@ -34,10 +34,10 @@
     }
   },
   "dependencies": {
-    "SimpleInjector": "3.2.7",
-    "EasyNetQ": "2.0.2-netcore0001"
+    "EasyNetQ": "2.0.2-netcore0001",
+    "dotnet-test-nunit": "3.4.0-beta-3",
+    "NUnit": "3.5.0",
   },
-
   "tools": {
     "dotnet-gitversion": {
       "version": "1.0.0",
@@ -49,22 +49,34 @@
   "commands": {
     "dn-version": "dotnet gitversion"
   },
+
+  "testRunner": "nunit",
+
   "frameworks": {
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "buildOptions": {
         "define": [
           "NET_STANDARD"
         ]
       },
-      "dependencies": {}
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.1",
+          "type": "platform"
+        }
+      },
+      "imports": "dnxcore50"
     },
     "net451": {
       "buildOptions": {
         "define": [
           "NETFX"
         ]
-      },
-      "frameworkAssemblies": {}
+      }
     }
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {}
   }
 }

--- a/Source/EasyNetQ.Scheduler.Mongo.Tests/project.json
+++ b/Source/EasyNetQ.Scheduler.Mongo.Tests/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.2-netcore0001",
+  "version": "99.0.0-dev",
   "description": "EasyNetQ.Scheduler.Mongo.Tests",
   "title": "EasyNetQ.Scheduler.Mongo.Tests",
   "name": "EasyNetQ.Scheduler.Mongo.Tests",
@@ -34,9 +34,9 @@
     }
   },
   "dependencies": {
-    "EasyNetQ": "2.0.2-netcore0001",
     "dotnet-test-nunit": "3.4.0-beta-3",
-    "NUnit": "3.5.0",
+    "EasyNetQ": "99.0.0-dev",
+    "NUnit": "3.5.0"
   },
   "tools": {
     "dotnet-gitversion": {

--- a/Source/EasyNetQ.Scheduler.Mongo/EasyNetQ.Scheduler.Mongo.xproj
+++ b/Source/EasyNetQ.Scheduler.Mongo/EasyNetQ.Scheduler.Mongo.xproj
@@ -1,15 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>6b86e7df-72b7-474b-9409-3c0a787bfb09</ProjectGuid>
-    <RootNamespace>EasyNetQ.Tests.Messages</RootNamespace>
+    <ProjectGuid>AFD272B4-4A2B-43D4-81ED-666F8918FD01</ProjectGuid>
+    <RootNamespace>EasyNetQ.Scheduler.Mongo</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Source/EasyNetQ.Scheduler.Mongo/project.json
+++ b/Source/EasyNetQ.Scheduler.Mongo/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.2-netcore0001",
+  "version": "99.0.0-dev",
   "description": "EasyNetQ.Scheduler.Mongo",
   "title": "EasyNetQ.Scheduler.Mongo",
   "name": "EasyNetQ.Scheduler.Mongo",
@@ -34,7 +34,7 @@
     }
   },
   "dependencies": {
-    "EasyNetQ": "2.0.2-netcore0001"
+    "EasyNetQ": "99.0.0-dev"
   },
   "tools": {
     "dotnet-gitversion": {

--- a/Source/EasyNetQ.Scheduler.Mongo/project.json
+++ b/Source/EasyNetQ.Scheduler.Mongo/project.json
@@ -31,10 +31,16 @@
   "buildOptions": {
     "compile": {
       "includeFiles": "..\\Version.cs"
-    }
+    },
+    "copyToOutput": [
+      "log4net.config"
+    ]
   },
   "dependencies": {
-    "EasyNetQ": "99.0.0-dev"
+    "EasyNetQ": "99.0.0-dev",
+    "EasyNetQ.Scheduler.Mongo.Core": "99.0.0-dev",
+    "log4net": "2.0.5",
+    "Topshelf": "3.1.4"
   },
   "tools": {
     "dotnet-gitversion": {
@@ -49,7 +55,9 @@
   },
   "frameworks": {
     "net451": {
-      
+      "frameworkAssemblies": {
+        "System.Configuration": "4.0.0.0"
+      }
     }
   },
   "runtimes": {

--- a/Source/EasyNetQ.Scheduler.Mongo/project.json
+++ b/Source/EasyNetQ.Scheduler.Mongo/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "2.0.3-netcore0001",
-  "description": "An adaptor to allow EasyNetQ to use SimpleInjector as its internal IoC container",
-  "title": "EasyNetQ.DI.SimpleInjector",
-  "name": "EasyNetQ.DI.SimpleInjector",
+  "version": "2.0.2-netcore0001",
+  "description": "EasyNetQ.Scheduler.Mongo",
+  "title": "EasyNetQ.Scheduler.Mongo",
+  "name": "EasyNetQ.Scheduler.Mongo",
   "packOptions": {
     "licenseUrl": "https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/master/licence.txt",
     "projectUrl": "https://github.com/EasyNetQ/EasyNetQ",
@@ -34,10 +34,8 @@
     }
   },
   "dependencies": {
-    "SimpleInjector": "3.2.7",
     "EasyNetQ": "2.0.2-netcore0001"
   },
-
   "tools": {
     "dotnet-gitversion": {
       "version": "1.0.0",
@@ -50,21 +48,12 @@
     "dn-version": "dotnet gitversion"
   },
   "frameworks": {
-    "netstandard1.5": {
-      "buildOptions": {
-        "define": [
-          "NET_STANDARD"
-        ]
-      },
-      "dependencies": {}
-    },
     "net451": {
-      "buildOptions": {
-        "define": [
-          "NETFX"
-        ]
-      },
-      "frameworkAssemblies": {}
+      
     }
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {}
   }
 }

--- a/Source/EasyNetQ.Scheduler.Tests/EasyNetQ.Scheduler.Tests.xproj
+++ b/Source/EasyNetQ.Scheduler.Tests/EasyNetQ.Scheduler.Tests.xproj
@@ -15,5 +15,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/Source/EasyNetQ.Scheduler.Tests/EasyNetQ.Scheduler.Tests.xproj
+++ b/Source/EasyNetQ.Scheduler.Tests/EasyNetQ.Scheduler.Tests.xproj
@@ -1,15 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>6b86e7df-72b7-474b-9409-3c0a787bfb09</ProjectGuid>
-    <RootNamespace>EasyNetQ.Tests.Messages</RootNamespace>
+    <ProjectGuid>530A771C-B12E-48E4-AE10-11B8F6537F4F</ProjectGuid>
+    <RootNamespace>EasyNetQ.Scheduler.Tests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Source/EasyNetQ.Scheduler.Tests/ScheduleRepositoryTests.cs
+++ b/Source/EasyNetQ.Scheduler.Tests/ScheduleRepositoryTests.cs
@@ -1,10 +1,10 @@
 // ReSharper disable InconsistentNaming
-using System;
-using System.Text;
 using EasyNetQ.SystemMessages;
 using EasyNetQ.Topology;
+using NSubstitute;
 using NUnit.Framework;
-using Rhino.Mocks;
+using System;
+using System.Text;
 
 namespace EasyNetQ.Scheduler.Tests
 {
@@ -17,7 +17,7 @@ namespace EasyNetQ.Scheduler.Tests
         [SetUp]
         public void SetUp()
         {
-            var log = MockRepository.GenerateStub<IEasyNetQLogger>();
+            var log = Substitute.For<IEasyNetQLogger>();
             var configuration = new ScheduleRepositoryConfiguration
             {
                 ProviderName = "System.Data.SqlClient",

--- a/Source/EasyNetQ.Scheduler.Tests/project.json
+++ b/Source/EasyNetQ.Scheduler.Tests/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "2.0.3-netcore0001",
-  "description": "An adaptor to allow EasyNetQ to use SimpleInjector as its internal IoC container",
-  "title": "EasyNetQ.DI.SimpleInjector",
-  "name": "EasyNetQ.DI.SimpleInjector",
+  "version": "2.0.2-netcore0001",
+  "description": "EasyNetQ.Scheduler.Tests",
+  "title": "EasyNetQ.Scheduler.Tests",
+  "name": "EasyNetQ.Scheduler.Tests",
   "packOptions": {
     "licenseUrl": "https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/master/licence.txt",
     "projectUrl": "https://github.com/EasyNetQ/EasyNetQ",
@@ -34,10 +34,11 @@
     }
   },
   "dependencies": {
-    "SimpleInjector": "3.2.7",
-    "EasyNetQ": "2.0.2-netcore0001"
+    "dotnet-test-nunit": "3.4.0-beta-3",
+    "EasyNetQ": "2.0.2-netcore0001",
+    "EasyNetQ.Scheduler": "2.0.2-netcore0001",
+    "NUnit": "3.5.0"
   },
-
   "tools": {
     "dotnet-gitversion": {
       "version": "1.0.0",
@@ -49,22 +50,20 @@
   "commands": {
     "dn-version": "dotnet gitversion"
   },
+
+  "testRunner": "nunit",
+
   "frameworks": {
-    "netstandard1.5": {
-      "buildOptions": {
-        "define": [
-          "NET_STANDARD"
-        ]
-      },
-      "dependencies": {}
-    },
     "net451": {
       "buildOptions": {
         "define": [
           "NETFX"
         ]
-      },
-      "frameworkAssemblies": {}
+      }
     }
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {}
   }
 }

--- a/Source/EasyNetQ.Scheduler.Tests/project.json
+++ b/Source/EasyNetQ.Scheduler.Tests/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.2-netcore0001",
+  "version": "99.0.0-dev",
   "description": "EasyNetQ.Scheduler.Tests",
   "title": "EasyNetQ.Scheduler.Tests",
   "name": "EasyNetQ.Scheduler.Tests",
@@ -35,8 +35,8 @@
   },
   "dependencies": {
     "dotnet-test-nunit": "3.4.0-beta-3",
-    "EasyNetQ": "2.0.2-netcore0001",
-    "EasyNetQ.Scheduler": "2.0.2-netcore0001",
+    "EasyNetQ": "99.0.0-dev",
+    "EasyNetQ.Scheduler": "99.0.0-dev",
     "NUnit": "3.5.0"
   },
   "tools": {

--- a/Source/EasyNetQ.Scheduler.Tests/project.json
+++ b/Source/EasyNetQ.Scheduler.Tests/project.json
@@ -37,6 +37,7 @@
     "dotnet-test-nunit": "3.4.0-beta-3",
     "EasyNetQ": "99.0.0-dev",
     "EasyNetQ.Scheduler": "99.0.0-dev",
+    "NSubstitute": "2.0.0-rc",
     "NUnit": "3.5.0"
   },
   "tools": {

--- a/Source/EasyNetQ.Scheduler/EasyNetQ.Scheduler.xproj
+++ b/Source/EasyNetQ.Scheduler/EasyNetQ.Scheduler.xproj
@@ -1,15 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>6b86e7df-72b7-474b-9409-3c0a787bfb09</ProjectGuid>
-    <RootNamespace>EasyNetQ.Tests.Messages</RootNamespace>
+    <ProjectGuid>03B93AAD-6CAB-4726-826E-B05684AEC1B9</ProjectGuid>
+    <RootNamespace>EasyNetQ.Scheduler</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Source/EasyNetQ.Scheduler/project.json
+++ b/Source/EasyNetQ.Scheduler/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "2.0.3-netcore0001",
-  "description": "An adaptor to allow EasyNetQ to use SimpleInjector as its internal IoC container",
-  "title": "EasyNetQ.DI.SimpleInjector",
-  "name": "EasyNetQ.DI.SimpleInjector",
+  "version": "2.0.2-netcore0001",
+  "description": "EasyNetQ.Scheduler",
+  "title": "EasyNetQ.Scheduler",
+  "name": "EasyNetQ.Scheduler",
   "packOptions": {
     "licenseUrl": "https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/master/licence.txt",
     "projectUrl": "https://github.com/EasyNetQ/EasyNetQ",
@@ -31,11 +31,17 @@
   "buildOptions": {
     "compile": {
       "includeFiles": "..\\Version.cs"
-    }
+    },
+    "copyToOutput": [
+      "log4net.config"
+    ]
   },
   "dependencies": {
-    "SimpleInjector": "3.2.7",
-    "EasyNetQ": "2.0.2-netcore0001"
+    "EasyNetQ": "2.0.2-netcore0001",
+    "log4net": "2.0.5",
+    "Newtonsoft.Json": "9.0.1",
+    "RabbitMQ.Client": "4.1.1",
+    "Topshelf": "3.1.4"
   },
 
   "tools": {
@@ -50,21 +56,16 @@
     "dn-version": "dotnet gitversion"
   },
   "frameworks": {
-    "netstandard1.5": {
-      "buildOptions": {
-        "define": [
-          "NET_STANDARD"
-        ]
-      },
-      "dependencies": {}
-    },
     "net451": {
-      "buildOptions": {
-        "define": [
-          "NETFX"
-        ]
-      },
-      "frameworkAssemblies": {}
+      "frameworkAssemblies": {
+        "System.Configuration": "4.0.0.0",
+        "System.Data": "4.0.0.0",
+        "System.Transactions": "4.0.0.0"
+      }
     }
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {}
   }
 }

--- a/Source/EasyNetQ.Scheduler/project.json
+++ b/Source/EasyNetQ.Scheduler/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.2-netcore0001",
+  "version": "99.0.0-dev",
   "description": "EasyNetQ.Scheduler",
   "title": "EasyNetQ.Scheduler",
   "name": "EasyNetQ.Scheduler",
@@ -37,7 +37,7 @@
     ]
   },
   "dependencies": {
-    "EasyNetQ": "2.0.2-netcore0001",
+    "EasyNetQ": "99.0.0-dev",
     "log4net": "2.0.5",
     "Newtonsoft.Json": "9.0.1",
     "RabbitMQ.Client": "4.1.1",

--- a/Source/EasyNetQ.Serilog/project.json
+++ b/Source/EasyNetQ.Serilog/project.json
@@ -34,7 +34,7 @@
     }
   },
   "dependencies": {
-    "Serilog": "2.1.0",
+    "Serilog": "2.3.0",
     "EasyNetQ": "99.0.0-dev"
   },
   "tools": {

--- a/Source/EasyNetQ.Serilog/project.json
+++ b/Source/EasyNetQ.Serilog/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.3-netcore0001",
+  "version": "99.0.0-dev",
   "description": "An Implementation to use Serilog as a logging component for EasyNetQ",
   "title": "EasyNetQ.Serilog",
   "name": "EasyNetQ.Serilog",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "Serilog": "2.1.0",
-    "EasyNetQ": "2.0.2-netcore0001"
+    "EasyNetQ": "99.0.0-dev"
   },
   "tools": {
     "dotnet-gitversion": {

--- a/Source/EasyNetQ.Serilog/project.json
+++ b/Source/EasyNetQ.Serilog/project.json
@@ -27,6 +27,12 @@
     "Wiebe Tijsma",
     "Contributors (see GitHub repo) "
   ],
+
+  "buildOptions": {
+    "compile": {
+      "includeFiles": "..\\Version.cs"
+    }
+  },
   "dependencies": {
     "Serilog": "2.1.0",
     "EasyNetQ": "2.0.2-netcore0001"

--- a/Source/EasyNetQ.Tests.Messages/project.json
+++ b/Source/EasyNetQ.Tests.Messages/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.2-netcore0001",
+  "version": "99.0.0-dev",
   "description": "EasyNetQ.Tests.Messages",
   "title": "EasyNetQ.Tests.Messages",
   "name": "EasyNetQ.Tests.Messages",

--- a/Source/EasyNetQ.Tests.Tasks/CommandLineTaskRunner.cs
+++ b/Source/EasyNetQ.Tests.Tasks/CommandLineTaskRunner.cs
@@ -56,7 +56,7 @@ namespace EasyNetQ.Tests.Tasks
 
         private static void SetupLogging(ContainerBuilder builder)
         {
-            SelfLog.Out = Console.Out;
+            SelfLog.Enable(Console.Out);
 
             var logger = new LoggerConfiguration()
                 .WriteTo.ColoredConsole(LogEventLevel.Debug)

--- a/Source/EasyNetQ.Tests.Tasks/EasyNetQ.Tests.Tasks.xproj
+++ b/Source/EasyNetQ.Tests.Tasks/EasyNetQ.Tests.Tasks.xproj
@@ -1,15 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>6b86e7df-72b7-474b-9409-3c0a787bfb09</ProjectGuid>
-    <RootNamespace>EasyNetQ.Tests.Messages</RootNamespace>
+    <ProjectGuid>A5CF1B2C-E390-4BFF-BB1A-0F171DB0D6BD</ProjectGuid>
+    <RootNamespace>EasyNetQ.Tests.Tasks</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Source/EasyNetQ.Tests.Tasks/project.json
+++ b/Source/EasyNetQ.Tests.Tasks/project.json
@@ -34,7 +34,13 @@
     }
   },
   "dependencies": {
-    "EasyNetQ": "99.0.0-dev"
+    "Autofac": "4.2.0",
+    "EasyNetQ": "99.0.0-dev",
+    "EasyNetQ.Serilog": "99.0.0-dev",
+    "EasyNetQ.Tests.Messages": "99.0.0-dev",
+    "Net.Autofac":"0.1.12",
+    "Net.Core": "0.1.12",
+    "Serilog.Sinks.ColoredConsole": "2.0.0"
   },
   "tools": {
     "dotnet-gitversion": {
@@ -48,20 +54,6 @@
     "dn-version": "dotnet gitversion"
   },
   "frameworks": {
-    "netcoreapp1.0": {
-      "buildOptions": {
-        "define": [
-          "NET_STANDARD"
-        ]
-      },
-      "dependencies": {
-        "Microsoft.NETCore.App": {
-          "version": "1.0.1",
-          "type": "platform"
-        }
-      },
-      "imports": "dnxcore50"
-    },
     "net451": {
       "buildOptions": {
         "define": [

--- a/Source/EasyNetQ.Tests.Tasks/project.json
+++ b/Source/EasyNetQ.Tests.Tasks/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "2.0.3-netcore0001",
-  "description": "An adaptor to allow EasyNetQ to use SimpleInjector as its internal IoC container",
-  "title": "EasyNetQ.DI.SimpleInjector",
-  "name": "EasyNetQ.DI.SimpleInjector",
+  "version": "2.0.2-netcore0001",
+  "description": "EasyNetQ.Tests.Tasks",
+  "title": "EasyNetQ.Tests.Tasks",
+  "name": "EasyNetQ.Tests.Tasks",
   "packOptions": {
     "licenseUrl": "https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/master/licence.txt",
     "projectUrl": "https://github.com/EasyNetQ/EasyNetQ",
@@ -34,10 +34,8 @@
     }
   },
   "dependencies": {
-    "SimpleInjector": "3.2.7",
     "EasyNetQ": "2.0.2-netcore0001"
   },
-
   "tools": {
     "dotnet-gitversion": {
       "version": "1.0.0",
@@ -50,21 +48,26 @@
     "dn-version": "dotnet gitversion"
   },
   "frameworks": {
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "buildOptions": {
         "define": [
           "NET_STANDARD"
         ]
       },
-      "dependencies": {}
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.1",
+          "type": "platform"
+        }
+      },
+      "imports": "dnxcore50"
     },
     "net451": {
       "buildOptions": {
         "define": [
           "NETFX"
         ]
-      },
-      "frameworkAssemblies": {}
+      }
     }
   }
 }

--- a/Source/EasyNetQ.Tests.Tasks/project.json
+++ b/Source/EasyNetQ.Tests.Tasks/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.2-netcore0001",
+  "version": "99.0.0-dev",
   "description": "EasyNetQ.Tests.Tasks",
   "title": "EasyNetQ.Tests.Tasks",
   "name": "EasyNetQ.Tests.Tasks",
@@ -34,7 +34,7 @@
     }
   },
   "dependencies": {
-    "EasyNetQ": "2.0.2-netcore0001"
+    "EasyNetQ": "99.0.0-dev"
   },
   "tools": {
     "dotnet-gitversion": {

--- a/Source/EasyNetQ.Tests/project.json
+++ b/Source/EasyNetQ.Tests/project.json
@@ -6,39 +6,41 @@
   "buildOptions": {
     "compile": {
       "includeFiles": "..\\Version.cs"
-     }
-    },
-   "dependencies": {
-      "NUnit": "3.5.0",
-      "NSubstitute": "2.0.0-rc",
-      "Newtonsoft.Json": "9.0.1",
-      "dotnet-test-nunit": "3.4.0-beta-3",
-      "RabbitMQ.Client": "4.1.1",
-      "EasyNetQ": "99.0.0-dev",
-      "EasyNetQ.Management.Client": "2.0.0-netcore0001",
-      "EasyNetQ.Tests.Messages": "99.0.0-dev"
-    },
-
-    "testRunner": "nunit",
-
-    "frameworks": {
-      "netcoreapp1.0": {
-        "imports": "portable-net45+win8",
-        "dependencies": {
-          "Microsoft.NETCore.App": {
-            "version": "1.0.1",
-            "type": "platform"
-          },
-          "System.Net.Http": "4.1.0"
-        }
-      },
-      "net451": {
-        "frameworkAssemblies": {
-          "System": "4.0.0.0",
-          "System.Net.Http": "4.0.0.0"
-        }
-      }
-
     }
+  },
+  "dependencies": {
+    "NUnit": "3.5.0",
+    "NSubstitute": "2.0.0-rc",
+    "Newtonsoft.Json": "9.0.1",
+    "dotnet-test-nunit": "3.4.0-beta-3",
+    "RabbitMQ.Client": "4.1.1",
+    "EasyNetQ": "99.0.0-dev",
+    "EasyNetQ.Management.Client": "2.0.0-netcore0001",
+    "EasyNetQ.Tests.Messages": "99.0.0-dev"
+  },
+
+  "testRunner": "nunit",
+
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": "portable-net45+win8",
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.1",
+          "type": "platform"
+        },
+        "System.Net.Http": "4.1.0"
+      }
+    },
+    "net451": {
+      "frameworkAssemblies": {
+        "System": "4.0.0.0",
+        "System.Net.Http": "4.0.0.0"
+      }
+    }
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {}
   }
- 
+}

--- a/Source/EasyNetQ.Tests/project.json
+++ b/Source/EasyNetQ.Tests/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.2-netcore0001",
+  "version": "99.0.0-dev",
   "description": "EasyNetQ.Tests",
   "title": "EasyNetQ.Tests",
   "name": "EasyNetQ.Tests",
@@ -14,9 +14,9 @@
       "Newtonsoft.Json": "9.0.1",
       "dotnet-test-nunit": "3.4.0-beta-3",
       "RabbitMQ.Client": "4.1.1",
-      "EasyNetQ": "2.0.2-netcore0001",
+      "EasyNetQ": "99.0.0-dev",
       "EasyNetQ.Management.Client": "2.0.0-netcore0001",
-      "EasyNetQ.Tests.Messages": "2.0.2-netcore0001"
+      "EasyNetQ.Tests.Messages": "99.0.0-dev"
     },
 
     "testRunner": "nunit",

--- a/Source/EasyNetQ.Tests/project.json
+++ b/Source/EasyNetQ.Tests/project.json
@@ -26,7 +26,7 @@
         "imports": "portable-net45+win8",
         "dependencies": {
           "Microsoft.NETCore.App": {
-            "version": "1.0.0-*",
+            "version": "1.0.1",
             "type": "platform"
           },
           "System.Net.Http": "4.1.0"
@@ -41,3 +41,4 @@
 
     }
   }
+ 

--- a/Source/EasyNetQ.Trace/CSVFile.cs
+++ b/Source/EasyNetQ.Trace/CSVFile.cs
@@ -33,7 +33,7 @@ namespace EasyNetQ.Trace
 
         public CSVFile(string path)
         {
-            Writer = new StreamWriter(path);
+            Writer = new StreamWriter(File.Open(path, FileMode.OpenOrCreate));
         }
 
         //Write each column

--- a/Source/EasyNetQ.Trace/EasyNetQ.Trace.xproj
+++ b/Source/EasyNetQ.Trace/EasyNetQ.Trace.xproj
@@ -1,15 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>6b86e7df-72b7-474b-9409-3c0a787bfb09</ProjectGuid>
-    <RootNamespace>EasyNetQ.Tests.Messages</RootNamespace>
+    <ProjectGuid>11DF08A9-3D14-44CC-A65E-5933121D3D63</ProjectGuid>
+    <RootNamespace>EasyNetQ.Trace</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Source/EasyNetQ.Trace/project.json
+++ b/Source/EasyNetQ.Trace/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "2.0.3-netcore0001",
-  "description": "An adaptor to allow EasyNetQ to use SimpleInjector as its internal IoC container",
-  "title": "EasyNetQ.DI.SimpleInjector",
-  "name": "EasyNetQ.DI.SimpleInjector",
+  "version": "2.0.2-netcore0001",
+  "description": "EasyNetQ.Trace",
+  "title": "EasyNetQ.Trace",
+  "name": "EasyNetQ.Trace",
   "packOptions": {
     "licenseUrl": "https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/master/licence.txt",
     "projectUrl": "https://github.com/EasyNetQ/EasyNetQ",
@@ -34,10 +34,8 @@
     }
   },
   "dependencies": {
-    "SimpleInjector": "3.2.7",
     "EasyNetQ": "2.0.2-netcore0001"
   },
-
   "tools": {
     "dotnet-gitversion": {
       "version": "1.0.0",
@@ -50,21 +48,26 @@
     "dn-version": "dotnet gitversion"
   },
   "frameworks": {
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "buildOptions": {
         "define": [
           "NET_STANDARD"
         ]
       },
-      "dependencies": {}
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.1",
+          "type": "platform"
+        }
+      },
+      "imports": "dnxcore50"
     },
     "net451": {
       "buildOptions": {
         "define": [
           "NETFX"
         ]
-      },
-      "frameworkAssemblies": {}
+      }
     }
   }
 }

--- a/Source/EasyNetQ.Trace/project.json
+++ b/Source/EasyNetQ.Trace/project.json
@@ -34,6 +34,7 @@
     }
   },
   "dependencies": {
+    "CommandLineParser": "2.1.1-beta",
     "EasyNetQ": "99.0.0-dev"
   },
   "tools": {

--- a/Source/EasyNetQ.Trace/project.json
+++ b/Source/EasyNetQ.Trace/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.2-netcore0001",
+  "version": "99.0.0-dev",
   "description": "EasyNetQ.Trace",
   "title": "EasyNetQ.Trace",
   "name": "EasyNetQ.Trace",
@@ -34,7 +34,7 @@
     }
   },
   "dependencies": {
-    "EasyNetQ": "2.0.2-netcore0001"
+    "EasyNetQ": "99.0.0-dev"
   },
   "tools": {
     "dotnet-gitversion": {

--- a/Source/EasyNetQ.sln
+++ b/Source/EasyNetQ.sln
@@ -19,35 +19,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Version.cs = Version.cs
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ.Scheduler", "EasyNetQ.Scheduler\EasyNetQ.Scheduler.csproj", "{03B93AAD-6CAB-4726-826E-B05684AEC1B9}"
-	ProjectSection(ProjectDependencies) = postProject
-		{ED270A39-D32C-438A-BF4F-AA0E66C7879C} = {ED270A39-D32C-438A-BF4F-AA0E66C7879C}
-	EndProjectSection
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ.Scheduler.Tests", "EasyNetQ.Scheduler.Tests\EasyNetQ.Scheduler.Tests.csproj", "{530A771C-B12E-48E4-AE10-11B8F6537F4F}"
-	ProjectSection(ProjectDependencies) = postProject
-		{ED270A39-D32C-438A-BF4F-AA0E66C7879C} = {ED270A39-D32C-438A-BF4F-AA0E66C7879C}
-	EndProjectSection
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ.LogReader", "EasyNetQ.LogReader\EasyNetQ.LogReader.csproj", "{AA7F9D04-085B-4B71-8541-B838F5CAF9F2}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ.Hosepipe", "EasyNetQ.Hosepipe\EasyNetQ.Hosepipe.csproj", "{99A7A83D-6F75-4A1C-83E8-7C4AF881B273}"
-	ProjectSection(ProjectDependencies) = postProject
-		{ED270A39-D32C-438A-BF4F-AA0E66C7879C} = {ED270A39-D32C-438A-BF4F-AA0E66C7879C}
-	EndProjectSection
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ.Hosepipe.Tests", "EasyNetQ.Hosepipe.Tests\EasyNetQ.Hosepipe.Tests.csproj", "{DA597678-7873-4156-8112-8C70B164381A}"
-	ProjectSection(ProjectDependencies) = postProject
-		{ED270A39-D32C-438A-BF4F-AA0E66C7879C} = {ED270A39-D32C-438A-BF4F-AA0E66C7879C}
-	EndProjectSection
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ.Hosepipe.SetupActions", "EasyNetQ.Hosepipe.SetupActions\EasyNetQ.Hosepipe.SetupActions.csproj", "{93F795C9-FCA3-4B9F-B7EC-19759B8E44CE}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DatabaseScripts", "DatabaseScripts", "{896B72E7-50D5-49B9-987B-4250092E39BB}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "EasyNetQ.Scheduler", "EasyNetQ.Scheduler", "{F8DF03D5-863A-4F10-89DF-D0ADA3269FB2}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ.Trace", "EasyNetQ.Trace\EasyNetQ.Trace.csproj", "{11DF08A9-3D14-44CC-A65E-5933121D3D63}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "mssql", "mssql", "{F11F4058-9B0E-40B5-800F-628BC884A783}"
 	ProjectSection(SolutionItems) = preProject
@@ -67,26 +41,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "postgres", "postgres", "{CD
 		..\DatabaseScripts\EasyNetQ.Scheduler\postgres\uspGetNextBatchOfMessages.sql = ..\DatabaseScripts\EasyNetQ.Scheduler\postgres\uspGetNextBatchOfMessages.sql
 		..\DatabaseScripts\EasyNetQ.Scheduler\postgres\uspMarkWorkItemForPurge.sql = ..\DatabaseScripts\EasyNetQ.Scheduler\postgres\uspMarkWorkItemForPurge.sql
 		..\DatabaseScripts\EasyNetQ.Scheduler\postgres\uspWorkItemsSelfPurge.sql = ..\DatabaseScripts\EasyNetQ.Scheduler\postgres\uspWorkItemsSelfPurge.sql
-	EndProjectSection
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ.Scheduler.Mongo.Core", "EasyNetQ.Scheduler.Mongo.Core\EasyNetQ.Scheduler.Mongo.Core.csproj", "{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}"
-	ProjectSection(ProjectDependencies) = postProject
-		{ED270A39-D32C-438A-BF4F-AA0E66C7879C} = {ED270A39-D32C-438A-BF4F-AA0E66C7879C}
-	EndProjectSection
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ.Scheduler.Mongo", "EasyNetQ.Scheduler.Mongo\EasyNetQ.Scheduler.Mongo.csproj", "{AFD272B4-4A2B-43D4-81ED-666F8918FD01}"
-	ProjectSection(ProjectDependencies) = postProject
-		{ED270A39-D32C-438A-BF4F-AA0E66C7879C} = {ED270A39-D32C-438A-BF4F-AA0E66C7879C}
-	EndProjectSection
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ.Scheduler.Mongo.Tests", "EasyNetQ.Scheduler.Mongo.Tests\EasyNetQ.Scheduler.Mongo.Tests.csproj", "{4E7F926F-D939-4962-A7EF-112DE41B4236}"
-	ProjectSection(ProjectDependencies) = postProject
-		{ED270A39-D32C-438A-BF4F-AA0E66C7879C} = {ED270A39-D32C-438A-BF4F-AA0E66C7879C}
-	EndProjectSection
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyNetQ.Tests.Tasks", "EasyNetQ.Tests.Tasks\EasyNetQ.Tests.Tasks.csproj", "{A5CF1B2C-E390-4BFF-BB1A-0F171DB0D6BD}"
-	ProjectSection(ProjectDependencies) = postProject
-		{ED270A39-D32C-438A-BF4F-AA0E66C7879C} = {ED270A39-D32C-438A-BF4F-AA0E66C7879C}
 	EndProjectSection
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "EasyNetQ", "EasyNetQ\EasyNetQ.xproj", "{ED270A39-D32C-438A-BF4F-AA0E66C7879C}"
@@ -111,56 +65,34 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "EasyNetQ.Tests.Messages", "
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "EasyNetQ.DI.Tests", "EasyNetQ.DI.Tests\EasyNetQ.DI.Tests.xproj", "{76A3A0C3-10D8-465F-9ACA-5D0D3F61B445}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "EasyNetQ.Hosepipe", "EasyNetQ.Hosepipe\EasyNetQ.Hosepipe.xproj", "{99A7A83D-6F75-4A1C-83E8-7C4AF881B273}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "EasyNetQ.Hosepipe.SetupActions", "EasyNetQ.Hosepipe.SetupActions\EasyNetQ.Hosepipe.SetupActions.xproj", "{93F795C9-FCA3-4B9F-B7EC-19759B8E44CE}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "EasyNetQ.Hosepipe.Tests", "EasyNetQ.Hosepipe.Tests\EasyNetQ.Hosepipe.Tests.xproj", "{DA597678-7873-4156-8112-8C70B164381A}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "EasyNetQ.Scheduler", "EasyNetQ.Scheduler\EasyNetQ.Scheduler.xproj", "{03B93AAD-6CAB-4726-826E-B05684AEC1B9}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "EasyNetQ.Scheduler.Tests", "EasyNetQ.Scheduler.Tests\EasyNetQ.Scheduler.Tests.xproj", "{530A771C-B12E-48E4-AE10-11B8F6537F4F}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "EasyNetQ.Scheduler.Mongo", "EasyNetQ.Scheduler.Mongo\EasyNetQ.Scheduler.Mongo.xproj", "{AFD272B4-4A2B-43D4-81ED-666F8918FD01}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "EasyNetQ.Scheduler.Mongo.Core", "EasyNetQ.Scheduler.Mongo.Core\EasyNetQ.Scheduler.Mongo.Core.xproj", "{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "EasyNetQ.Scheduler.Mongo.Tests", "EasyNetQ.Scheduler.Mongo.Tests\EasyNetQ.Scheduler.Mongo.Tests.xproj", "{4E7F926F-D939-4962-A7EF-112DE41B4236}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "EasyNetQ.LogReader", "EasyNetQ.LogReader\EasyNetQ.LogReader.xproj", "{AA7F9D04-085B-4B71-8541-B838F5CAF9F2}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "EasyNetQ.Tests.Tasks", "EasyNetQ.Tests.Tasks\EasyNetQ.Tests.Tasks.xproj", "{A5CF1B2C-E390-4BFF-BB1A-0F171DB0D6BD}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "EasyNetQ.Trace", "EasyNetQ.Trace\EasyNetQ.Trace.xproj", "{11DF08A9-3D14-44CC-A65E-5933121D3D63}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{03B93AAD-6CAB-4726-826E-B05684AEC1B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{03B93AAD-6CAB-4726-826E-B05684AEC1B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{03B93AAD-6CAB-4726-826E-B05684AEC1B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{03B93AAD-6CAB-4726-826E-B05684AEC1B9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{530A771C-B12E-48E4-AE10-11B8F6537F4F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{530A771C-B12E-48E4-AE10-11B8F6537F4F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{530A771C-B12E-48E4-AE10-11B8F6537F4F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{530A771C-B12E-48E4-AE10-11B8F6537F4F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{AA7F9D04-085B-4B71-8541-B838F5CAF9F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{AA7F9D04-085B-4B71-8541-B838F5CAF9F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{AA7F9D04-085B-4B71-8541-B838F5CAF9F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{AA7F9D04-085B-4B71-8541-B838F5CAF9F2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{99A7A83D-6F75-4A1C-83E8-7C4AF881B273}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{99A7A83D-6F75-4A1C-83E8-7C4AF881B273}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{99A7A83D-6F75-4A1C-83E8-7C4AF881B273}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{99A7A83D-6F75-4A1C-83E8-7C4AF881B273}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DA597678-7873-4156-8112-8C70B164381A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DA597678-7873-4156-8112-8C70B164381A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DA597678-7873-4156-8112-8C70B164381A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DA597678-7873-4156-8112-8C70B164381A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{93F795C9-FCA3-4B9F-B7EC-19759B8E44CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{93F795C9-FCA3-4B9F-B7EC-19759B8E44CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{93F795C9-FCA3-4B9F-B7EC-19759B8E44CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{93F795C9-FCA3-4B9F-B7EC-19759B8E44CE}.Release|Any CPU.Build.0 = Release|Any CPU
-		{11DF08A9-3D14-44CC-A65E-5933121D3D63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{11DF08A9-3D14-44CC-A65E-5933121D3D63}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{11DF08A9-3D14-44CC-A65E-5933121D3D63}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{11DF08A9-3D14-44CC-A65E-5933121D3D63}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{AFD272B4-4A2B-43D4-81ED-666F8918FD01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{AFD272B4-4A2B-43D4-81ED-666F8918FD01}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{AFD272B4-4A2B-43D4-81ED-666F8918FD01}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{AFD272B4-4A2B-43D4-81ED-666F8918FD01}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4E7F926F-D939-4962-A7EF-112DE41B4236}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4E7F926F-D939-4962-A7EF-112DE41B4236}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4E7F926F-D939-4962-A7EF-112DE41B4236}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4E7F926F-D939-4962-A7EF-112DE41B4236}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A5CF1B2C-E390-4BFF-BB1A-0F171DB0D6BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A5CF1B2C-E390-4BFF-BB1A-0F171DB0D6BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A5CF1B2C-E390-4BFF-BB1A-0F171DB0D6BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A5CF1B2C-E390-4BFF-BB1A-0F171DB0D6BD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{ED270A39-D32C-438A-BF4F-AA0E66C7879C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{ED270A39-D32C-438A-BF4F-AA0E66C7879C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ED270A39-D32C-438A-BF4F-AA0E66C7879C}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -205,6 +137,50 @@ Global
 		{76A3A0C3-10D8-465F-9ACA-5D0D3F61B445}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{76A3A0C3-10D8-465F-9ACA-5D0D3F61B445}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{76A3A0C3-10D8-465F-9ACA-5D0D3F61B445}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99A7A83D-6F75-4A1C-83E8-7C4AF881B273}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99A7A83D-6F75-4A1C-83E8-7C4AF881B273}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99A7A83D-6F75-4A1C-83E8-7C4AF881B273}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99A7A83D-6F75-4A1C-83E8-7C4AF881B273}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93F795C9-FCA3-4B9F-B7EC-19759B8E44CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93F795C9-FCA3-4B9F-B7EC-19759B8E44CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93F795C9-FCA3-4B9F-B7EC-19759B8E44CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93F795C9-FCA3-4B9F-B7EC-19759B8E44CE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA597678-7873-4156-8112-8C70B164381A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA597678-7873-4156-8112-8C70B164381A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA597678-7873-4156-8112-8C70B164381A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA597678-7873-4156-8112-8C70B164381A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03B93AAD-6CAB-4726-826E-B05684AEC1B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03B93AAD-6CAB-4726-826E-B05684AEC1B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03B93AAD-6CAB-4726-826E-B05684AEC1B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03B93AAD-6CAB-4726-826E-B05684AEC1B9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{530A771C-B12E-48E4-AE10-11B8F6537F4F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{530A771C-B12E-48E4-AE10-11B8F6537F4F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{530A771C-B12E-48E4-AE10-11B8F6537F4F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{530A771C-B12E-48E4-AE10-11B8F6537F4F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AFD272B4-4A2B-43D4-81ED-666F8918FD01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AFD272B4-4A2B-43D4-81ED-666F8918FD01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AFD272B4-4A2B-43D4-81ED-666F8918FD01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AFD272B4-4A2B-43D4-81ED-666F8918FD01}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F444E58F-DA2A-47E8-8246-C4BDD9A192B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E7F926F-D939-4962-A7EF-112DE41B4236}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E7F926F-D939-4962-A7EF-112DE41B4236}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E7F926F-D939-4962-A7EF-112DE41B4236}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E7F926F-D939-4962-A7EF-112DE41B4236}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA7F9D04-085B-4B71-8541-B838F5CAF9F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA7F9D04-085B-4B71-8541-B838F5CAF9F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA7F9D04-085B-4B71-8541-B838F5CAF9F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA7F9D04-085B-4B71-8541-B838F5CAF9F2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5CF1B2C-E390-4BFF-BB1A-0F171DB0D6BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5CF1B2C-E390-4BFF-BB1A-0F171DB0D6BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5CF1B2C-E390-4BFF-BB1A-0F171DB0D6BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5CF1B2C-E390-4BFF-BB1A-0F171DB0D6BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11DF08A9-3D14-44CC-A65E-5933121D3D63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11DF08A9-3D14-44CC-A65E-5933121D3D63}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11DF08A9-3D14-44CC-A65E-5933121D3D63}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11DF08A9-3D14-44CC-A65E-5933121D3D63}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/EasyNetQ/project.json
+++ b/Source/EasyNetQ/project.json
@@ -26,10 +26,17 @@
     "Wiebe Tijsma",
     "Contributors (see GitHub repo) "
   ],
+
+  "buildOptions": {
+    "compile": {
+      "includeFiles": "..\\Version.cs"
+    }
+  },
   "dependencies": {
     "Newtonsoft.Json": "9.0.1",
     "RabbitMQ.Client": "4.1.1"
   },
+
   "tools": {
     "dotnet-gitversion": {
       "version": "1.0.0",

--- a/Source/EasyNetQ/project.json
+++ b/Source/EasyNetQ/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.3-netcore0001",
+  "version": "99.0.0-dev",
   "description": "EasyNetQ",
   "title": "EasyNetQ",
   "name": "EasyNetQ",


### PR DESCRIPTION
* Migrates remaining projects to .NET Core or xproj
   * Some of the projects like EasyNetQ.Scheduler rely on Topshelf which is not yet on .NET Core. So they only compile against .NET 4.5.1
* Fixes issue where NuGet packages were being restored from myget feed instead of in dev because of the version number (2.0.3-netcore0001) in the myget feed. I updated them to 99.0,0-dev, but when dotnet-gitversion is run, it should update it appropriately.
   * The next PR will utilise dotnet-gitversion to properly update the versions

#508 