### PR TITLE
Fixing NuGet package creation

### DIFF
--- a/Build/EasyNetQ.proj
+++ b/Build/EasyNetQ.proj
@@ -64,7 +64,10 @@
             <NuGetPackageDirectory>$(Package)</NuGetPackageDirectory>
         </PropertyGroup>
         <ItemGroup>
-            <ClientLibraries Include="$(Source)\**\project.json" Exclude="$(Source)\*Tests\project.json" />
+            <ClientLibraries Include="$(Source)\EasyNetQ\project.json" />
+            <ClientLibraries Include="$(Source)\EasyNetQ.DI.*\project.json" Exclude="$(Source)\*Tests*\project.json" />
+            <ClientLibraries Include="$(Source)\EasyNetQ.Serilog\project.json" />
+
             <FilesToDelete Include="$(NuGetPackageDirectory)\*.nupkg" />
         </ItemGroup>
 

--- a/Build/UpdateGitVersion.ps1
+++ b/Build/UpdateGitVersion.ps1
@@ -8,11 +8,11 @@ if (!(Test-Path $sourceFolder)) {
     Write-Error "Cannot find $sourceFolder"
 }
 
-$projects = Get-ChildItem $sourceFolder | ? { $_.PSIsContainer -and !$_.Name.Contains("Tests") -and !$_.Name.Contains("Hosepipe.Setup") }
+$projects = Get-ChildItem $sourceFolder\project.json -Recurse | ? { !$_.Directory.Name.Contains("Tests") }
 
 foreach ($projectJson in $projects) {
 
-    $directory = $projectJson.FullName
+    $directory = $projectJson.DirectoryName
         
     pushd $directory
 

--- a/Build/UpdateGitVersion.ps1
+++ b/Build/UpdateGitVersion.ps1
@@ -1,4 +1,9 @@
-﻿$repositoryRoot = [IO.Path]::GetFullPath($(Join-Path $PSScriptRoot "\..\"))
+﻿[CmdletBinding()]
+param(
+    [string[]]$ExcludeUpdatingDependencies = @("EasyNetQ.Management.Client", "EasyNetQ.Tests.Common", "EasyNetQ.Tests.Tasks")
+)
+
+$repositoryRoot = [IO.Path]::GetFullPath($(Join-Path $PSScriptRoot "\..\"))
 $sourceFolder = Join-Path $repositoryRoot "Source"
 
 Write-Host "Repository: $repositoryRoot"
@@ -8,13 +13,18 @@ if (!(Test-Path $sourceFolder)) {
     Write-Error "Cannot find $sourceFolder"
 }
 
-$projects = Get-ChildItem $sourceFolder\project.json -Recurse | ? { !$_.Directory.Name.Contains("Tests") }
+$projects = Get-ChildItem $sourceFolder\project.json -Recurse
+$projectsExcludingTests = $projects | ? { !$_.Directory.Name.Contains("Tests") }
 
-foreach ($projectJson in $projects) {
+# Update the version number in all of the project.jsons
+
+foreach ($projectJson in $projectsExcludingTests) {
 
     $directory = $projectJson.DirectoryName
-        
+
     pushd $directory
+
+    Write-Host "Updating version for $($projectJson.Directory.Name)..."
 
     if (!(Test-Path $(Join-Path $directory "project.lock.json"))) {
         & dotnet restore
@@ -23,4 +33,43 @@ foreach ($projectJson in $projects) {
     & dotnet gitversion
 
     popd
+}
+
+# Update the dependency in each of the project.jsons
+# ie) "EasyNetQ" : "99.0.0-dev", we want updated to "EasyNetQ": "<new version>"
+# Or else, when we do a dotnet-pack, it will specify 99.0.0-dev in the package
+# for the dependency EasyNetQ.
+$regex = "NuGetVersion: (?<version>.+)"
+$gitVersionCache = Get-ChildItem $([IO.Path]::Combine($repositoryRoot, ".git", "gitversion_cache")) `
+    | Sort-Object -Descending LastWriteTimeUtc `
+    | Select -First 1 `
+    | select-string $regex
+
+if ($gitVersionCache -eq $null -or @($gitVersionCache).Count -eq 0) {
+    Write-Warning "Could not find gitversion_cache and a match to $regex.  Please run dotnet gitversion."
+    return
+}
+
+$version = $gitVersionCache.Matches[0].Groups["version"].Value
+
+Write-Host "Getting version from: $($gitVersionCache.Path)"
+
+foreach ($projectJson in $projects) {
+    $json = ConvertFrom-Json "$(Get-Content $projectJson.FullName)"
+
+    Write-Host "$($projectJson.Directory.Name): Updating dependencies..."
+
+    if ($json.dependencies -eq $null -or @($json.dependencies).Count -eq 0) {
+        Write-Host "SKIPPING: There are no dependencies in $($projectJson.Directory.Name)."
+        continue
+    }
+
+    $dependencies = $json.dependencies.PsObject.Members `
+        | ? { $_.MemberType -eq "NoteProperty" -and $_.Name.StartsWith("EasyNetQ") -and !$ExcludeUpdatingDependencies.Contains($_.Name) } `
+        | foreach {
+                Write-Host "    - $($_.Name): Updating $($_.Value) -> $version"
+                $_.Value = $version
+            }
+        
+    ConvertTo-Json $json -Depth 99 | Set-Content $projectJson.FullName
 }


### PR DESCRIPTION
* Limiting NuGet packages that are created to the ones before
    * EasyNetQ
    * EasyNetQ.DI.*
    * EasyNetQ.Serilog
* Updating dependencies in project.jsons to their updated versions so the packaged nupkg has the correct version

Note that the PR's CI build passed but was unable to run dotnet-gitversion successfully because PRs are run in a detached head state. When this PR is merged, the versions will be updated correctly like my build [here](https://ci.appveyor.com/project/conniey/easynetq).

@alinapopa @zidad @micdenny 