### PR TITLE
Fixing tests

### DIFF
--- a/Source/EasyNetQ.Tests/Integration/ConsumerShutdownTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/ConsumerShutdownTests.cs
@@ -22,6 +22,7 @@ namespace EasyNetQ.Tests.Integration
         [Fact]
         public void Message_can_be_processed_but_not_ACKd()
         {
+            var waitTime = TimeSpan.FromMinutes(2);
             var receivedEvent = new AutoResetEvent(false);
             var processedEvent = new AutoResetEvent(false);
 
@@ -49,13 +50,15 @@ namespace EasyNetQ.Tests.Integration
             bus.Advanced.Publish(Exchange.GetDefault(), queueName, false, new MessageProperties(), message);
             Console.Out.WriteLine("Published");
 
-            receivedEvent.WaitOne();
+            var signalReceived = receivedEvent.WaitOne(waitTime);
+            Assert.True(signalReceived, $"Expected reset event within {waitTime.TotalSeconds} seconds");
 
             Console.Out.WriteLine("Dispose Called");
             bus.Dispose();
             Console.Out.WriteLine("Disposed");
 
-            processedEvent.WaitOne(1000);
+            signalReceived = processedEvent.WaitOne(waitTime);
+            Assert.True(signalReceived, $"Expected reset event within {waitTime.TotalSeconds} seconds");
         }
     }
 }

--- a/Source/EasyNetQ.Tests/Integration/SendReceiveIntegrationTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/SendReceiveIntegrationTests.cs
@@ -41,6 +41,7 @@ namespace EasyNetQ.Tests.Integration
         {
             const string queue = "send_receive_test";
             var are = new AutoResetEvent(false);
+            var waitTime = TimeSpan.FromMinutes(2);
 
             bus.Receive(queue, x => x.Add<MyMessage>(message =>
                 {
@@ -60,7 +61,8 @@ namespace EasyNetQ.Tests.Integration
 
             bus.Send(queue, new MyMessage { Text = "Hello Widgets!" });
 
-            are.WaitOne();
+            var signalReceived = are.WaitOne(waitTime);
+            Assert.True(signalReceived, $"Expected reset event within {waitTime.TotalSeconds} seconds");
         }
     }
 }

--- a/Source/EasyNetQ.Tests/ModelCleanupTests.cs
+++ b/Source/EasyNetQ.Tests/ModelCleanupTests.cs
@@ -1,20 +1,23 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using EasyNetQ.Events;
 using EasyNetQ.Tests.Mocking;
-using Xunit;
 using NSubstitute;
+using Xunit;
 
 namespace EasyNetQ.Tests
 {
     public class ModelCleanupTests
     {
-        private IBus bus;
-        private MockBuilder mockBuilder;
+        private readonly IBus bus;
+        private readonly MockBuilder mockBuilder;
+        private readonly TimeSpan waitTime;
 
         public ModelCleanupTests()
         {
             mockBuilder = new MockBuilder();
             bus = mockBuilder.Bus;
+            waitTime = TimeSpan.FromMinutes(2);
         }
 
         [Fact]
@@ -34,7 +37,8 @@ namespace EasyNetQ.Tests
 
             bus.Dispose();
 
-            are.WaitOne();
+            bool signalReceived = are.WaitOne(waitTime);
+            Assert.True(signalReceived, $"Set event was not received within {waitTime.TotalSeconds} seconds");
 
             mockBuilder.Channels[1].Received().Dispose();
         }
@@ -47,7 +51,8 @@ namespace EasyNetQ.Tests
 
             bus.Dispose();
 
-            are.WaitOne();
+            bool signalReceived = are.WaitOne(waitTime);
+            Assert.True(signalReceived, $"Set event was not received within {waitTime.TotalSeconds} seconds");
 
             mockBuilder.Channels[1].Received().Dispose();
         }
@@ -60,7 +65,8 @@ namespace EasyNetQ.Tests
 
             bus.Dispose();
 
-            are.WaitOne();
+            bool signalReceived = are.WaitOne(waitTime);
+            Assert.True(signalReceived, $"Set event was not received within {waitTime.TotalSeconds} seconds");
 
             mockBuilder.Channels[1].Received().Dispose();
         }
@@ -73,7 +79,8 @@ namespace EasyNetQ.Tests
 
             bus.Dispose();
 
-            are.WaitOne();
+            bool signalReceived = are.WaitOne(waitTime);
+            Assert.True(signalReceived, $"Set event was not received within {waitTime.TotalSeconds} seconds");
 
             mockBuilder.Channels[1].Received().Dispose();
         }


### PR DESCRIPTION
The [latest build](https://ci.appveyor.com/project/EasyNetQ/easynetq) failed because it reached a maximum of 60 minutes on the build server.  It appears to be because some of the tests have a AutoResetEvent.WaitOne call that will wait forever.

* Added a maximum TimeSpan to wait for a set event.  Test will fail if one was not received within that time span.
* Replaced a lock(object) with ConcurrentDictionary.AddOrUpdate.