### PR TITLE
added support for dynamically generated types in TypeNameSerializer

### DIFF
--- a/Source/EasyNetQ/TypeNameSerializer.cs
+++ b/Source/EasyNetQ/TypeNameSerializer.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
 
 namespace EasyNetQ
 {
@@ -9,29 +11,42 @@ namespace EasyNetQ
         Type DeSerialize(string typeName);
     }
 
-	
     public class TypeNameSerializer : ITypeNameSerializer
     {
         private readonly ConcurrentDictionary<string, Type> deserializedTypes = new ConcurrentDictionary<string, Type>();
+        private readonly ConcurrentDictionary<string, Assembly> assemblies = new ConcurrentDictionary<string, Assembly>();
 
         public Type DeSerialize(string typeName)
         {
-            Preconditions.CheckNotBlank(typeName, "typeName");
+            Preconditions.CheckNotBlank(typeName, nameof(typeName));
+            return deserializedTypes.GetOrAdd(typeName, GetType);
+        }
 
-            return deserializedTypes.GetOrAdd(typeName, t =>
+        private Type GetType(string t)
+        {
+            var nameParts = t.Split(':');
+            if (nameParts.Length != 2)
             {
-                var nameParts = t.Split(':');
-                if (nameParts.Length != 2)
-                {
-                    throw new EasyNetQException("type name {0}, is not a valid EasyNetQ type name. Expected Type:Assembly", t);
-                }
-                var type = Type.GetType(nameParts[0] + ", " + nameParts[1]);
-                if (type == null)
-                {
-                    throw new EasyNetQException("Cannot find type {0}", t);
-                }
-                return type;
-            });
+                throw new EasyNetQException("type name {0}, is not a valid EasyNetQ type name. Expected Type:Assembly", t);
+            }
+
+            var assemblyName = nameParts[1];
+            var typeName = nameParts[0];
+
+            var type = Type.GetType(typeName + ", " + assemblyName);
+
+            if (type == null)
+            {
+                var assembly = assemblies.GetOrAdd(assemblyName, a =>
+                    AppDomain.CurrentDomain.GetAssemblies().Single(aa => GetAssemblyName(aa).Equals(a, StringComparison.Ordinal)));
+                type = assembly.GetType(typeName);
+            }
+
+            if (type == null)
+            {
+                throw new EasyNetQException("Cannot find type {0}", t);
+            }
+            return type;
         }
 
         private readonly ConcurrentDictionary<Type, string> serializedTypes = new ConcurrentDictionary<Type, string>();
@@ -42,7 +57,7 @@ namespace EasyNetQ
 
             return serializedTypes.GetOrAdd(type, t =>
             {
-                var typeName = t.FullName + ":" + t.Assembly.GetName().Name;
+                var typeName = t.FullName + ":" + GetAssemblyName(t.Assembly);
                 if (typeName.Length > 255)
                 {
                     throw new EasyNetQException("The serialized name of type '{0}' exceeds the AMQP " +
@@ -51,5 +66,7 @@ namespace EasyNetQ
                 return typeName;
             });
         }
+
+        private static string GetAssemblyName(Assembly assembly) => assembly.GetName().Name;
     }
 }


### PR DESCRIPTION
Originally used method Type.GetType() is searching for types only in assemblies loaded from disk ([msdn](https://msdn.microsoft.com/en-us/library/w3f99sx1(v=vs.110).aspx)). Added fallback to search in assemblies in AppDomain.