### PR TITLE
added new implementation of ITypeNameSerializer -> DynamicTypeNameSerializer

### DIFF
--- a/Source/EasyNetQ.Tests/DynamicTypeNameSerializerTests.cs
+++ b/Source/EasyNetQ.Tests/DynamicTypeNameSerializerTests.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using EasyNetQ.Tests.ProducerTests.Very.Long.Namespace.Certainly.Longer.Than.The255.Char.Length.That.RabbitMQ.Likes.That.Will.Certainly.Cause.An.AMQP.Exception.If.We.Dont.Do.Something.About.It.And.Stop.It.From.Happening;
+using NUnit.Framework;
+
+namespace EasyNetQ.Tests
+{
+    // ReSharper disable InconsistentNaming
+    [TestFixture]
+    public class DynamicTypeNameSerializerTests
+    {
+        private const string expectedTypeName = "System.String:mscorlib";
+        private const string expectedCustomTypeName = "EasyNetQ.Tests.DynamicTypeNameSerializer_SomeRandomClass:EasyNetQ.Tests";
+
+        private ITypeNameSerializer typeNameSerializer;
+
+        [SetUp]
+        public void SetUp()
+        {
+            typeNameSerializer = new DynamicTypeNameSerializer();
+        }
+
+        [Test]
+        public void Should_serialize_a_type_name()
+        {
+            var typeName = typeNameSerializer.Serialize(typeof(string));
+            typeName.ShouldEqual(expectedTypeName);
+        }
+
+        [Test]
+        public void Should_serialize_a_custom_type()
+        {
+            var typeName = typeNameSerializer.Serialize(typeof(DynamicTypeNameSerializer_SomeRandomClass));
+            typeName.ShouldEqual(expectedCustomTypeName);
+        }
+
+        [Test]
+        public void Should_serialize_a_dynamic_type()
+        {
+            var dynamicAssembyName = Guid.NewGuid().ToString("N");
+            var dynamicTypeName = Guid.NewGuid().ToString("N");
+            var dynamicType = CreateDynamicType(dynamicAssembyName, dynamicTypeName);
+            var expectedDynamicTypeName = $"{dynamicTypeName}:{dynamicAssembyName}";
+
+            var typeName = typeNameSerializer.Serialize(dynamicType);
+            typeName.ShouldEqual(expectedDynamicTypeName);
+        }
+
+        [Test]
+        public void Should_deserialize_a_type_name()
+        {
+            var type = typeNameSerializer.DeSerialize(expectedTypeName);
+            type.ShouldEqual(typeof(string));
+        }
+
+        [Test]
+        public void Should_deserialize_a_custom_type()
+        {
+            var type = typeNameSerializer.DeSerialize(expectedCustomTypeName);
+            type.ShouldEqual(typeof(DynamicTypeNameSerializer_SomeRandomClass));
+        }
+
+        [Test]
+        public void Should_deserialize_a_dynamic_type()
+        {
+            var dynamicAssembyName = Guid.NewGuid().ToString("N");
+            var dynamicTypeName = Guid.NewGuid().ToString("N");
+            var dynamicType = CreateDynamicType(dynamicAssembyName, dynamicTypeName);
+            var serializedDynamicTypeName = $"{dynamicTypeName}:{dynamicAssembyName}";
+
+            var type = typeNameSerializer.DeSerialize(serializedDynamicTypeName);
+            type.ShouldEqual(dynamicType);
+        }
+
+        [Test]
+        [ExpectedException(typeof(EasyNetQException))]
+        public void Should_throw_exception_when_type_name_is_not_recognised()
+        {
+            typeNameSerializer.DeSerialize("EasyNetQ.DynamicTypeNameSerializer.None:EasyNetQ");
+        }
+
+        [Test]
+        [ExpectedException(typeof(EasyNetQException))]
+        public void Should_throw_if_type_name_is_too_long()
+        {
+            typeNameSerializer.Serialize(
+                typeof(
+                    MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes
+                ));
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Should_throw_exception_if_type_name_is_null()
+        {
+            typeNameSerializer.DeSerialize(null);
+        }
+
+        public void Spike()
+        {
+            var type = Type.GetType("EasyNetQ.Tests.DynamicTypeNameSerializer_SomeRandomClass, EasyNetQ.Tests");
+            type.ShouldEqual(typeof(DynamicTypeNameSerializer_SomeRandomClass));
+        }
+
+        public void Spike2()
+        {
+            var name = typeof(DynamicTypeNameSerializer_SomeRandomClass).AssemblyQualifiedName;
+            Console.Out.WriteLine(name);
+        }
+
+        private static Type CreateDynamicType(string assemblyName, string typeName)
+        {
+            var assembly = AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName(assemblyName), AssemblyBuilderAccess.Run);
+            var module = assembly.DefineDynamicModule(assemblyName + "_module");
+            var typeBuilder = module.DefineType(typeName, TypeAttributes.Public | TypeAttributes.Class);
+            return typeBuilder.CreateType();
+        }
+    }
+
+    public class DynamicTypeNameSerializer_SomeRandomClass
+    {
+
+    }
+    // ReSharper restore InconsistentNaming
+}

--- a/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
+++ b/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
@@ -89,6 +89,7 @@
       <Link>Properties\Version.cs</Link>
     </Compile>
     <Compile Include="AdvancedBusEventHandlersTests.cs" />
+    <Compile Include="DynamicTypeNameSerializerTests.cs" />
     <Compile Include="MultipleExchangeTest\MultipleExchangePublishExchangeDeclareStrategyTests.cs" />
     <Compile Include="MultipleExchangeTest\IMessageInterfaceTwo.cs" />
     <Compile Include="MultipleExchangeTest\IMessageInterfaceOne.cs" />

--- a/Source/EasyNetQ/DynamicTypeNameSerializer.cs
+++ b/Source/EasyNetQ/DynamicTypeNameSerializer.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+
+namespace EasyNetQ
+{
+    public class DynamicTypeNameSerializer : ITypeNameSerializer
+    {
+        private readonly ConcurrentDictionary<string, Type> deserializedTypes = new ConcurrentDictionary<string, Type>();
+        private readonly ConcurrentDictionary<string, Assembly> assemblies = new ConcurrentDictionary<string, Assembly>();
+
+        public Type DeSerialize(string typeName)
+        {
+            Preconditions.CheckNotBlank(typeName, nameof(typeName));
+            return deserializedTypes.GetOrAdd(typeName, GetType);
+        }
+
+        private Type GetType(string t)
+        {
+            var nameParts = t.Split(':');
+            if (nameParts.Length != 2)
+            {
+                throw new EasyNetQException("type name {0}, is not a valid EasyNetQ type name. Expected Type:Assembly", t);
+            }
+
+            var typeName = nameParts[0];
+            var assemblyName = nameParts[1];
+
+            var fullTypeName = typeName + ", " + assemblyName;
+            var type = Type.GetType(fullTypeName);
+
+            if (type == null)
+            {
+                var assembly = assemblies.GetOrAdd(assemblyName, a =>
+                    AppDomain.CurrentDomain.GetAssemblies().Single(aa => GetAssemblyName(aa).Equals(a, StringComparison.Ordinal)));
+                type = assembly.GetType(typeName);
+            }
+
+            if (type == null)
+            {
+                throw new EasyNetQException("Cannot find type {0}", t);
+            }
+            return type;
+        }
+
+        private readonly ConcurrentDictionary<Type, string> serializedTypes = new ConcurrentDictionary<Type, string>();
+
+        public string Serialize(Type type)
+        {
+            Preconditions.CheckNotNull(type, "type");
+
+            return serializedTypes.GetOrAdd(type, t =>
+            {
+                var typeName = t.FullName + ":" + GetAssemblyName(t.Assembly);
+                if (typeName.Length > 255)
+                {
+                    throw new EasyNetQException("The serialized name of type '{0}' exceeds the AMQP " +
+                                                "maximum short string length of 255 characters.", t.Name);
+                }
+                return typeName;
+            });
+        }
+
+        private static string GetAssemblyName(Assembly assembly) => assembly.GetName().Name;
+    }
+}

--- a/Source/EasyNetQ/EasyNetQ.projitems
+++ b/Source/EasyNetQ/EasyNetQ.projitems
@@ -180,5 +180,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Topology\IQueue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Topology\Queue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TypeNameSerializer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DynamicTypeNameSerializer.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
TypeNameSerializer uses method Type.GetType(). This method searches types only in assemblies loaded from disk ([msdn](https://msdn.microsoft.com/en-us/library/w3f99sx1(v=vs.110).aspx)). Added alternative implementation of ITypeNameSerializer which has fallback to search in assemblies in AppDomain to support dynamically generated types and assemblies. You can find more in #664 