### PR TITLE
Bug fix in SimpleInjectorAdapter: defer execution of serviceCreator

### DIFF
--- a/Source/EasyNetQ.DI.SimpleInjector/SimpleInjectorAdapter.cs
+++ b/Source/EasyNetQ.DI.SimpleInjector/SimpleInjectorAdapter.cs
@@ -22,7 +22,7 @@ namespace EasyNetQ.DI
         {
             if (!IsRegistered<TService>())
             {
-                _simpleInjectorContainer.RegisterSingleton(serviceCreator(this));
+                _simpleInjectorContainer.RegisterSingleton(() => serviceCreator(this));
             }
             
             return this;

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -7,9 +7,10 @@ using System.Reflection;
 // MINOR version when you add functionality in a backwards-compatible manner, and
 // PATCH version when you make backwards-compatible bug fixes.
 
-[assembly: AssemblyVersion("1.0.2.0")]
+[assembly: AssemblyVersion("1.0.3.0")]
 [assembly: CLSCompliant(false)]
 
+// 1.0.3.0 Bug Fix, defer execution of serviceCreator parameter in SimpleInjectorAdapter.Register
 // 1.0.2.0 Added start consuming events for failure and success
 // 1.0.1.0  First stable release
 // 0.63.6.0 Added support for multiple exchange (creating an exchange per implemented interface for a concreate type)

--- a/hall_of_fame.md
+++ b/hall_of_fame.md
@@ -62,3 +62,4 @@ No particular order. Don't forget to add your name with your pull request.
 * Alex Wiese
 * Georg Pfeiffer
 * Thomas T
+* Brett Janer


### PR DESCRIPTION
Pretty minor fix here, so I didn't bother opening up an issue.  Just trying to get in the hall_of_fame :D.  In the SimpleInjectorAdapter.Register method that takes a factory delegate, the delegate is being executed in the method instead of being deferred.  I believe I've made the appropriate fix.  Let me know your thoughts.

Thanks,

Brett J