### PR TITLE
Included queue name in Error message

### DIFF
--- a/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
+++ b/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
@@ -201,6 +201,7 @@ namespace EasyNetQ.Consumer
             {
                 RoutingKey = context.Info.RoutingKey,
                 Exchange = context.Info.Exchange,
+                Queue = context.Info.Queue,
                 Exception = exception.ToString(),
                 Message = messageAsString,
                 DateTime = DateTime.UtcNow

--- a/Source/EasyNetQ/SystemMessages/Error.cs
+++ b/Source/EasyNetQ/SystemMessages/Error.cs
@@ -9,6 +9,7 @@ namespace EasyNetQ.SystemMessages
     {
         public string RoutingKey { get; set; }
         public string Exchange { get; set; }
+        public string Queue { get; set; }
         public string Exception { get; set; }
         public string Message { get; set; }
         public DateTime DateTime { get; set; }

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -7,9 +7,10 @@ using System.Reflection;
 // MINOR version when you add functionality in a backwards-compatible manner, and
 // PATCH version when you make backwards-compatible bug fixes.
 
-[assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyVersion("1.0.4.0")]
 [assembly: CLSCompliant(false)]
 
+// 1.0.4.0 Included queue name in Error message
 // 1.0.3.0 Bug Fix, defer execution of serviceCreator parameter in SimpleInjectorAdapter.Register
 // 1.0.2.0 Added start consuming events for failure and success
 // 1.0.1.0  First stable release


### PR DESCRIPTION
This is to include queue name into Error Message. Queue name is retrieved from ConsumerExecutionContext.Info.Queue.

This is what we talked about in #681 

@micdenny 