### PR TITLE
Newtonsoft.Json added as an explicit NuGet dependency instead of embedding it to EasyNetQ.dll

### DIFF
--- a/Build/EasyNetQ.proj
+++ b/Build/EasyNetQ.proj
@@ -19,7 +19,7 @@
 
     <Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Targets"/>
 
-    <Target Name="Default" DependsOnTargets="Version; Build; Test; Merge; Package; PackageDiWindsor; PackageDiNinject; PackageDiSimpleInjector; PackageDILightInject; PackageDiStructureMap; PackageDiAutofac; PackageSerilog" />
+    <Target Name="Default" DependsOnTargets="Version; Build; Test; Package; PackageDiWindsor; PackageDiNinject; PackageDiSimpleInjector; PackageDILightInject; PackageDiStructureMap; PackageDiAutofac; PackageSerilog" />
 
     <Target Name="Version">
         <FileUpdate Files="$(Source)\Version.cs"
@@ -34,49 +34,42 @@
     </ItemGroup>
 
     <Target Name="Build" DependsOnTargets="Version">
-        <Exec 
-          WorkingDirectory="$(Source)" 
+        <Exec
+          WorkingDirectory="$(Source)"
           Command="$(NuGet)\NuGet.exe restore $(Source)\EasyNetQ.sln" />
 
         <MSBuild Projects="@(ProjectToBuild)" Targets="Clean;Rebuild"/>
     </Target>
 
     <Target Name="Test" DependsOnTargets="Build">
-        <CreateItem Include="$(Source)\EasyNetQ.Tests\bin\Release\*.Tests.dll">  
-          <Output TaskParameter="Include" ItemName="TestAssembly" />  
+        <CreateItem Include="$(Source)\EasyNetQ.Tests\bin\Release\*.Tests.dll">
+          <Output TaskParameter="Include" ItemName="TestAssembly" />
         </CreateItem>
-        <CreateItem Include="$(Source)\EasyNetQ.DI.Tests\bin\Release\*.Tests.dll">  
-          <Output TaskParameter="Include" ItemName="TestAssembly" />  
+        <CreateItem Include="$(Source)\EasyNetQ.DI.Tests\bin\Release\*.Tests.dll">
+          <Output TaskParameter="Include" ItemName="TestAssembly" />
         </CreateItem>
-        <CreateItem Include="$(Source)\EasyNetQ.Hosepipe.Tests\bin\Release\*.Tests.dll">  
-          <Output TaskParameter="Include" ItemName="TestAssembly" />  
+        <CreateItem Include="$(Source)\EasyNetQ.Hosepipe.Tests\bin\Release\*.Tests.dll">
+          <Output TaskParameter="Include" ItemName="TestAssembly" />
         </CreateItem>
-        <CreateItem Include="$(Source)\EasyNetQ.Scheduler.Tests\bin\Release\*.Tests.dll">  
-          <Output TaskParameter="Include" ItemName="TestAssembly" />  
+        <CreateItem Include="$(Source)\EasyNetQ.Scheduler.Tests\bin\Release\*.Tests.dll">
+          <Output TaskParameter="Include" ItemName="TestAssembly" />
         </CreateItem>
-        <CreateItem Include="$(Source)\EasyNetQ.Scheduler.Mongo.Tests\bin\Release\*.Tests.dll">  
-          <Output TaskParameter="Include" ItemName="TestAssembly" />  
+        <CreateItem Include="$(Source)\EasyNetQ.Scheduler.Mongo.Tests\bin\Release\*.Tests.dll">
+          <Output TaskParameter="Include" ItemName="TestAssembly" />
         </CreateItem>
         <NUnit ToolPath="$(Nunit)" DisableShadowCopy="true" Assemblies="@(TestAssembly)" Framework="4.0.30319" Force32Bit="true" />
     </Target>
 
-    <Target Name="Merge" DependsOnTargets="Test">
-      <Exec 
-          WorkingDirectory="$(Net45OutputDir)" 
-          Command="$(ILRepack) /internalize /targetplatform:v4 /out:EasyNetQ.dll EasyNetQ.dll Newtonsoft.Json.dll" />
-    </Target>
-
-
     <!-- Packaging -->
 
-    <Target Name="Package" DependsOnTargets="Merge">
+    <Target Name="Package" DependsOnTargets="Test">
 
         <ItemGroup>
             <FilesToDelete Include="$(Package)\EasyNetQ\*.nupkg"  />
         </ItemGroup>
-      
+
         <Delete Files="@(FilesToDelete)" />
-                                  
+
         <GetAssemblyIdentity AssemblyFiles="$(Source)\EasyNetQ NET45\bin\Release\EasyNetQ.dll">
             <Output TaskParameter="Assemblies" ItemName="AsmInfo" />
         </GetAssemblyIdentity>
@@ -88,8 +81,8 @@
             Namespace="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"
             XmlFileName="$(Package)\EasyNetQ\EasyNetQ.nuspec"
             XPath="/package/metadata/version"
-            Value="%(AsmInfo.Version)" />        
-        
+            Value="%(AsmInfo.Version)" />
+
         <Exec WorkingDirectory="$(Package)\EasyNetQ" Command="$(NuGet)\NuGet.exe pack $(Package)\EasyNetQ\EasyNetQ.nuspec" />
 
     </Target>
@@ -183,7 +176,7 @@
     <Exec WorkingDirectory="$(Package)\EasyNetQ.DI.Ninject" Command="$(NuGet)\NuGet.exe pack $(Package)\EasyNetQ.DI.Ninject\EasyNetQ.DI.Ninject.nuspec" />
 
   </Target>
-  
+
   <Target Name="PackageDiSimpleInjector" DependsOnTargets="Build">
 
     <ItemGroup>

--- a/Package/EasyNetQ/EasyNetQ.nuspec
+++ b/Package/EasyNetQ/EasyNetQ.nuspec
@@ -17,6 +17,7 @@
     <copyright>Copyright Mike Hadlow 2015</copyright>
     <tags>RabbitMQ Messaging AMQP</tags>
     <dependencies>
+      <dependency id="Newtonsoft.Json" version="[8.0.2,11.0.0)" />
       <dependency id="RabbitMQ.Client" version="[3.6.0,4.0.0)" />
     </dependencies>
   </metadata>

--- a/Source/EasyNetQ NET45/EasyNetQ NET45.csproj
+++ b/Source/EasyNetQ NET45/EasyNetQ NET45.csproj
@@ -41,8 +41,8 @@
     <NoWarn>1591,1734,1711</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RabbitMQ.Client, Version=3.6.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">

--- a/Source/EasyNetQ NET45/packages.config
+++ b/Source/EasyNetQ NET45/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="RabbitMQ.Client" version="3.6.0" targetFramework="net45" />
 </packages>

--- a/Source/EasyNetQ.Hosepipe.Tests/packages.config
+++ b/Source/EasyNetQ.Hosepipe.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EasyNetQ.Management.Client" version="0.47.17.64" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
   <package id="RabbitMQ.Client" version="3.6.0" targetFramework="net45" />
 </packages>

--- a/Source/EasyNetQ.Hosepipe/EasyNetQ.Hosepipe.csproj
+++ b/Source/EasyNetQ.Hosepipe/EasyNetQ.Hosepipe.csproj
@@ -39,8 +39,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RabbitMQ.Client, Version=3.6.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">

--- a/Source/EasyNetQ.Hosepipe/packages.config
+++ b/Source/EasyNetQ.Hosepipe/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EasyNetQ.Management.Client" version="0.47.17.64" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="RabbitMQ.Client" version="3.6.0" targetFramework="net45" />
 </packages>

--- a/Source/EasyNetQ.LogReader/EasyNetQ.LogReader.csproj
+++ b/Source/EasyNetQ.LogReader/EasyNetQ.LogReader.csproj
@@ -43,8 +43,8 @@
       <HintPath>..\packages\EasyNetQ.Management.Client.0.47.17.64\lib\net40\EasyNetQ.Management.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RabbitMQ.Client, Version=3.6.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">

--- a/Source/EasyNetQ.LogReader/packages.config
+++ b/Source/EasyNetQ.LogReader/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EasyNetQ.Management.Client" version="0.47.17.64" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="RabbitMQ.Client" version="3.6.0" targetFramework="net45" />
 </packages>

--- a/Source/EasyNetQ.Scheduler/EasyNetQ.Scheduler.csproj
+++ b/Source/EasyNetQ.Scheduler/EasyNetQ.Scheduler.csproj
@@ -50,8 +50,8 @@
       <HintPath>..\packages\log4net.2.0.0\lib\net40-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RabbitMQ.Client, Version=3.6.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">

--- a/Source/EasyNetQ.Scheduler/packages.config
+++ b/Source/EasyNetQ.Scheduler/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="EasyNetQ.Management.Client" version="0.47.17.64" targetFramework="net45" />
   <package id="log4net" version="2.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="RabbitMQ.Client" version="3.6.0" targetFramework="net45" />
   <package id="Topshelf" version="3.1.0" targetFramework="net45" />
 </packages>

--- a/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
+++ b/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
@@ -65,8 +65,8 @@
       <HintPath>..\packages\EasyNetQ.Management.Client.0.47.17.64\lib\net40\EasyNetQ.Management.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">

--- a/Source/EasyNetQ.Tests/packages.config
+++ b/Source/EasyNetQ.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EasyNetQ.Management.Client" version="0.47.17.64" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
   <package id="RabbitMQ.Client" version="3.6.0" targetFramework="net45" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net45" />

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -7,9 +7,10 @@ using System.Reflection;
 // MINOR version when you add functionality in a backwards-compatible manner, and
 // PATCH version when you make backwards-compatible bug fixes.
 
-[assembly: AssemblyVersion("1.0.4.0")]
+[assembly: AssemblyVersion("1.0.5.0")]
 [assembly: CLSCompliant(false)]
 
+// 1.0.5.0 Newtonsoft.Json added as an explicit NuGet dependency instead of embedding it to EasyNetQ.dll
 // 1.0.4.0 Included queue name in Error message
 // 1.0.3.0 Bug Fix, defer execution of serviceCreator parameter in SimpleInjectorAdapter.Register
 // 1.0.2.0 Added start consuming events for failure and success
@@ -28,17 +29,17 @@ using System.Reflection;
 // 0.60.1.0 Added SimpleInjector DI support
 // 0.60.0.0 Remove [Serializable] attribute from messages and exceptions
 // 0.59.0.0 Support of priority queues to IBus publish methods
-// 0.58.0.0 added IErrorMessageSerializer and 2 implementations (UTF8 and Base64) 
+// 0.58.0.0 added IErrorMessageSerializer and 2 implementations (UTF8 and Base64)
 // 0.57.2.0 Removed from the hosepipe library the useless dependency on easynetq management client
 // 0.57.1.0 Fix hosepipe usage description to describe the option `x`: the get (noack)
 // 0.57.0.0 RPC responses go through the dedicated RPC exchange (easy_net_q_rpc by default) instead of the default exchange
 // 0.56.0.0 Updated to StructreMap 4, Note: this is only a breaking change for users of 'EasyNetQ.DI.StructureMap'
 // 0.55.1.0 Marked Rpc.Respond overload as virtual
 // 0.55.0.0 Bug fix, DefaultConsumerErrorStrategy does not decode header values
-// 0.54.3.0 Allow usage of background threads  
-// 0.54.2.0 Fix bug with infinite dispose  
+// 0.54.3.0 Allow usage of background threads
+// 0.54.2.0 Fix bug with infinite dispose
 // 0.54.1.0 Added LightInject DI support
-// 0.54.0.0 Updated RabbitMQ client to 3.6.0 
+// 0.54.0.0 Updated RabbitMQ client to 3.6.0
 // 0.53.6.0 set CLSCompliant to false
 // 0.53.5.0 Added custom queue-name support to 'err' and 'retry' commands
 // 0.53.4.0 Update RabbitMQ.Client to 3.5.7
@@ -47,11 +48,11 @@ using System.Reflection;
 // 0.53.1.0 Removed separate test applications in favor of a single task runner
 // 0.53.0.0 fix expires default behavior of subscription configuration attribute
 // 0.52.0.0 Added synchronous callback on Consume(byte[]) methods of the advaced api
-// 0.51.0.0 Brand new sync/async implementation, a lot of changes in publish mechanisms. Should be used with care  
-// 0.50.12.0 Added Serilog nuget package 
-// 0.50.11.0 Updated Scheduler for MSSQL to support all properties of the ScheduleMe message 
-// 0.50.10.0 Updated RabbitMQ client to 3.5.6 
-// 0.50.9.0 Updated RabbitMQ client to 3.5.5 
+// 0.51.0.0 Brand new sync/async implementation, a lot of changes in publish mechanisms. Should be used with care
+// 0.50.12.0 Added Serilog nuget package
+// 0.50.11.0 Updated Scheduler for MSSQL to support all properties of the ScheduleMe message
+// 0.50.10.0 Updated RabbitMQ client to 3.5.6
+// 0.50.9.0 Updated RabbitMQ client to 3.5.5
 // 0.50.8.0 Allow SubscriptionConfigurationAttribute on class
 // 0.50.7.0 Fix typo in Extensions
 // 0.50.6.0 Allow specifying the maximum size of the message queue when it is being declared


### PR DESCRIPTION
There was a problem with deserializing F# list when using FSharp.Core >= 4.1.0 as it now implements IReadOnlyCollection. Newtonsoft.Json fixed this in version 10 but EasyNetQ has version 8.0.2 embedded inside.