### PR TITLE
Add useBackgroundThreads as connection string part

### DIFF
--- a/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
+++ b/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
@@ -14,8 +14,9 @@ namespace EasyNetQ.Tests.ConnectionString
         private ConnectionStringParser connectionStringParser;
 
         private const string connectionString =
-            "virtualHost=Copa;username=Copa;host=192.168.1.1;password=abc_xyz;port=12345;" + 
-            "requestedHeartbeat=3;prefetchcount=2;timeout=12;publisherConfirms=true;cancelOnHaFailover=true";
+            "virtualHost=Copa;username=Copa;host=192.168.1.1;password=abc_xyz;port=12345;" +
+            "requestedHeartbeat=3;prefetchcount=2;timeout=12;publisherConfirms=true;cancelOnHaFailover=true;" +
+            "useBackgroundThreads=true";
 
         [SetUp]
         public void SetUp()
@@ -38,6 +39,7 @@ namespace EasyNetQ.Tests.ConnectionString
             connectionConfiguration.Timeout.ShouldEqual(12);
             connectionConfiguration.PublisherConfirms.ShouldBeTrue();
             connectionConfiguration.CancelOnHaFailover.ShouldBeTrue();
+            connectionConfiguration.UseBackgroundThreads.ShouldBeTrue();
         }
 
         [Test]

--- a/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
+++ b/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
@@ -42,7 +42,8 @@ namespace EasyNetQ.ConnectionString
             BuildKeyValueParser("persistentMessages", Bool, c => c.PersistentMessages),
             BuildKeyValueParser("cancelOnHaFailover", Bool, c => c.CancelOnHaFailover),
             BuildKeyValueParser("product", Text, c => c.Product),
-            BuildKeyValueParser("platform", Text, c => c.Platform)
+            BuildKeyValueParser("platform", Text, c => c.Platform),
+            BuildKeyValueParser("useBackgroundThreads", Bool, c => c.UseBackgroundThreads)
         }.Aggregate((a, b) => a.Or(b));
 
         public static Parser<UpdateConfiguration> AMQPAlone =

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -7,9 +7,10 @@ using System.Reflection;
 // MINOR version when you add functionality in a backwards-compatible manner, and
 // PATCH version when you make backwards-compatible bug fixes.
 
-[assembly: AssemblyVersion("1.0.4.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
 [assembly: CLSCompliant(false)]
 
+// 1.1.0.0 Add useBackgroundThreads as connection string part
 // 1.0.4.0 Included queue name in Error message
 // 1.0.3.0 Bug Fix, defer execution of serviceCreator parameter in SimpleInjectorAdapter.Register
 // 1.0.2.0 Added start consuming events for failure and success


### PR DESCRIPTION
The property UseBackgroundThreads was added to ConnectionConfiguration in a previous commit, but was never added as a connection string part.  Not sure if this is a patch or minor update from a sematic versioning stand point.  I've updated the minor, but let me know if we should change.

Thanks,
Brett