### PR TITLE
RPC timer would end immediately if timeout was 0

### DIFF
--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -7,9 +7,10 @@ using System.Reflection;
 // MINOR version when you add functionality in a backwards-compatible manner, and
 // PATCH version when you make backwards-compatible bug fixes.
 
-[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyVersion("1.1.2.0")]
 [assembly: CLSCompliant(false)]
 
+// 1.1.2.0 Fix a bug where timer would end immediately if timeout=0 (= no timeout)
 // 1.1.1.0 Logging fix to correctly reflect the port and vhost that is connected to
 // 1.1.0.0 Add useBackgroundThreads as connection string part
 // 1.0.4.0 Included queue name in Error message


### PR DESCRIPTION
This fixes a bug where RPC would throw a timeout exception immediately, if timeout was set to 0 (= disabled).

Let me know if you want to merge this PR and if and what version I should bump...

Br