### PR TITLE
Fix for incorrect port and vhost in logs for amqp/amqps connection strings

### DIFF
--- a/Source/EasyNetQ.Tests/ConnectionConfigurationTests.cs
+++ b/Source/EasyNetQ.Tests/ConnectionConfigurationTests.cs
@@ -26,6 +26,42 @@ namespace EasyNetQ.Tests
         }
 
         [Test]
+        public void The_validate_method_should_apply_Default_AmqpsPort_Correctly()
+        {
+            ConnectionConfiguration connectionConfiguration = new ConnectionStringParser().Parse("amqps://user:pass@host/vhost");
+            connectionConfiguration.Validate(); 
+
+            connectionConfiguration.Port.ShouldEqual(5671);
+        }
+
+        [Test]
+        public void The_validate_method_should_apply_Default_AmqpPort_Correctly()
+        {
+            ConnectionConfiguration connectionConfiguration = new ConnectionStringParser().Parse("amqp://user:pass@host/vhost");
+            connectionConfiguration.Validate();
+
+            connectionConfiguration.Port.ShouldEqual(5672);
+        }
+
+        [Test]
+        public void The_validate_method_should_apply_NonDefault_VirtualHost_Correctly()
+        {
+            ConnectionConfiguration connectionConfiguration = new ConnectionStringParser().Parse("amqp://user:pass@host/vhost");
+            connectionConfiguration.Validate();
+
+            connectionConfiguration.VirtualHost.ShouldEqual("vhost");
+        }
+
+        [Test]
+        public void The_validate_method_should_apply_Default_VirtualHost_Correctly()
+        {
+            ConnectionConfiguration connectionConfiguration = new ConnectionStringParser().Parse("amqp://user:pass@host/");
+            connectionConfiguration.Validate();
+
+            connectionConfiguration.VirtualHost.ShouldEqual("/");
+        }
+
+        [Test]
         public void The_AuthMechanisms_property_should_default_to_PlainMechanism()
         {
             ConnectionConfiguration connectionConfiguration = new ConnectionConfiguration();

--- a/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
+++ b/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
@@ -96,7 +96,7 @@ namespace EasyNetQ.Tests.ConnectionString
             yield return new AmqpSpecification(new Uri("amqp://user:pass@host:10000/vhost"), "host", 10000);
             yield return new AmqpSpecification(new Uri("amqp://"), "", 5672);
             yield return new AmqpSpecification(new Uri("amqp://host"), "host", 5672);
-            yield return new AmqpSpecification(new Uri("amqps://host"), "host", 5672);
+            yield return new AmqpSpecification(new Uri("amqps://host"), "host", 5671);
         }
 
         [Test]

--- a/Source/EasyNetQ/ConnectionConfiguration.cs
+++ b/Source/EasyNetQ/ConnectionConfiguration.cs
@@ -10,6 +10,7 @@ namespace EasyNetQ
     public class ConnectionConfiguration
     {
         private const int DefaultPort = 5672;
+        private const int DefaultAmqpsPort = 5671;
         public ushort Port { get; set; }
         public string VirtualHost { get; set; }
         public string UserName { get; set; }
@@ -111,8 +112,17 @@ namespace EasyNetQ
         {
             if (AMQPConnectionString != null && !Hosts.Any(h => h.Host == AMQPConnectionString.Host))
             {
-                if(Port == DefaultPort && AMQPConnectionString.Port > 0) 
-                        Port = (ushort) AMQPConnectionString.Port;
+                if (Port == DefaultPort)
+                {
+                    if (AMQPConnectionString.Port > 0)
+                        Port = (ushort)AMQPConnectionString.Port;
+                    else if(AMQPConnectionString.Scheme.Equals("amqps", StringComparison.OrdinalIgnoreCase))
+                        Port = DefaultAmqpsPort;
+                }
+                if (AMQPConnectionString.Segments.Length > 1)
+                {
+                    VirtualHost = AMQPConnectionString.Segments.Last();
+                }
                 Hosts = Hosts.Concat(new[] {new HostConfiguration {Host = AMQPConnectionString.Host}});
             }
             if (!Hosts.Any())

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -7,9 +7,10 @@ using System.Reflection;
 // MINOR version when you add functionality in a backwards-compatible manner, and
 // PATCH version when you make backwards-compatible bug fixes.
 
-[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
 [assembly: CLSCompliant(false)]
 
+// 1.1.0.0 Logging fix to correctly reflect the port and vhost that is connected to
 // 1.1.0.0 Add useBackgroundThreads as connection string part
 // 1.0.4.0 Included queue name in Error message
 // 1.0.3.0 Bug Fix, defer execution of serviceCreator parameter in SimpleInjectorAdapter.Register

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 [assembly: AssemblyVersion("1.1.1.0")]
 [assembly: CLSCompliant(false)]
 
-// 1.1.0.0 Logging fix to correctly reflect the port and vhost that is connected to
+// 1.1.1.0 Logging fix to correctly reflect the port and vhost that is connected to
 // 1.1.0.0 Add useBackgroundThreads as connection string part
 // 1.0.4.0 Included queue name in Error message
 // 1.0.3.0 Bug Fix, defer execution of serviceCreator parameter in SimpleInjectorAdapter.Register


### PR DESCRIPTION
This is a fix for issue #697 