### PR TITLE
Connection error logging in PersistentConnection.cs not surfacing inner exception message

### DIFF
--- a/Source/EasyNetQ/PersistentConnection.cs
+++ b/Source/EasyNetQ/PersistentConnection.cs
@@ -138,7 +138,7 @@ namespace EasyNetQ
             // if there is an inner exception, surface its message since it has more detailed information on why connection failed
             if (exception.InnerException != null)
             {
-                exceptionMessage = exception.InnerException.Message;
+                exceptionMessage = $"{exceptionMessage} ({exception.InnerException.Message})";
             }
 
             logger.ErrorWrite("Failed to connect to Broker: '{0}', Port: {1} VHost: '{2}'. " +

--- a/Source/EasyNetQ/PersistentConnection.cs
+++ b/Source/EasyNetQ/PersistentConnection.cs
@@ -134,12 +134,19 @@ namespace EasyNetQ
 
         void LogException(Exception exception)
         {
+            var exceptionMessage = exception.Message;
+            // if there is an inner exception, surface its message since it has more detailed information on why connection failed
+            if (exception.InnerException != null)
+            {
+                exceptionMessage = exception.InnerException.Message;
+            }
+
             logger.ErrorWrite("Failed to connect to Broker: '{0}', Port: {1} VHost: '{2}'. " +
                     "ExceptionMessage: '{3}'",
                 connectionFactory.CurrentHost.Host,
                 connectionFactory.CurrentHost.Port,
                 connectionFactory.Configuration.VirtualHost,
-                exception.Message);
+                exceptionMessage);
         }
 
         void OnConnectionShutdown(object sender, ShutdownEventArgs e)

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -7,9 +7,10 @@ using System.Reflection;
 // MINOR version when you add functionality in a backwards-compatible manner, and
 // PATCH version when you make backwards-compatible bug fixes.
 
-[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyVersion("1.1.2.0")]
 [assembly: CLSCompliant(false)]
 
+// 1.1.2.0 Update logging in PersistentConnection.cs so both inner and outer exceptions are logged when connections fail
 // 1.1.1.0 Logging fix to correctly reflect the port and vhost that is connected to
 // 1.1.0.0 Add useBackgroundThreads as connection string part
 // 1.0.4.0 Included queue name in Error message


### PR DESCRIPTION
When PersistentConnection.cs logs connection failures, it only logs the outer exception message. The outer exception often obfuscates the actual connection error captured by the inner exception. For connection errors debugging we are finding the outer exception much less helpful than inner exception, and I think we should surface the inner exception message when an inner exception is present.