### PR TITLE
Revert to full .NET Framework MSBuild for Pack target

### DIFF
--- a/Build/EasyNetQ.proj
+++ b/Build/EasyNetQ.proj
@@ -1,6 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0" DefaultTargets="Default">
+<!-- GitVersionTask does not work using .NET CLI because it calls MSBuild
+    Core rather than the full .NET Framework MSBuild.
+    We need the GitVersionTask to properly version the assemblies, so we
+    use the full .NET Framework MSBuild when calling EasyNetQ.proj: Line 46.
 
+    Unfortunately, GitVersion_NuGetVersion is not propagated after exiting
+    that MSBuild task, so we have to use the full .NET Framework MSBuild
+    again with the .NET Core SDK to package a NuGet.
+
+    NOTE: This does not currently work with Visual Studio 2017 Build Tools
+    because it does not include the new NuGet targets, nor does it contain the
+    .NET Core SDK.
+
+    Related issues:
+        * https://github.com/GitTools/GitVersion/issues/1175
+        * https://github.com/Microsoft/msbuild/issues/1697
+    -->
     <PropertyGroup>
         <BaseDir>$(MSBuildProjectDirectory)\..</BaseDir>
         <OutputDir>$(BaseDir)\bin</OutputDir>
@@ -45,7 +61,6 @@
     <Target Name="Build" DependsOnTargets="Version; Restore">
         <MSBuild Projects="@(ProjectToBuild)" Targets="Rebuild"/>
     </Target>
-
     <!-- Test all projects against their targeted frameworks. Only tests that
         are not Integration or Explicit tests. -->
     <Target Name="Test" DependsOnTargets="Build">
@@ -77,6 +92,6 @@
 
         <MakeDir Directories="$(NuGetPackageDirectory)" Condition="!Exists('$(NuGetPackageDirectory)')" />
         <Delete Files="@(FilesToDelete)" />
-        <Exec Command='dotnet pack %(ClientLibraries.FullPath) --no-build --output $(NuGetPackageDirectory) --configuration $(Configuration)' />
+        <MSBuild Projects="@(ClientLibraries)" Targets="Pack" Properties="Configuration=$(Configuration);PackageOutputPath=$(NuGetPackageDirectory)" />
     </Target>
 </Project>

--- a/Source/build.props
+++ b/Source/build.props
@@ -2,7 +2,6 @@
 <Project>
     <!-- Properties common to all project builds -->
     <PropertyGroup>
-        <!--    <VersionPrefix>2.0.4-netcore1435</VersionPrefix>-->
         <Authors>Mike Hadlow;Michael Denny;Yury Pliner;Wiebe Tijsma;Contributors (see GitHub repo) </Authors>
         <PackageTags>Autofac;RabbitMQ;Messaging;AMQP;C#</PackageTags>
         <PackageProjectUrl>https://github.com/EasyNetQ/EasyNetQ</PackageProjectUrl>
@@ -16,16 +15,6 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    </PropertyGroup>
-
-    <!-- GitVersionTask does not work using .NET CLI because it calls MSBuild
-        Core rather than the full .NET Framework MSBuild.
-        We need the GitVersionTask to properly version the assemblies, so we use
-        the full .NET Framework MSBuild when calling EasyNetQ.proj: Line 46.
-        Issue: https://github.com/GitTools/GitVersion/issues/1175
-    -->
-    <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Core'">
-        <ExcludeRestorePackageImports>true</ExcludeRestorePackageImports>
     </PropertyGroup>
 
     <!-- This is for GitVersionTask because the version of JetBrains.Annotations


### PR DESCRIPTION
The issue is that using `dotnet pack` calls MSBuild Core, doesn't allow us to call GitVersionTask because it hasn't been ported to .NET Core.  As a result, the necessary GitVersion information is not propagated to the NuGet package.

This PR works around this by invoking the full .NET Framework MSBuild with the pack target.

Unfortunately, this will only work with a full installation of Visual Studio 2017.  It will not work on installations of Visual Studio 2017 Build Tools because the installer does not include:

* [.NET Core SDK](https://github.com/Microsoft/msbuild/issues/1697)
* [New NuGet targets (pack and restore)](https://github.com/NuGet/Home/issues/3660)