### PR TITLE
Proposed change of getting type of published messages

### DIFF
--- a/Source/EasyNetQ/RabbitBus.cs
+++ b/Source/EasyNetQ/RabbitBus.cs
@@ -48,7 +48,7 @@ namespace EasyNetQ
         {
             Preconditions.CheckNotNull(message, "message");
 
-            Publish(message, conventions.TopicNamingConvention(typeof(T)));
+            Publish(message, conventions.TopicNamingConvention(message.GetType()));
         }
 
         public virtual void Publish<T>(T message, string topic) where T : class
@@ -64,10 +64,10 @@ namespace EasyNetQ
             Preconditions.CheckNotNull(message, "message");
             Preconditions.CheckNotNull(configure, "configure");
 
-            var configuration = new PublishConfiguration(conventions.TopicNamingConvention(typeof(T)));
+            var messageType = message.GetType();
+            var configuration = new PublishConfiguration(conventions.TopicNamingConvention(messageType));
             configure(configuration);
 
-            var messageType = typeof(T);
             var easyNetQMessage = new Message<T>(message)
             {
                 Properties =
@@ -88,7 +88,7 @@ namespace EasyNetQ
         {
             Preconditions.CheckNotNull(message, "message");
 
-            return PublishAsync(message, conventions.TopicNamingConvention(typeof(T)));
+            return PublishAsync(message, conventions.TopicNamingConvention(message.GetType()));
         }
 
         public virtual Task PublishAsync<T>(T message, string topic) where T : class
@@ -104,10 +104,10 @@ namespace EasyNetQ
             Preconditions.CheckNotNull(message, "message");
             Preconditions.CheckNotNull(configure, "configure");
 
-            var configuration = new PublishConfiguration(conventions.TopicNamingConvention(typeof(T)));
+            var messageType = GetType();
+            var configuration = new PublishConfiguration(conventions.TopicNamingConvention(messageType));
             configure(configuration);
-
-            var messageType = typeof(T);
+            
             var easyNetQMessage = new Message<T>(message)
             {
                 Properties =


### PR DESCRIPTION
Hey,

I find it somewhat strange that in RabbitBus.Publish<T>(T message, ...) we get type of message with typeof(T), instead ot message.GetType().
This prevents us from using patterns like this:
`public IMessage GetMessage()
{
  if(...) return TestMessage1();
  else return TestMessage2();
}

var message = GetMessage();
bus.Publish(message);
`
This will always publish a IMessage and not a TestMessage1 or TestMessage2.

What do you think of this change?

If you want I can also change the pull request to create an interface + implementation like it is right now, which handles getting types of publish messages. So if one doesn't like this behaviour he can easily overwrite it without reimplemeting RabbitBus methods.