### PR TITLE
Added MaxLength and MaxLengthBytes options to fluent SubscriptionConfiguration

### DIFF
--- a/Source/EasyNetQ.Tests/FluentConfiguration/SubscriptionConfigurationTests.cs
+++ b/Source/EasyNetQ.Tests/FluentConfiguration/SubscriptionConfigurationTests.cs
@@ -1,0 +1,24 @@
+﻿using EasyNetQ.FluentConfiguration;
+using Xunit;
+
+namespace EasyNetQ.Tests.FluentConfiguration
+{
+    public class SubscriptionConfigurationTests
+    {
+        [Fact]
+        public void Defaults_are_correct()
+        {
+            var configuration = new SubscriptionConfiguration(99);
+            Assert.Equal(0, configuration.Topics.Count);
+            Assert.False(configuration.AutoDelete);
+            Assert.Equal(0, configuration.Priority);
+            Assert.False(configuration.CancelOnHaFailover);
+            Assert.Equal(99, configuration.PrefetchCount);
+            Assert.False(configuration.IsExclusive);
+            Assert.True(configuration.Durable);
+            Assert.Null(configuration.QueueName);
+            Assert.Null(configuration.MaxLength);
+            Assert.Null(configuration.MaxLengthBytes);
+        }
+    }
+}

--- a/Source/EasyNetQ/FluentConfiguration/ISubscriptionConfiguration.cs
+++ b/Source/EasyNetQ/FluentConfiguration/ISubscriptionConfiguration.cs
@@ -67,7 +67,7 @@ namespace EasyNetQ.FluentConfiguration
         /// Configures the consumer's to be exclusive
         /// </summary>
         /// <returns></returns>
-        ISubscriptionConfiguration AsExclusive();
+        ISubscriptionConfiguration AsExclusive(bool isExclusive = true);
 
         /// <summary>
         /// Configures the queue's maxPriority
@@ -81,6 +81,18 @@ namespace EasyNetQ.FluentConfiguration
         /// <param name="queueName"></param>
         /// <returns></returns>
         ISubscriptionConfiguration WithQueueName(string queueName);
+
+        /// <summary>
+        /// The maximum number of ready messages that may exist on the queue. 
+        /// Messages will be dropped or dead-lettered from the front of the queue to make room for new messages once the limit is reached.
+        /// </summary>
+        ISubscriptionConfiguration WithMaxLength(int maxLength);
+
+        /// <summary>
+        /// The maximum size of the queue in bytes.
+        /// Messages will be dropped or dead-lettered from the front of the queue to make room for new messages once the limit is reached
+        /// </summary>
+        ISubscriptionConfiguration WithMaxLengthBytes(int maxLengthBytes);
     }
 
     public class SubscriptionConfiguration : ISubscriptionConfiguration
@@ -96,6 +108,8 @@ namespace EasyNetQ.FluentConfiguration
         public byte? MaxPriority { get; private set; }
         public bool Durable { get; private set; }
         public string QueueName { get; private set; }
+        public int? MaxLength { get; private set; }
+        public int? MaxLengthBytes { get; private set; }
 
         public SubscriptionConfiguration(ushort defaultPrefetchCount)
         {
@@ -150,9 +164,9 @@ namespace EasyNetQ.FluentConfiguration
             return this;
         }
 
-        public ISubscriptionConfiguration AsExclusive()
+        public ISubscriptionConfiguration AsExclusive(bool isExclusive = true)
         {
-            IsExclusive = true;
+            IsExclusive = isExclusive;
             return this;
         }
 
@@ -165,6 +179,18 @@ namespace EasyNetQ.FluentConfiguration
         public ISubscriptionConfiguration WithQueueName(string queueName)
         {
             QueueName = queueName;
+            return this;
+        }
+
+        public ISubscriptionConfiguration WithMaxLength(int maxLength)
+        {
+            MaxLength = maxLength;
+            return this;
+        }
+
+        public ISubscriptionConfiguration WithMaxLengthBytes(int maxLengthBytes)
+        {
+            MaxLengthBytes = maxLengthBytes;
             return this;
         }
     }

--- a/Source/EasyNetQ/RabbitBus.cs
+++ b/Source/EasyNetQ/RabbitBus.cs
@@ -155,7 +155,14 @@ namespace EasyNetQ
             var queueName = configuration.QueueName ?? conventions.QueueNamingConvention(typeof(T), subscriptionId);
             var exchangeName = conventions.ExchangeNamingConvention(typeof(T));
 
-            var queue = advancedBus.QueueDeclare(queueName, autoDelete: configuration.AutoDelete, durable: configuration.Durable, expires: configuration.Expires, maxPriority: configuration.MaxPriority);
+            var queue = advancedBus.QueueDeclare(
+                queueName, 
+                autoDelete: configuration.AutoDelete, 
+                durable: configuration.Durable, 
+                expires: configuration.Expires, 
+                maxPriority: configuration.MaxPriority,
+                maxLength: configuration.MaxLength,
+                maxLengthBytes: configuration.MaxLengthBytes);
             var exchange = advancedBus.ExchangeDeclare(exchangeName, ExchangeType.Topic);
 
             foreach (var topic in configuration.Topics.DefaultIfEmpty("#"))

--- a/hall_of_fame.md
+++ b/hall_of_fame.md
@@ -65,3 +65,4 @@ No particular order. Don't forget to add your name with your pull request.
 * Brett Janer
 * Alina Popa
 * Connie Yau
+* Marcus Hellsten


### PR DESCRIPTION
When creating subscribers for very busy exchanges, it is helpful to be able to limit the maximum queue size as a number of messages or bytes, so that if the subscribers can't keep up for some reason, it doesn't further exacerbate the problem by running RabbitMQ out of resources, or creating an unmanageable backlog of messages.