### PR TITLE
Use specified connection name when creating new RabbitMQ connection

### DIFF
--- a/Source/EasyNetQ/IConnectionFactory.cs
+++ b/Source/EasyNetQ/IConnectionFactory.cs
@@ -71,7 +71,9 @@ namespace EasyNetQ
 
         public virtual IConnection CreateConnection()
         {
-            return clusterHostSelectionStrategy.Current().ConnectionFactory.CreateConnection();
+            object connectionNameValue = null;
+            Configuration?.ClientProperties.TryGetValue("connection_name", out connectionNameValue);
+            return clusterHostSelectionStrategy.Current().ConnectionFactory.CreateConnection(connectionNameValue as string);
         }
 
         public virtual HostConfiguration CurrentHost => clusterHostSelectionStrategy.Current().HostConfiguration;


### PR DESCRIPTION
Related to #694.