### PR TITLE
Added braces escaping for non-format format string

### DIFF
--- a/Source/EasyNetQ.Scheduler.Mongo.Core/SchedulerService.cs
+++ b/Source/EasyNetQ.Scheduler.Mongo.Core/SchedulerService.cs
@@ -68,7 +68,7 @@ namespace EasyNetQ.Scheduler.Mongo.Core
                     var exchangeName = schedule.Exchange ?? schedule.BindingKey;
                     var routingKey = schedule.RoutingKey ?? schedule.BindingKey;
                     var properties = schedule.BasicProperties ?? new MessageProperties {Type = schedule.BindingKey};
-                    log.DebugWrite(string.Format("Publishing Scheduled Message with to exchange '{0}'", exchangeName));
+                    log.DebugWrite("Publishing Scheduled Message with to exchange '{0}'", exchangeName);
                     var exchange = bus.Advanced.ExchangeDeclare(exchangeName, schedule.ExchangeType ?? ExchangeType.Topic);
                     bus.Advanced.Publish(
                         exchange,

--- a/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
+++ b/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
@@ -170,21 +170,19 @@ namespace EasyNetQ.Consumer
             catch (BrokerUnreachableException)
             {
                 // thrown if the broker is unreachable during initial creation.
-                logger.ErrorWrite("EasyNetQ Consumer Error Handler cannot connect to Broker\n" +
-                    CreateConnectionCheckMessage());
+                logger.ErrorWrite("EasyNetQ Consumer Error Handler cannot connect to Broker\n{0}", CreateConnectionCheckMessage());
             }
             catch (OperationInterruptedException interruptedException)
             {
                 // thrown if the broker connection is broken during declare or publish.
-                logger.ErrorWrite("EasyNetQ Consumer Error Handler: Broker connection was closed while attempting to publish Error message.\n" +
-                    string.Format("Exception was: '{0}'\n", interruptedException.Message) +
+                logger.ErrorWrite("EasyNetQ Consumer Error Handler: Broker connection was closed while attempting to publish Error message.\nException was: '{0}'\n{1}",
+                    interruptedException.Message,
                     CreateConnectionCheckMessage());
             }
             catch (Exception unexpectedException)
             {
                 // Something else unexpected has gone wrong :(
-                logger.ErrorWrite("EasyNetQ Consumer Error Handler: Failed to publish error message\nException is:\n"
-                    + unexpectedException);
+                logger.ErrorWrite("EasyNetQ Consumer Error Handler: Failed to publish error message\nException is:\n{0}", unexpectedException);
             }
             return AckStrategies.Ack;
         }

--- a/Source/EasyNetQ/Consumer/HandlerRunner.cs
+++ b/Source/EasyNetQ/Consumer/HandlerRunner.cs
@@ -70,7 +70,7 @@ namespace EasyNetQ.Consumer
             {
                 if (task.IsFaulted)
                 {
-                    logger.ErrorWrite(BuildErrorMessage(context, task.Exception));
+                    logger.ErrorWrite(BuildErrorMessage(context, task.Exception).EscapeBraces());
                     ackStrategy = consumerErrorStrategy.HandleConsumerError(context, task.Exception);
                 }
                 else if (task.IsCanceled)

--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -79,7 +79,7 @@ namespace EasyNetQ.Consumer
         {
             Cancel();
             logger.InfoWrite("BasicCancel(Consumer Cancel Notification from broker) event received. " +
-                             "Consumer tag: " + consumerTag);
+                             "Consumer tag: {0}", consumerTag);
         }
 
         public void HandleModelShutdown(object model, ShutdownEventArgs reason)

--- a/Source/EasyNetQ/Extensions.cs
+++ b/Source/EasyNetQ/Extensions.cs
@@ -33,6 +33,11 @@ namespace EasyNetQ
         {
             ((IDictionary<TKey, TValue>)source).Add(key, value);        
         }
+
+        public static string EscapeBraces(this string s)
+        {
+            return s?.Replace("{", "{{").Replace("}", "}}");
+        }
     }
 
 }

--- a/Source/EasyNetQ/Loggers/ConsoleLogger.cs
+++ b/Source/EasyNetQ/Loggers/ConsoleLogger.cs
@@ -18,34 +18,19 @@ namespace EasyNetQ.Loggers
         public void DebugWrite(string format, params object[] args)
         {
             if (!Debug) return;
-            SafeConsoleWrite("DEBUG: " + format, args);
+            Console.WriteLine("DEBUG: " + format, args);
         }
 
         public void InfoWrite(string format, params object[] args)
         {
             if (!Info) return;
-            SafeConsoleWrite("INFO: " + format, args);
+            Console.WriteLine("INFO: " + format, args);
         }
 
         public void ErrorWrite(string format, params object[] args)
         {
             if (!Error) return;
-            SafeConsoleWrite("ERROR: " + format, args);
-        }
-
-        public void SafeConsoleWrite(string format, params object[] args)
-        {
-            // even a zero length args paramter causes WriteLine to interpret 'format' as
-            // a format string. Rather than escape JSON, better to check the intention of 
-            // the caller.
-            if (args.Length == 0)
-            {
-                Console.WriteLine(format);
-            }
-            else
-            {
-                Console.WriteLine(format, args);
-            }
+            Console.WriteLine("ERROR: " + format, args);
         }
 
         public void ErrorWrite(Exception exception)


### PR DESCRIPTION
I wanted to add logging via log4net to my application.

I implemented `IEasyNetQLogger` interface according to [manual](https://github.com/EasyNetQ/EasyNetQ/wiki/Logging):
```csharp
public class EasyNetQLog4NetLogger : IEasyNetQLogger
{
    private readonly ILog log;

    public EasyNetQLog4NetLogger(string name)
    {
        log = LogManager.GetLogger(name);
    }

    public void DebugWrite(string format, params object[] args)
    {
        log.DebugFormat(format, args);
    }

    public void InfoWrite(string format, params object[] args)
    {
        log.InfoFormat(format, args);
    }

    public void ErrorWrite(string format, params object[] args)
    {
        log.ErrorFormat(format, args);
    }

    public void ErrorWrite(Exception exception)
    {
        log.Error(exception.Message, exception);
    }
}
```

And when my handler threw an exception, I got the following error message in log:
```
[2017-08-14 15:31:39,014] [ERROR] [EasyNetQLogger]: <log4net.Error>Exception during StringFormat: Input string was not in a correct format. <format>Exception thrown by subscription callback.
        Exchange:    'exchange'
        Routing Key: ''
        Redelivered: 'True'
Message:
<message json>
...
</format><args>{}</args></log4net.Error>
```

The problem is that there is a JSON in the message. It's known problem, see #228.
And the fix is trivial - we need to escape braces in format string ([microsoft docs](https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting#escaping-braces) ).

In this PR I:
1. Found all usages of `IEasyNetQLogger` interface and fixed format strings in them.
2. Escaped braces in `logger.ErrorWrite(BuildErrorMessage(context, task.Exception));`