### PR TITLE
Allow subclasses of DefaultConsumerErrorStrategy to call connect method

### DIFF
--- a/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
+++ b/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
@@ -58,7 +58,7 @@ namespace EasyNetQ.Consumer
             this.errorMessageSerializer = errorMessageSerializer;
         }
 
-        private void Connect()
+        protected void Connect()
         {
             if (connection == null || !connection.IsOpen)
             {


### PR DESCRIPTION
The bug fix in this method has made the Connect method pretty long. It would be nice to just inherit from this class and just be able to override HandleConsumerError(), and change some code in there. As the class is not sealed, and has a couple virtual methods, lets make Connect() protected!