### PR TITLE
Fix #516

### DIFF
--- a/Source/EasyNetQ/DefaultMessageSerializationStrategy.cs
+++ b/Source/EasyNetQ/DefaultMessageSerializationStrategy.cs
@@ -27,12 +27,6 @@ namespace EasyNetQ
             return new SerializedMessage(messageProperties, messageBody);
         }
 
-        public IMessage<T> DeserializeMessage<T>(MessageProperties properties, byte[] body) where T : class
-        {
-            var messageBody = serializer.BytesToMessage<T>(body);
-            return new Message<T>(messageBody, properties);
-        }
-
         public IMessage DeserializeMessage(MessageProperties properties, byte[] body)
         {
             var messageType = typeNameSerializer.DeSerialize(properties.Type);

--- a/Source/EasyNetQ/IMessageSerializationStrategy.cs
+++ b/Source/EasyNetQ/IMessageSerializationStrategy.cs
@@ -4,7 +4,6 @@ namespace EasyNetQ
     public interface IMessageSerializationStrategy
     {
         SerializedMessage SerializeMessage(IMessage message);
-        IMessage<T> DeserializeMessage<T>(MessageProperties properties, byte[] body) where T : class;
         IMessage DeserializeMessage(MessageProperties properties, byte[] body);
     }
 

--- a/Source/EasyNetQ/MessageVersioning/VersionedMessageSerializationStrategy.cs
+++ b/Source/EasyNetQ/MessageVersioning/VersionedMessageSerializationStrategy.cs
@@ -1,6 +1,6 @@
 
 namespace EasyNetQ.MessageVersioning
-{
+{ 
     public class VersionedMessageSerializationStrategy : IMessageSerializationStrategy
     {
         private readonly ITypeNameSerializer typeNameSerializer;
@@ -27,13 +27,6 @@ namespace EasyNetQ.MessageVersioning
             return new SerializedMessage(messageProperties, messageBody);
         }
 
-        public IMessage<T> DeserializeMessage<T>(MessageProperties properties, byte[] body) where T : class
-        {
-            var messageTypeProperty = MessageTypeProperty.ExtractFromProperties(properties, typeNameSerializer);
-            messageTypeProperty.AppendTo(properties);
-            var messageBody = serializer.BytesToMessage<T>(body);
-            return new Message<T>(messageBody, properties);
-        }
 
         public IMessage DeserializeMessage(MessageProperties properties, byte[] body)
         {


### PR DESCRIPTION
```
    public interface IMessageSerializationStrategy
    {
        SerializedMessage SerializeMessage(IMessage message);
        IMessage<T> DeserializeMessage<T>(MessageProperties properties, byte[] body) where T : class;
        IMessage DeserializeMessage(MessageProperties properties, byte[] body);
    }
```

` IMessage<T> DeserializeMessage<T>(MessageProperties properties, byte[] body) where T : class` should be removed, because during deserialization of polymorph data we should pass exactly type of the data, but not the root `<T>` type.

Also it seems we can remove `BytesToMessage<T>` from `ISerializer`.
