### PR TITLE
Allow to pass JsonSerializerSettings to JsonSerializer

### DIFF
--- a/Source/EasyNetQ/JsonSerializer.cs
+++ b/Source/EasyNetQ/JsonSerializer.cs
@@ -35,6 +35,7 @@ namespace EasyNetQ
 
         public object BytesToMessage(Type type, byte[] bytes)
         {
+            Preconditions.CheckNotNull(type, "type");
             Preconditions.CheckNotNull(bytes, "bytes");
             return JsonConvert.DeserializeObject(Encoding.UTF8.GetString(bytes), type, serializerSettings);
         }

--- a/Source/EasyNetQ/JsonSerializer.cs
+++ b/Source/EasyNetQ/JsonSerializer.cs
@@ -6,10 +6,20 @@ namespace EasyNetQ
 {
     public class JsonSerializer : ISerializer
     {
-        private readonly JsonSerializerSettings serializerSettings = new JsonSerializerSettings
+        private readonly JsonSerializerSettings serializerSettings;
+
+        public JsonSerializer()
         {
-            TypeNameHandling = TypeNameHandling.Auto
-        };
+            serializerSettings = new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.Auto
+            };
+        }
+
+        public JsonSerializer(JsonSerializerSettings serializerSettings)
+        {
+            this.serializerSettings = serializerSettings;
+        }
 
         public byte[] MessageToBytes<T>(T message) where T : class
         {


### PR DESCRIPTION
Because we don't merge Newtonsoft.Json anymore, we can create constructor which accepts JsonSerializationSettings.