### PR TITLE
Add hotfix for AutoSubscriber configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 _ReSharper.*
 *.orig
 *.dll
+.vscode
 
 # Ignore NCrunch cache files.
 *.crunchproject.local.xml

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 _ReSharper.*
 *.orig
 *.dll
-.vscode
+.vscode 
 
 # Ignore NCrunch cache files.
 *.crunchproject.local.xml

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using EasyNetQ.AutoSubscribe;
+using EasyNetQ.Tests.Mocking;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace EasyNetQ.Tests.AutoSubscriberTests
+{
+    public class When_autosubscribing_async : IDisposable
+    {
+        readonly MockBuilder mockBuilder;
+
+        const string expectedQueueName1 =
+            "EasyNetQ.Tests.AutoSubscriberTests.When_autosubscribing_async+MessageA, EasyNetQ.Tests_my_app:9a0467719db423b16b7e5c35d25b877c";
+
+        const string expectedQueueName2 =
+            "EasyNetQ.Tests.AutoSubscriberTests.When_autosubscribing_async+MessageB, EasyNetQ.Tests_MyExplicitId";
+
+        const string expectedQueueName3 =
+            "EasyNetQ.Tests.AutoSubscriberTests.When_autosubscribing_async+MessageC, EasyNetQ.Tests_my_app:63691066ce7a3fb38d685ce30873d12e";
+
+        public When_autosubscribing_async()
+        {
+            //mockBuilder = new MockBuilder();
+            mockBuilder = new MockBuilder();
+
+            var autoSubscriber = new AutoSubscriber(bus: mockBuilder.Bus, subscriptionIdPrefix: "my_app");
+            autoSubscriber.SubscribeAsync(typeof(MyAsyncConsumer));
+        }
+
+        public void Dispose()
+        {
+            mockBuilder.Bus.Dispose();
+        }
+
+        [Fact]
+        public void Should_have_declared_the_queues()
+        {
+            void VerifyQueueDeclared(string queueName) => 
+                mockBuilder.Channels[0].Received().QueueDeclare(
+                    queue: Arg.Is(value: queueName), 
+                    durable: Arg.Is(true), 
+                    exclusive: Arg.Is(false), 
+                    autoDelete: Arg.Is(false), 
+                    arguments: Arg.Any<IDictionary<string, object>>()
+                );
+
+            VerifyQueueDeclared(queueName: expectedQueueName1);
+            VerifyQueueDeclared(queueName: expectedQueueName2);
+            VerifyQueueDeclared(queueName: expectedQueueName3);
+        }
+
+        [Fact]
+        public void Should_have_bound_to_queues()
+        {
+            // ReSharper disable once CollectionNeverUpdated.Local
+            var parameters = new Dictionary<string, object>(){ };
+
+            void ConsumerStarted(int channelIndex, string queueName, string topicName) => 
+                mockBuilder.Channels[0].Received().QueueBind(
+                    queue: Arg.Is(value: queueName), 
+                    exchange: Arg.Any<string>(), 
+                    routingKey: Arg.Is(value: topicName), 
+                    arguments: Arg.Is<IDictionary<string, object>>(x => x.SequenceEqual(parameters))
+                );
+
+            ConsumerStarted(channelIndex: 1, queueName: expectedQueueName1, topicName: "#");
+            ConsumerStarted(channelIndex: 2, queueName: expectedQueueName2, topicName: "#");
+            ConsumerStarted(channelIndex: 3, queueName: expectedQueueName3, topicName: "Important");
+        }
+
+        [Fact]
+        public void Should_have_started_consuming_from_the_correct_queues()
+        {
+            mockBuilder.ConsumerQueueNames.Contains(expectedQueueName1).Should().BeTrue();
+            mockBuilder.ConsumerQueueNames.Contains(expectedQueueName2).Should().BeTrue();
+            mockBuilder.ConsumerQueueNames.Contains(expectedQueueName3).Should().BeTrue();
+        }
+
+        //Discovered by reflection over test assembly, do not remove.
+        class MyAsyncConsumer : IConsumeAsync<MessageA>, IConsumeAsync<MessageB>, IConsumeAsync<MessageC>
+        {
+            public Task ConsumeAsync(MessageA message)
+            {
+                throw new NotImplementedException();
+            }
+
+            [AutoSubscriberConsumer(SubscriptionId = "MyExplicitId")]
+            public Task ConsumeAsync(MessageB message)
+            {
+                throw new NotImplementedException();
+            }
+
+            [ForTopic("Important")]
+            public Task ConsumeAsync(MessageC message)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        class MessageA
+        {
+            public string Text { get; set; }
+        }
+
+        class MessageB
+        {
+            public string Text { get; set; }
+        }
+
+        class MessageC
+        {
+            public string Text { get; set; }
+        }
+
+    }
+}

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async_with_subscription_configuration.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async_with_subscription_configuration.cs
@@ -1,0 +1,157 @@
+﻿// ReSharper disable InconsistentNaming
+using System;
+using EasyNetQ.AutoSubscribe;
+using EasyNetQ.FluentConfiguration;
+using Xunit;
+using NSubstitute;
+using System.Reflection;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+namespace EasyNetQ.Tests.AutoSubscriberTests
+{
+    public class When_autosubscribing_async_with_subscription_configuration_attribute : IDisposable
+    {
+        private readonly IBus bus;
+        private Action<ISubscriptionConfiguration> capturedAction;
+       
+        public When_autosubscribing_async_with_subscription_configuration_attribute()
+        {
+            bus = Substitute.For<IBus>();
+            
+            var autoSubscriber = new AutoSubscriber(bus, "my_app");
+
+            bus.When(x => x.SubscribeAsync(
+                    Arg.Is("MyAttrTest"),
+                    Arg.Any<Func<MessageA, Task>>(),
+                    Arg.Any<Action<ISubscriptionConfiguration>>()
+                    ))
+                    .Do(a =>
+                    {
+                        capturedAction = (Action<ISubscriptionConfiguration>)a.Args()[2];
+                    });
+
+            autoSubscriber.SubscribeAsync(GetType().GetTypeInfo().Assembly);
+
+        }
+
+        public void Dispose()
+        {
+            bus.Dispose();
+        }
+
+        [Fact]
+        public void Should_have_called_subscribe()
+        {
+            bus.Received().SubscribeAsync(
+                        Arg.Any<string>(),
+                        Arg.Any<Func<MessageA, Task>>(),
+                        Arg.Any<Action<ISubscriptionConfiguration>>()
+                        );
+        }
+
+        [Fact]
+        public void Should_have_called_subscribe_with_action_capable_of_configuring_subscription()
+        {
+            var subscriptionConfiguration = new SubscriptionConfiguration(1);
+
+            capturedAction.Should().NotBeNull("SubscribeAsync should have been invoked");
+            capturedAction(subscriptionConfiguration);
+
+            subscriptionConfiguration.AutoDelete.Should().BeTrue();
+            subscriptionConfiguration.Expires.Should().Be(10);
+            subscriptionConfiguration.PrefetchCount.Should().Be((ushort)10);
+            subscriptionConfiguration.Priority.Should().Be(10);
+        }
+
+        // Discovered by reflection over test assembly, do not remove.
+        private class MyConsumerWithAttr : IConsumeAsync<MessageA>
+        {
+            [AutoSubscriberConsumer(SubscriptionId = "MyAttrTest")]
+            [SubscriptionConfiguration(AutoDelete = true, Expires = 10, PrefetchCount = 10, Priority = 10)]
+            public Task ConsumeAsync(MessageA message)
+            {
+                return Task.FromResult(0);
+            }
+        }
+
+        private class MessageA
+        {
+            public string Text { get; set; }
+        }
+    }
+    
+    
+    public class When_autosubscribing_async_explicit_implementation_with_subscription_configuration_attribute : IDisposable
+    {
+        private readonly IBus bus;
+        private Action<ISubscriptionConfiguration> capturedAction;
+       
+        public When_autosubscribing_async_explicit_implementation_with_subscription_configuration_attribute()
+        {
+            bus = Substitute.For<IBus>();
+            
+            var autoSubscriber = new AutoSubscriber(bus, "my_app");
+
+            bus.When(x => x.SubscribeAsync(
+                    Arg.Is("MyAttrTest"),
+                    Arg.Any<Func<MessageA, Task>>(),
+                    Arg.Any<Action<ISubscriptionConfiguration>>()
+                    ))
+                    .Do(a =>
+                    {
+                        capturedAction = (Action<ISubscriptionConfiguration>)a.Args()[2];
+                    });
+
+            autoSubscriber.SubscribeAsync(GetType().GetTypeInfo().Assembly);
+
+        }
+
+        public void Dispose()
+        {
+            bus.Dispose();
+        }
+
+        [Fact]
+        public void Should_have_called_subscribe()
+        {
+            bus.Received().SubscribeAsync(
+                        Arg.Any<string>(),
+                        Arg.Any<Func<MessageA, Task>>(),
+                        Arg.Any<Action<ISubscriptionConfiguration>>()
+                        );
+        }
+
+        [Fact]
+        public void Should_have_called_subscribe_with_action_capable_of_configuring_subscription()
+        {
+            var subscriptionConfiguration = new SubscriptionConfiguration(1);
+
+            capturedAction.Should().NotBeNull("SubscribeAsync should have been invoked");
+            capturedAction(subscriptionConfiguration);
+
+            subscriptionConfiguration.AutoDelete.Should().BeTrue();
+            subscriptionConfiguration.Expires.Should().Be(10);
+            subscriptionConfiguration.PrefetchCount.Should().Be(10);
+            subscriptionConfiguration.Priority.Should().Be(10);
+        }
+
+        // Discovered by reflection over test assembly, do not remove.
+        private class MyConsumerWithAttr : IConsumeAsync<MessageA>
+        {
+            [AutoSubscriberConsumer(SubscriptionId = "MyAttrTest")]
+            [SubscriptionConfiguration(AutoDelete = true, Expires = 10, PrefetchCount = 10, Priority = 10)]
+            Task IConsumeAsync<MessageA>.ConsumeAsync(MessageA message)
+            {
+                return Task.FromResult(0);
+            }
+        }
+
+        private class MessageA
+        {
+            public string Text { get; set; }
+        }
+    }
+}
+
+// ReSharper restore InconsistentNaming

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async_with_subscription_configuration_action.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async_with_subscription_configuration_action.cs
@@ -1,0 +1,93 @@
+﻿// ReSharper disable InconsistentNaming
+using System;
+using EasyNetQ.AutoSubscribe;
+using EasyNetQ.FluentConfiguration;
+using Xunit;
+using NSubstitute;
+using System.Reflection;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+namespace EasyNetQ.Tests.AutoSubscriberTests
+{
+    public class When_autosubscribing_async_with_subscription_configuration_action : IDisposable
+    {
+        private IBus bus;
+        private Action<ISubscriptionConfiguration> capturedAction;
+       
+        public When_autosubscribing_async_with_subscription_configuration_action()
+        {
+            bus = Substitute.For<IBus>();
+           
+
+            var autoSubscriber = new AutoSubscriber(bus, "my_app")
+                {
+                        ConfigureSubscriptionConfiguration =
+                                c => c.WithAutoDelete()
+                                    .WithExpires(10)
+                                    .WithPrefetchCount(10)
+                                    .WithPriority(10)
+                };
+
+            bus.When(x => x.SubscribeAsync(
+                    Arg.Is("MyActionTest"),
+                    Arg.Any<Func<MessageA, Task>>(),
+                    Arg.Any<Action<ISubscriptionConfiguration>>()
+                    ))
+                    .Do(a =>
+                    {
+                        capturedAction = (Action<ISubscriptionConfiguration>)a.Args()[2];
+                    });
+
+            autoSubscriber.SubscribeAsync(GetType().GetTypeInfo().Assembly);
+
+
+        }
+
+        public void Dispose()
+        {
+            bus.Dispose();
+        }
+
+        [Fact]
+        public void Should_have_called_subscribe_async()
+        {
+            bus.Received().SubscribeAsync(Arg.Any<string>(),
+                                     Arg.Any<Func<MessageA, Task>>(),
+                                     Arg.Any<Action<ISubscriptionConfiguration>>());
+        }
+
+        [Fact]
+        public void Should_have_called_subscribe_with_action_capable_of_configuring_subscription()
+        {
+            var subscriptionConfiguration = new SubscriptionConfiguration(1);
+
+            capturedAction.Should().NotBeNull("SubscribeAsync should have been invoked");
+                
+            capturedAction(subscriptionConfiguration);
+
+            subscriptionConfiguration.AutoDelete.Should().BeTrue();
+            subscriptionConfiguration.Expires.Should().Be(10);
+            subscriptionConfiguration.PrefetchCount.Should().Be(10);
+            subscriptionConfiguration.Priority.Should().Be(10);
+        }
+
+        // Discovered by reflection over test assembly, do not remove.
+        // ReSharper disable once UnusedMember.Local
+        class MyConsumerWithAction : IConsumeAsync<MessageA>
+        {
+            [AutoSubscriberConsumer(SubscriptionId = "MyActionTest")]
+            public Task ConsumeAsync(MessageA message)
+            {
+                return Task.FromResult(0);
+            }
+        }
+
+        class MessageA
+        {
+            public string Text { get; set; }
+        }
+    }
+}
+
+// ReSharper restore InconsistentNaming

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async_with_subscription_configuration_action_and_attribute.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async_with_subscription_configuration_action_and_attribute.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using EasyNetQ.AutoSubscribe;
+using EasyNetQ.FluentConfiguration;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace EasyNetQ.Tests.AutoSubscriberTests
+{
+    public class When_autosubscribing_async_with_subscription_configuration_action_and_attribute : IDisposable
+    {
+        readonly IBus bus;
+        Action<ISubscriptionConfiguration> capturedAction;
+       
+        public When_autosubscribing_async_with_subscription_configuration_action_and_attribute()
+        {
+            bus = Substitute.For<IBus>();
+           
+            var autoSubscriber = new AutoSubscriber(bus, "my_app")
+            {
+                ConfigureSubscriptionConfiguration =
+                    c => c.WithAutoDelete(false)
+                        .WithExpires(11)
+                        .WithPrefetchCount(11)
+                        .WithPriority(11)
+            };
+
+            bus.When(x => x.SubscribeAsync(
+                    Arg.Is("MyActionAndAttributeTest"),
+                    Arg.Any<Func<MessageA, Task>>(),
+                    Arg.Any<Action<ISubscriptionConfiguration>>()
+                ))
+                .Do(a =>
+                {
+                    capturedAction = (Action<ISubscriptionConfiguration>)a.Args()[2];
+                });
+
+            autoSubscriber.SubscribeAsync(GetType().GetTypeInfo().Assembly);
+
+        }
+
+        public void Dispose()
+        {
+            bus.Dispose();
+        }
+
+        [Fact]
+        public void Should_have_called_subscribe_async()
+        {
+            bus.Received().SubscribeAsync(Arg.Any<string>(),
+                Arg.Any<Func<MessageA, Task>>(),
+                Arg.Any<Action<ISubscriptionConfiguration>>());
+        }
+
+        [Fact]
+        public void Should_have_called_subscribe_async_with_attribute_values_notaction_values()
+        {
+            var subscriptionConfiguration = new SubscriptionConfiguration(1);
+
+            capturedAction.Should().NotBeNull("SubscribeAsync should have been invoked");
+            
+            capturedAction(subscriptionConfiguration);
+
+            subscriptionConfiguration.AutoDelete.Should().BeTrue();
+            subscriptionConfiguration.Expires.Should().Be(10);
+            subscriptionConfiguration.PrefetchCount.Should().Be(10);
+            subscriptionConfiguration.Priority.Should().Be(10);
+        }
+
+        // Discovered by reflection over test assembly, do not remove.
+        // ReSharper disable once UnusedMember.Local
+        class MyConsumerWithActionAndAttribute : IConsumeAsync<MessageA>
+        {
+            [AutoSubscriberConsumer(SubscriptionId = "MyActionAndAttributeTest")]
+            [SubscriptionConfiguration(AutoDelete = true, Expires = 10, PrefetchCount = 10, Priority = 10)]
+            public Task ConsumeAsync(MessageA message)
+            {
+                return Task.FromResult(0);
+            }
+        }
+
+        class MessageA
+        {
+            public string Text { get; set; }
+        }
+    }
+}

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_explicit_implementation.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_explicit_implementation.cs
@@ -11,21 +11,21 @@ using FluentAssertions;
 
 namespace EasyNetQ.Tests.AutoSubscriberTests
 {
-    public class When_autosubscribing : IDisposable
+    public class When_autosubscribing_with_explicit_implementation : IDisposable
     {
         private MockBuilder mockBuilder;
         private Dictionary<string, object> parameters;
 
         private const string expectedQueueName1 =
-            "EasyNetQ.Tests.AutoSubscriberTests.When_autosubscribing+MessageA, EasyNetQ.Tests_my_app:d7617d39b90b6b695b90c630539a12e2";
+            "EasyNetQ.Tests.AutoSubscriberTests.When_autosubscribing_with_explicit_implementation+MessageA, EasyNetQ.Tests_my_app:fe528c6fdb14f1b5a2216b78ab508ca9";
 
         private const string expectedQueueName2 =
-            "EasyNetQ.Tests.AutoSubscriberTests.When_autosubscribing+MessageB, EasyNetQ.Tests_MyExplicitId";
+            "EasyNetQ.Tests.AutoSubscriberTests.When_autosubscribing_with_explicit_implementation+MessageB, EasyNetQ.Tests_MyExplicitId";
 
         private const string expectedQueueName3 =
-            "EasyNetQ.Tests.AutoSubscriberTests.When_autosubscribing+MessageC, EasyNetQ.Tests_my_app:8b7980aa5e42959b4202e32ee442fc52";
+            "EasyNetQ.Tests.AutoSubscriberTests.When_autosubscribing_with_explicit_implementation+MessageC, EasyNetQ.Tests_my_app:34db9400fe90bb9dc2cf2743a21dadbf";
 
-        public When_autosubscribing()
+        public When_autosubscribing_with_explicit_implementation()
         {
             //mockBuilder = new MockBuilder();
             mockBuilder = new MockBuilder();
@@ -84,17 +84,17 @@ namespace EasyNetQ.Tests.AutoSubscriberTests
         // Discovered by reflection over test assembly, do not remove.
         private class MyConsumer : IConsume<MessageA>, IConsume<MessageB>, IConsume<MessageC>
         {
-            public void Consume(MessageA message)
+            void IConsume<MessageA>.Consume(MessageA message)
             {
             }
 
             [AutoSubscriberConsumer(SubscriptionId = "MyExplicitId")]
-            public void Consume(MessageB message)
+            void IConsume<MessageB>.Consume(MessageB message)
             {
             }
 
             [ForTopic("Important")]
-            public void Consume(MessageC message)
+            void IConsume<MessageC>.Consume(MessageC message)
             {
             }
           

--- a/Source/EasyNetQ.sln.DotSettings
+++ b/Source/EasyNetQ.sln.DotSettings
@@ -1,4 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_PRIVATE_MODIFIER/@EntryValue">Explicit</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypesAndNamespaces/@EntryIndexedValue">&lt;Policy Inspect="False" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=0A288D8B266E054893824362572CD01C/@KeyIndexDefined">True</s:Boolean>
 	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=0A288D8B266E054893824362572CD01C/Comment/@EntryValue">replace expectedexception</s:String>
 	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=0A288D8B266E054893824362572CD01C/CustomPatternPlaceholder/=Test/@KeyIndexDefined">True</s:Boolean>

--- a/Source/EasyNetQ/AutoSubscribe/AutoSubscriber.cs
+++ b/Source/EasyNetQ/AutoSubscribe/AutoSubscriber.cs
@@ -15,9 +15,12 @@ namespace EasyNetQ.AutoSubscribe
     /// </summary>
     public class AutoSubscriber
     {
-        protected const string ConsumeMethodName = "Consume";
-        protected const string DispatchMethodName = "Dispatch";
-        protected const string DispatchAsyncMethodName = "DispatchAsync";
+        protected const string ConsumeMethodName = nameof(IConsume<object>.Consume);
+        protected const string ConsumeAsyncMethodName = nameof(IConsumeAsync<object>.ConsumeAsync);
+        protected const string DispatchMethodName = nameof(IAutoSubscriberMessageDispatcher.Dispatch);
+        protected const string DispatchAsyncMethodName = nameof(IAutoSubscriberMessageDispatcher.DispatchAsync);
+        protected const string SubscribeMethodName = nameof(IBus.Subscribe);
+        protected const string SubscribeAsyncMethodName =  nameof(IBus.SubscribeAsync);
         protected readonly IBus bus;
 
         /// <summary>
@@ -98,9 +101,9 @@ namespace EasyNetQ.AutoSubscribe
         /// <param name="consumerTypes">the types to register as consumers.</param>
         public virtual void Subscribe(params Type[] consumerTypes)
         {
-            if (consumerTypes == null) throw new ArgumentNullException("consumerTypes");
+            if (consumerTypes == null) throw new ArgumentNullException(nameof(consumerTypes));
 
-            var genericBusSubscribeMethod = GetSubscribeMethodOfBus("Subscribe",typeof(Action<>));
+            var genericBusSubscribeMethod = GetSubscribeMethodOfBus(SubscribeMethodName,typeof(Action<>));
             var subscriptionInfos = GetSubscriptionInfos(consumerTypes, typeof(IConsume<>));
 
             InvokeMethods(subscriptionInfos,DispatchMethodName, genericBusSubscribeMethod, messageType => typeof(Action<>).MakeGenericType(messageType));
@@ -115,7 +118,7 @@ namespace EasyNetQ.AutoSubscribe
         /// <param name="assemblies">The assemblies to scan for consumers.</param>
         public virtual void SubscribeAsync(params Assembly[] assemblies)
         {
-            Preconditions.CheckAny(assemblies, "assemblies", "No assemblies specified.");
+            Preconditions.CheckAny(assemblies, nameof(assemblies), "No assemblies specified.");
 
             SubscribeAsync(assemblies.SelectMany(a => a.GetTypes()).ToArray());
         }
@@ -129,10 +132,10 @@ namespace EasyNetQ.AutoSubscribe
         /// <param name="consumerTypes">the types to register as consumers.</param>
         public virtual void SubscribeAsync(params Type[] consumerTypes)
         {
-            var genericBusSubscribeMethod = GetSubscribeMethodOfBus("SubscribeAsync", typeof(Func<,>));
+            var genericBusSubscribeMethod = GetSubscribeMethodOfBus(SubscribeAsyncMethodName, typeof(Func<,>));
             var subscriptionInfos = GetSubscriptionInfos(consumerTypes, typeof(IConsumeAsync<>));
-            Func<Type,Type> subscriberTypeFromMessageTypeDelegate = messageType => typeof (Func<,>).MakeGenericType(messageType, typeof (Task));
-            InvokeMethods(subscriptionInfos, DispatchAsyncMethodName, genericBusSubscribeMethod, subscriberTypeFromMessageTypeDelegate);
+            Type SubscriberDelegate(Type messageType) => typeof(Func<,>).MakeGenericType(messageType, typeof(Task));
+            InvokeMethods(subscriptionInfos, DispatchAsyncMethodName, genericBusSubscribeMethod, SubscriberDelegate);
         }
 
         protected virtual void InvokeMethods(IEnumerable<KeyValuePair<Type, AutoSubscriberConsumerInfo[]>> subscriptionInfos, string dispatchName, MethodInfo genericBusSubscribeMethod, Func<Type, Type> subscriberTypeFromMessageTypeDelegate)
@@ -174,17 +177,17 @@ namespace EasyNetQ.AutoSubscribe
 
         }
 
-        private Action<ISubscriptionConfiguration> TopicInfo(AutoSubscriberConsumerInfo subscriptionInfo)
+        private static Action<ISubscriptionConfiguration> TopicInfo(AutoSubscriberConsumerInfo subscriptionInfo)
         {
             var topics = GetTopAttributeValues(subscriptionInfo);
-            if (topics.Count() != 0)
+            if (topics.Length != 0)
             {
                 return GenerateConfigurationFromTopics(topics);
             }
             return configuration => configuration.WithTopic("#");
         }
 
-        private Action<ISubscriptionConfiguration> GenerateConfigurationFromTopics(IEnumerable<string> topics)
+        private static Action<ISubscriptionConfiguration> GenerateConfigurationFromTopics(string[] topics)
         {
             return configuration =>
                 {
@@ -195,16 +198,16 @@ namespace EasyNetQ.AutoSubscribe
                 };
         }
 
-        private IEnumerable<string> GetTopAttributeValues(AutoSubscriberConsumerInfo subscriptionInfo)
+        private static string[] GetTopAttributeValues(AutoSubscriberConsumerInfo subscriptionInfo)
         {
-            var consumeMethod = ConsumeMethod(subscriptionInfo);
-            object[] customAttributes = consumeMethod.GetCustomAttributes(typeof(ForTopicAttribute), true).Cast<object>().ToArray();
-            return customAttributes
+            var consumeMethod = subscriptionInfo.ConsumeMethod;
+            return consumeMethod.GetCustomAttributes(typeof(ForTopicAttribute), true)
                              .OfType<ForTopicAttribute>()
-                             .Select(a => a.Topic);
+                             .Select(a => a.Topic)
+                             .ToArray();
         }
 
-        private Action<ISubscriptionConfiguration> AutoSubscriberConsumerInfo(AutoSubscriberConsumerInfo subscriptionInfo)
+        private static Action<ISubscriptionConfiguration> AutoSubscriberConsumerInfo(AutoSubscriberConsumerInfo subscriptionInfo)
         {
             var configSettings = GetSubscriptionConfigurationAttributeValue(subscriptionInfo);
             if(configSettings == null)
@@ -227,18 +230,12 @@ namespace EasyNetQ.AutoSubscribe
                 };
         }
 
-        private SubscriptionConfigurationAttribute GetSubscriptionConfigurationAttributeValue(AutoSubscriberConsumerInfo subscriptionInfo)
+        private static SubscriptionConfigurationAttribute GetSubscriptionConfigurationAttributeValue(AutoSubscriberConsumerInfo subscriptionInfo)
         {
-            var consumeMethod = ConsumeMethod(subscriptionInfo);
-            object[] customAttributes = consumeMethod.GetCustomAttributes(typeof(SubscriptionConfigurationAttribute), true).Cast<object>().ToArray();
+            object[] customAttributes = subscriptionInfo.ConsumeMethod.GetCustomAttributes(typeof(SubscriptionConfigurationAttribute), true);
             return customAttributes
                              .OfType<SubscriptionConfigurationAttribute>()
                              .FirstOrDefault();
-        }
-
-        protected virtual bool IsValidMarkerType(Type markerType)
-        {
-            return markerType.GetTypeInfo().IsInterface && markerType.GetMethods().Any(m => m.Name == ConsumeMethodName);
         }
 
         protected virtual MethodInfo GetSubscribeMethodOfBus(string methodName, Type parmType)
@@ -255,21 +252,9 @@ namespace EasyNetQ.AutoSubscribe
 
         protected virtual AutoSubscriberConsumerAttribute GetSubscriptionAttribute(AutoSubscriberConsumerInfo consumerInfo)
         {
-            var consumeMethod = ConsumeMethod(consumerInfo);
-
-            return consumeMethod.GetCustomAttributes(typeof(AutoSubscriberConsumerAttribute), true).SingleOrDefault() as AutoSubscriberConsumerAttribute;
-        }
-
-        private MethodInfo ConsumeMethod(AutoSubscriberConsumerInfo consumerInfo)
-        {
-            return consumerInfo.ConcreteType.GetMethod(ConsumeMethodName, new[] { consumerInfo.MessageType }) ??
-                   GetExplicitlyDeclaredInterfaceMethod(consumerInfo.MessageType);
-        }
-
-        private MethodInfo GetExplicitlyDeclaredInterfaceMethod(Type messageType)
-        {
-            var interfaceType = typeof (IConsume<>).MakeGenericType(messageType);
-            return interfaceType.GetMethod(ConsumeMethodName);
+            return consumerInfo.ConsumeMethod
+                .GetCustomAttributes(typeof(AutoSubscriberConsumerAttribute), true)
+                .SingleOrDefault() as AutoSubscriberConsumerAttribute;
         }
 
         protected virtual IEnumerable<KeyValuePair<Type, AutoSubscriberConsumerInfo[]>> GetSubscriptionInfos(IEnumerable<Type> types,Type interfaceType)

--- a/Source/EasyNetQ/AutoSubscribe/AutoSubscriberConsumerInfo.cs
+++ b/Source/EasyNetQ/AutoSubscribe/AutoSubscriberConsumerInfo.cs
@@ -1,12 +1,15 @@
 using System;
+using System.Linq;
+using System.Reflection;
 
 namespace EasyNetQ.AutoSubscribe
 {
     public class AutoSubscriberConsumerInfo
     {
-        public readonly Type ConcreteType;
-        public readonly Type InterfaceType;
-        public readonly Type MessageType;
+        public Type ConcreteType{ get; }
+        public Type InterfaceType { get; }
+        public Type MessageType { get; }
+        public MethodInfo ConsumeMethod { get; }
 
         public AutoSubscriberConsumerInfo(Type concreteType, Type interfaceType, Type messageType)
         {
@@ -17,6 +20,8 @@ namespace EasyNetQ.AutoSubscribe
             ConcreteType = concreteType;
             InterfaceType = interfaceType;
             MessageType = messageType;
+            // get implementing method for interface implementation
+            ConsumeMethod = ConcreteType.GetInterfaceMap(InterfaceType).TargetMethods.Single();
         }
     }
 }


### PR DESCRIPTION
not using attributes for queue naming because of rename to ConsumeAsync.

Fixes https://github.com/EasyNetQ/EasyNetQ/issues/817