### PR TITLE
Ack on model should be called from Consumer Dispatcher Thread

### DIFF
--- a/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
@@ -94,15 +94,21 @@ namespace EasyNetQ.Tests.ConsumeTests
         {
             var autoResetEvent = new AutoResetEvent(false);
             MockBuilder.EventBus.Subscribe<DeliveredMessageEvent>(x => autoResetEvent.Set());
-            autoResetEvent.WaitOne(5000);
+            if(!autoResetEvent.WaitOne(5000))
+            {
+                throw new TimeoutException();
+            }
         }
 
-        protected void WaitForMessageDispatchToComplete()
+        private void WaitForMessageDispatchToComplete()
         {
             // wait for the subscription thread to handle the message ...
             var autoResetEvent = new AutoResetEvent(false);
             MockBuilder.EventBus.Subscribe<AckEvent>(x => autoResetEvent.Set());
-            autoResetEvent.WaitOne(5000);
+            if (!autoResetEvent.WaitOne(5000))
+            {
+                throw new TimeoutException();
+            }
         }
     }
 }

--- a/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
@@ -56,7 +56,7 @@ namespace EasyNetQ.Tests.ConsumeTests
         {
             ConsumerWasInvoked = false;
             var queue = new Queue("my_queue", false);
-            MockBuilder.Bus.Advanced.Consume(queue, (body, properties, messageInfo) => Task.Factory.StartNew(() =>
+            MockBuilder.Bus.Advanced.Consume(queue, (body, properties, messageInfo) => Task.Run(() =>
                 {
                     DeliveredMessageBody = body;
                     DeliveredMessageProperties = properties;
@@ -72,7 +72,7 @@ namespace EasyNetQ.Tests.ConsumeTests
             OriginalProperties = new BasicProperties
                 {
                     Type = "the_message_type",
-                    CorrelationId = "the_correlation_id"
+                    CorrelationId = "the_correlation_id",
                 };
             OriginalBody = Encoding.UTF8.GetBytes("Hello World");
 
@@ -94,7 +94,7 @@ namespace EasyNetQ.Tests.ConsumeTests
         {
             var autoResetEvent = new AutoResetEvent(false);
             MockBuilder.EventBus.Subscribe<DeliveredMessageEvent>(x => autoResetEvent.Set());
-            autoResetEvent.WaitOne(1000);
+            autoResetEvent.WaitOne(5000);
         }
 
         protected void WaitForMessageDispatchToComplete()
@@ -102,7 +102,7 @@ namespace EasyNetQ.Tests.ConsumeTests
             // wait for the subscription thread to handle the message ...
             var autoResetEvent = new AutoResetEvent(false);
             MockBuilder.EventBus.Subscribe<AckEvent>(x => autoResetEvent.Set());
-            autoResetEvent.WaitOne(1000);
+            autoResetEvent.WaitOne(5000);
         }
     }
 }

--- a/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
@@ -84,7 +84,7 @@ namespace EasyNetQ.Tests.ConsumeTests
                 "the_routing_key",
                 OriginalProperties,
                 OriginalBody
-                );
+            );
 
             WaitForMessageDispatchToBegin();
             WaitForMessageDispatchToComplete();

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_has_multiple_handlers.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_has_multiple_handlers.cs
@@ -47,7 +47,7 @@ namespace EasyNetQ.Tests.ConsumeTests
             Deliver(new MyOtherMessage { Text = "Hello Isomorphs!" });
             Deliver(new Dog());
 
-            countdownEvent.Wait(1000);
+            countdownEvent.Wait(5000);
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_has_multiple_handlers.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_has_multiple_handlers.cs
@@ -47,7 +47,10 @@ namespace EasyNetQ.Tests.ConsumeTests
             Deliver(new MyOtherMessage { Text = "Hello Isomorphs!" });
             Deliver(new Dog());
 
-            countdownEvent.Wait(5000);
+            if (!countdownEvent.Wait(5000))
+            {
+                throw new TimeoutException();
+            }
         }
 
         public void Dispose()
@@ -55,7 +58,7 @@ namespace EasyNetQ.Tests.ConsumeTests
             mockBuilder.Bus.Dispose();
         }
 
-        void Deliver<T>(T message) where T : class
+        private void Deliver<T>(T message) where T : class
         {
             var body = new JsonSerializer().MessageToBytes(message);
             var properties = new BasicProperties
@@ -71,7 +74,7 @@ namespace EasyNetQ.Tests.ConsumeTests
                 "routing_key",
                 properties,
                 body
-                );
+            );
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_by_the_broker.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_by_the_broker.cs
@@ -20,14 +20,17 @@ namespace EasyNetQ.Tests.ConsumeTests
 
             var queue = new Queue("my_queue", false);
 
-            mockBuilder.Bus.Advanced.Consume(queue, (bytes, properties, arg3) => Task.Factory.StartNew(() => { }));
+            mockBuilder.Bus.Advanced.Consume(queue, (bytes, properties, arg3) => Task.Run(() => { }));
 
             var are = new AutoResetEvent(false);
             mockBuilder.EventBus.Subscribe<ConsumerModelDisposedEvent>(x => are.Set());
 
             mockBuilder.Consumers[0].HandleBasicCancel("consumer_tag");
 
-            are.WaitOne(5000);
+            if (!are.WaitOne(5000))
+            {
+                throw new TimeoutException();
+            }
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_by_the_broker.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_by_the_broker.cs
@@ -27,7 +27,7 @@ namespace EasyNetQ.Tests.ConsumeTests
 
             mockBuilder.Consumers[0].HandleBasicCancel("consumer_tag");
 
-            are.WaitOne(500);
+            are.WaitOne(5000);
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_by_the_user.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_by_the_user.cs
@@ -22,14 +22,17 @@ namespace EasyNetQ.Tests.ConsumeTests
             var queue = new Queue("my_queue", false);
 
             var cancelSubscription = mockBuilder.Bus.Advanced
-                .Consume(queue, (bytes, properties, arg3) => Task.Factory.StartNew(() => { }));
+                .Consume(queue, (bytes, properties, arg3) => Task.Run(() => { }));
 
             var are = new AutoResetEvent(false);
             mockBuilder.EventBus.Subscribe<ConsumerModelDisposedEvent>(x => are.Set());
 
             cancelSubscription.Dispose();
 
-            are.WaitOne(500);
+            if (!are.WaitOne(5000))
+            {
+                throw new TimeoutException();
+            }
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_received.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_received.cs
@@ -77,7 +77,7 @@ namespace EasyNetQ.Tests.ConsumeTests
             // wait for the subscription thread to handle the message ...
             var autoResetEvent = new AutoResetEvent(false);
             mockBuilder.EventBus.Subscribe<AckEvent>(x => autoResetEvent.Set());
-            autoResetEvent.WaitOne(1000);
+            autoResetEvent.WaitOne(5000);
         }        
     }
 }

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_received.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_received.cs
@@ -77,7 +77,10 @@ namespace EasyNetQ.Tests.ConsumeTests
             // wait for the subscription thread to handle the message ...
             var autoResetEvent = new AutoResetEvent(false);
             mockBuilder.EventBus.Subscribe<AckEvent>(x => autoResetEvent.Set());
-            autoResetEvent.WaitOne(5000);
+            if (!autoResetEvent.WaitOne(5000))
+            {
+                throw new TimeoutException();
+            }
         }        
     }
 }

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_received.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_received.cs
@@ -59,6 +59,8 @@ namespace EasyNetQ.Tests.ConsumeTests
             };
             var body = Encoding.UTF8.GetBytes(message);
 
+            var autoResetEvent = new AutoResetEvent(false);
+            mockBuilder.EventBus.Subscribe<AckEvent>(x => autoResetEvent.Set());
             mockBuilder.Consumers[0].HandleBasicDeliver(
                 "consumer tag",
                 0,
@@ -68,20 +70,12 @@ namespace EasyNetQ.Tests.ConsumeTests
                 properties,
                 body
                 );
-
-            WaitForMessageDispatchToComplete();
-        }
-
-        private void WaitForMessageDispatchToComplete()
-        {
-            // wait for the subscription thread to handle the message ...
-            var autoResetEvent = new AutoResetEvent(false);
-            mockBuilder.EventBus.Subscribe<AckEvent>(x => autoResetEvent.Set());
+            
             if (!autoResetEvent.WaitOne(5000))
             {
                 throw new TimeoutException();
             }
-        }        
+        }       
     }
 }
 

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_polymorphic_message_is_delivered_to_the_consumer.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_polymorphic_message_is_delivered_to_the_consumer.cs
@@ -45,7 +45,10 @@ namespace EasyNetQ.Tests.ConsumeTests
                 body
                 );
 
-            are.WaitOne(5000);
+            if (!are.WaitOne(5000))
+            {
+                throw new TimeoutException();
+            }
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_polymorphic_message_is_delivered_to_the_consumer.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_polymorphic_message_is_delivered_to_the_consumer.cs
@@ -45,7 +45,7 @@ namespace EasyNetQ.Tests.ConsumeTests
                 body
                 );
 
-            are.WaitOne(1000);
+            are.WaitOne(5000);
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
@@ -78,11 +78,10 @@ namespace EasyNetQ.Tests.ConsumeTests
 
         private void WaitForResponse()
         {
-            var waiter = new SemaphoreSlim(0, 2);
-            mockBuilder.EventBus.Subscribe<PublishedMessageEvent>(x => waiter.Release());
-            mockBuilder.EventBus.Subscribe<AckEvent>(x => waiter.Release());
-            waiter.Wait(1000);
-            waiter.Wait(1000);
+            var waiter = new CountdownEvent(2);
+            mockBuilder.EventBus.Subscribe<PublishedMessageEvent>(x => waiter.Signal());
+            mockBuilder.EventBus.Subscribe<AckEvent>(x => waiter.Signal());
+            waiter.Wait(5000);
         }
 
         private class RpcRequest

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
@@ -63,6 +63,10 @@ namespace EasyNetQ.Tests.ConsumeTests
 
             var body = serializer.MessageToBytes(request);
 
+            var waiter = new CountdownEvent(2);
+            mockBuilder.EventBus.Subscribe<PublishedMessageEvent>(x => waiter.Signal());
+            mockBuilder.EventBus.Subscribe<AckEvent>(x => waiter.Signal());
+
             mockBuilder.Consumers[0].HandleBasicDeliver(
                 "consumer tag",
                 0,
@@ -73,20 +77,12 @@ namespace EasyNetQ.Tests.ConsumeTests
                 body
                 );
 
-            WaitForResponse();
-        }
-
-        private void WaitForResponse()
-        {
-            var waiter = new CountdownEvent(2);
-            mockBuilder.EventBus.Subscribe<PublishedMessageEvent>(x => waiter.Signal());
-            mockBuilder.EventBus.Subscribe<AckEvent>(x => waiter.Signal());
             if (!waiter.Wait(5000))
             {
                 throw new TimeoutException();
             }
         }
-
+        
         private class RpcRequest
         {
             public int Value { get; set; }

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
@@ -8,24 +8,23 @@ using Xunit;
 
 namespace EasyNetQ.Tests.ConsumeTests
 {
-
     public class When_a_responder_is_cancelled : IDisposable
     {
-        private MockBuilder mockBuilder;
+        private readonly MockBuilder mockBuilder;
         private PublishedMessageEvent publishedMessage;
         private AckEvent ackEvent;
 
-        private readonly IConventions Conventions;
-        private readonly ITypeNameSerializer TypeNameSerializer;
-        private readonly ISerializer Serializer;
+        private readonly IConventions conventions;
+        private readonly ITypeNameSerializer typeNameSerializer;
+        private readonly ISerializer serializer;
 
         public When_a_responder_is_cancelled()
         {
             mockBuilder = new MockBuilder();
 
-            Conventions = mockBuilder.Bus.Advanced.Conventions;
-            TypeNameSerializer = mockBuilder.Bus.Advanced.Container.Resolve<ITypeNameSerializer>();
-            Serializer = mockBuilder.Bus.Advanced.Container.Resolve<ISerializer>();
+            conventions = mockBuilder.Bus.Advanced.Conventions;
+            typeNameSerializer = mockBuilder.Bus.Advanced.Container.Resolve<ITypeNameSerializer>();
+            serializer = mockBuilder.Bus.Advanced.Container.Resolve<ISerializer>();
 
             mockBuilder.Bus.RespondAsync<RpcRequest, RpcResponse>(m =>
             {
@@ -57,12 +56,12 @@ namespace EasyNetQ.Tests.ConsumeTests
         {
             var properties = new BasicProperties
             {
-                Type = TypeNameSerializer.Serialize(request.GetType()),
+                Type = typeNameSerializer.Serialize(request.GetType()),
                 CorrelationId = "the_correlation_id",
-                ReplyTo = Conventions.RpcReturnQueueNamingConvention()
+                ReplyTo = conventions.RpcReturnQueueNamingConvention()
             };
 
-            var body = Serializer.MessageToBytes(request);
+            var body = serializer.MessageToBytes(request);
 
             mockBuilder.Consumers[0].HandleBasicDeliver(
                 "consumer tag",

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
@@ -81,7 +81,10 @@ namespace EasyNetQ.Tests.ConsumeTests
             var waiter = new CountdownEvent(2);
             mockBuilder.EventBus.Subscribe<PublishedMessageEvent>(x => waiter.Signal());
             mockBuilder.EventBus.Subscribe<AckEvent>(x => waiter.Signal());
-            waiter.Wait(5000);
+            if (!waiter.Wait(5000))
+            {
+                throw new TimeoutException();
+            }
         }
 
         private class RpcRequest

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_an_error_occurs_in_the_message_handler.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_an_error_occurs_in_the_message_handler.cs
@@ -31,9 +31,6 @@ namespace EasyNetQ.Tests.ConsumeTests
                                                            args.Body == OriginalBody),
                 Arg.Is<Exception>(e => e == exception)
             );
-
-            ConsumerErrorStrategy.DidNotReceive()
-                .HandleConsumerCancelled(Arg.Any<ConsumerExecutionContext>());
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_an_error_occurs_in_the_message_handler.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_an_error_occurs_in_the_message_handler.cs
@@ -17,10 +17,7 @@ namespace EasyNetQ.Tests.ConsumeTests
                      .ReturnsForAnyArgs(AckStrategies.Ack);
 
             exception = new Exception("I've had a bad day :(");
-            StartConsumer((body, properties, info) =>
-                {
-                    throw exception;
-                });
+            StartConsumer((body, properties, info) => throw exception);
             DeliverMessage();
         }
 
@@ -32,7 +29,8 @@ namespace EasyNetQ.Tests.ConsumeTests
                                                            args.Info.DeliverTag == DeliverTag &&
                                                            args.Info.Exchange == "the_exchange" &&
                                                            args.Body == OriginalBody),
-                Arg.Is<Exception>(ex => ex.InnerException == exception));
+                Arg.Is<Exception>(e => e == exception)
+            );
 
             ConsumerErrorStrategy.DidNotReceive()
                 .HandleConsumerCancelled(Arg.Any<ConsumerExecutionContext>());

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_cancellation_of_message_handler_occurs.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_cancellation_of_message_handler_occurs.cs
@@ -30,8 +30,6 @@ namespace EasyNetQ.Tests.ConsumeTests
                                                         args.Info.DeliverTag == DeliverTag &&
                                                         args.Info.Exchange == "the_exchange" &&
                                                         args.Body == OriginalBody));
-
-            ConsumerErrorStrategy.DidNotReceive().HandleConsumerError(Arg.Any<ConsumerExecutionContext>(), Arg.Any<Exception>());
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_cancelled.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Threading.Tasks;
 using EasyNetQ.Consumer;
+using EasyNetQ.Events;
 using Xunit;
 using RabbitMQ.Client;
 using NSubstitute;
@@ -25,7 +26,8 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
         public When_a_user_handler_is_cancelled()
         {
             consumerErrorStrategy = Substitute.For<IConsumerErrorStrategy>();
-            
+            consumerErrorStrategy.HandleConsumerCancelled(null).ReturnsForAnyArgs(AckStrategies.Ack);
+
             var handlerRunner = new HandlerRunner(consumerErrorStrategy);
 
             var consumer = Substitute.For<IBasicConsumer>();
@@ -56,7 +58,7 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
         }
 
         [Fact]
-        public void Should_Nack()
+        public void Should_Ack()
         {
             channel.Received().BasicAck(42, false);
         }

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_cancelled.cs
@@ -1,12 +1,8 @@
 ﻿// ReSharper disable InconsistentNaming
 
 using System;
-using System.Data;
-using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.Consumer;
-using EasyNetQ.Events;
-using FluentAssertions;
 using Xunit;
 using RabbitMQ.Client;
 using NSubstitute;
@@ -19,40 +15,50 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
             {
                 CorrelationId = "correlation_id"
             };
-        private readonly MessageReceivedInfo messageInfo = new MessageReceivedInfo("consumer_tag", 123, false, "exchange", "routingKey", "queue");
+        private readonly MessageReceivedInfo messageInfo = new MessageReceivedInfo("consumer_tag", 42, false, "exchange", "routingKey", "queue");
         private readonly byte[] messageBody = new byte[0];
 
         private readonly IConsumerErrorStrategy consumerErrorStrategy;
         private readonly ConsumerExecutionContext context;
+        private readonly IModel channel;
 
         public When_a_user_handler_is_cancelled()
         {
             consumerErrorStrategy = Substitute.For<IConsumerErrorStrategy>();
-            var eventBus = new EventBus();
-
-            var handlerRunner = new HandlerRunner(consumerErrorStrategy, eventBus);
-
-            Func<byte[], MessageProperties, MessageReceivedInfo, Task> userHandler = (body, properties, info) => 
-                Task.Run(() => throw new OperationCanceledException());
+            
+            var handlerRunner = new HandlerRunner(consumerErrorStrategy);
 
             var consumer = Substitute.For<IBasicConsumer>();
-            var channel = Substitute.For<IModel>();
+            channel = Substitute.For<IModel>();
             consumer.Model.Returns(channel);
 
-            context = new ConsumerExecutionContext(userHandler, messageInfo, messageProperties, messageBody, consumer);
+            context = new ConsumerExecutionContext(
+                async (body, properties, info) => throw new OperationCanceledException(),
+                messageInfo,
+                messageProperties,
+                messageBody
+            );
 
-            var autoResetEvent = new AutoResetEvent(false);
-            eventBus.Subscribe<AckEvent>(x => autoResetEvent.Set());
-
-            handlerRunner.InvokeUserMessageHandler(context);
-
-            autoResetEvent.WaitOne(1000);
+            handlerRunner.InvokeUserMessageHandlerAsync(context)
+                         .ContinueWith(async x =>
+                        {
+                            var ackStrategy = await x.ConfigureAwait(false);
+                            return ackStrategy(channel, 42);
+                        })
+                        .Unwrap()
+                        .Wait();
         }
 
         [Fact]
         public void Should_handle_consumer_cancelled()
         {
             consumerErrorStrategy.Received().HandleConsumerCancelled(context);
+        }
+
+        [Fact]
+        public void Should_Nack()
+        {
+            channel.Received().BasicAck(42, false);
         }
     }
 }

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_cancelled.cs
@@ -46,7 +46,7 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
                 {
                     var ackStrategy = await x.ConfigureAwait(false);
                     return ackStrategy(channel, 42);
-                })
+                }, TaskContinuationOptions.ExecuteSynchronously)
                 .Unwrap()
                 .Wait(5000);
         }

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_cancelled.cs
@@ -48,7 +48,7 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
                     return ackStrategy(channel, 42);
                 })
                 .Unwrap()
-                .Wait(1000);
+                .Wait(5000);
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_cancelled.cs
@@ -41,16 +41,20 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
                 messageBody
             );
 
-            handlerRunner.InvokeUserMessageHandlerAsync(context)
+            var handlerTask = handlerRunner.InvokeUserMessageHandlerAsync(context)
                 .ContinueWith(async x =>
                 {
                     var ackStrategy = await x.ConfigureAwait(false);
                     return ackStrategy(channel, 42);
                 }, TaskContinuationOptions.ExecuteSynchronously)
-                .Unwrap()
-                .Wait(5000);
-        }
+                .Unwrap();
 
+            if (!handlerTask.Wait(5000))
+            {
+                throw new TimeoutException();
+            }
+        }
+    
         [Fact]
         public void Should_handle_consumer_cancelled()
         {

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_cancelled.cs
@@ -42,13 +42,13 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
             );
 
             handlerRunner.InvokeUserMessageHandlerAsync(context)
-                         .ContinueWith(async x =>
-                        {
-                            var ackStrategy = await x.ConfigureAwait(false);
-                            return ackStrategy(channel, 42);
-                        })
-                        .Unwrap()
-                        .Wait();
+                .ContinueWith(async x =>
+                {
+                    var ackStrategy = await x.ConfigureAwait(false);
+                    return ackStrategy(channel, 42);
+                })
+                .Unwrap()
+                .Wait(1000);
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_executed.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_executed.cs
@@ -1,5 +1,6 @@
 ﻿// ReSharper disable InconsistentNaming
 
+using System;
 using System.Threading.Tasks;
 using EasyNetQ.Consumer;
 using FluentAssertions;
@@ -46,14 +47,18 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
                 messageBody
             );
 
-            handlerRunner.InvokeUserMessageHandlerAsync(context)
+            var handlerTask = handlerRunner.InvokeUserMessageHandlerAsync(context)
                 .ContinueWith(async x =>
                 {
                     var ackStrategy = await x.ConfigureAwait(false);
                     return ackStrategy(channel, 42);
                 }, TaskContinuationOptions.ExecuteSynchronously)
-                .Unwrap()
-                .Wait(5000);
+                .Unwrap();
+
+            if (!handlerTask.Wait(5000))
+            {
+                throw new TimeoutException();
+            }
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_executed.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_executed.cs
@@ -1,10 +1,7 @@
 ﻿// ReSharper disable InconsistentNaming
 
-using System;
-using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.Consumer;
-using EasyNetQ.Events;
 using FluentAssertions;
 using Xunit;
 using RabbitMQ.Client;
@@ -22,7 +19,7 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
             {
                 CorrelationId = "correlation_id"
             };
-        private readonly MessageReceivedInfo messageInfo = new MessageReceivedInfo("consumer_tag", 123, false, "exchange", "routingKey", "queue");
+        private readonly MessageReceivedInfo messageInfo = new MessageReceivedInfo("consumer_tag", 42, false, "exchange", "routingKey", "queue");
         private readonly byte[] messageBody = new byte[0];
 
         private readonly IModel channel;
@@ -30,31 +27,33 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
         public When_a_user_handler_is_executed()
         {
             var consumerErrorStrategy = Substitute.For<IConsumerErrorStrategy>();
-            var eventBus = new EventBus();
 
-            var handlerRunner = new HandlerRunner(consumerErrorStrategy, eventBus);
-
-            Func<byte[], MessageProperties, MessageReceivedInfo, Task> userHandler = (body, properties, info) => 
-                Task.Factory.StartNew(() =>
-                    {
-                        deliveredBody = body;
-                        deliveredProperties = properties;
-                        deliveredInfo = info;
-                    });
+            var handlerRunner = new HandlerRunner(consumerErrorStrategy);
 
             var consumer = Substitute.For<IBasicConsumer>();
             channel = Substitute.For<IModel>();
             consumer.Model.Returns(channel);
 
             var context = new ConsumerExecutionContext(
-                userHandler, messageInfo, messageProperties, messageBody, consumer);
+                (body, properties, info) => Task.Run(() =>
+                    {
+                        deliveredBody = body;
+                        deliveredProperties = properties;
+                        deliveredInfo = info;
+                    }),
+                messageInfo,
+                messageProperties,
+                messageBody
+            );
 
-            var autoResetEvent = new AutoResetEvent(false);
-            eventBus.Subscribe<AckEvent>(x => autoResetEvent.Set());
-
-            handlerRunner.InvokeUserMessageHandler(context);
-
-            autoResetEvent.WaitOne(1000);
+            handlerRunner.InvokeUserMessageHandlerAsync(context)
+                .ContinueWith(async x =>
+                {
+                    var ackStrategy = await x.ConfigureAwait(false);
+                    return ackStrategy(channel, 42);
+                })
+                .Unwrap()
+                .Wait();
         }
 
         [Fact]
@@ -76,9 +75,9 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
         }
 
         [Fact]
-        public void Should_ACK_message()
+        public void Should_ACK()
         {
-            channel.Received().BasicAck(123, false);
+            channel.Received().BasicAck(42, false);
         }
     }
 }

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_executed.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_executed.cs
@@ -53,7 +53,7 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
                     return ackStrategy(channel, 42);
                 })
                 .Unwrap()
-                .Wait(1000);
+                .Wait(5000);
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_executed.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_executed.cs
@@ -53,7 +53,7 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
                     return ackStrategy(channel, 42);
                 })
                 .Unwrap()
-                .Wait();
+                .Wait(1000);
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_executed.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_executed.cs
@@ -51,7 +51,7 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
                 {
                     var ackStrategy = await x.ConfigureAwait(false);
                     return ackStrategy(channel, 42);
-                })
+                }, TaskContinuationOptions.ExecuteSynchronously)
                 .Unwrap()
                 .Wait(5000);
         }

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_failed.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_failed.cs
@@ -37,7 +37,7 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
             consumer.Model.Returns(channel);
 
             context = new ConsumerExecutionContext(
-                (body, properties, info) => Task.Run(() => throw new Exception()),
+                async (body, properties, info) => throw new Exception(),
                 messageInfo,
                 messageProperties,
                 messageBody
@@ -48,7 +48,7 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
                 {
                     var ackStrategy = await x.ConfigureAwait(false);
                     return ackStrategy(channel, 42);
-                })
+                }, TaskContinuationOptions.ExecuteSynchronously)
                 .Unwrap()
                 .Wait(5000);
         }

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_failed.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_failed.cs
@@ -43,14 +43,18 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
                 messageBody
             );
 
-            handlerRunner.InvokeUserMessageHandlerAsync(context)
+            var handlerTask = handlerRunner.InvokeUserMessageHandlerAsync(context)
                 .ContinueWith(async x =>
                 {
                     var ackStrategy = await x.ConfigureAwait(false);
                     return ackStrategy(channel, 42);
                 }, TaskContinuationOptions.ExecuteSynchronously)
-                .Unwrap()
-                .Wait(5000);
+                .Unwrap();
+
+            if (!handlerTask.Wait(5000))
+            {
+                throw new TimeoutException();
+            }
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_failed.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_failed.cs
@@ -50,7 +50,7 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
                     return ackStrategy(channel, 42);
                 })
                 .Unwrap()
-                .Wait(1000);
+                .Wait(5000);
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_failed.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_failed.cs
@@ -23,35 +23,47 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
 
         private readonly IConsumerErrorStrategy consumerErrorStrategy;
         private readonly ConsumerExecutionContext context;
+        private readonly IModel channel;
 
         public When_a_user_handler_is_failed()
         {
             consumerErrorStrategy = Substitute.For<IConsumerErrorStrategy>();
-            var eventBus = new EventBus();
+            consumerErrorStrategy.HandleConsumerError(Arg.Any<ConsumerExecutionContext>(), Arg.Any<Exception>())
+                                 .Returns(AckStrategies.Ack);
 
-            var handlerRunner = new HandlerRunner(consumerErrorStrategy, eventBus);
-
-            Func<byte[], MessageProperties, MessageReceivedInfo, Task> userHandler = (body, properties, info) => 
-                Task.Run(() => throw new Exception());
+            var handlerRunner = new HandlerRunner(consumerErrorStrategy);
 
             var consumer = Substitute.For<IBasicConsumer>();
-            var channel = Substitute.For<IModel>();
+            channel = Substitute.For<IModel>();
             consumer.Model.Returns(channel);
 
-            context = new ConsumerExecutionContext(userHandler, messageInfo, messageProperties, messageBody, consumer);
+            context = new ConsumerExecutionContext(
+                (body, properties, info) => Task.Run(() => throw new Exception()),
+                messageInfo,
+                messageProperties,
+                messageBody
+            );
 
-            var autoResetEvent = new AutoResetEvent(false);
-            eventBus.Subscribe<AckEvent>(x => autoResetEvent.Set());
-
-            handlerRunner.InvokeUserMessageHandler(context);
-
-            autoResetEvent.WaitOne(1000);
+            handlerRunner.InvokeUserMessageHandlerAsync(context)
+                .ContinueWith(async x =>
+                {
+                    var ackStrategy = await x.ConfigureAwait(false);
+                    return ackStrategy(channel, 42);
+                })
+                .Unwrap()
+                .Wait();
         }
 
         [Fact]
         public void Should_handle_consumer_error()
         {
             consumerErrorStrategy.Received().HandleConsumerError(context, Arg.Any<Exception>());
+        }
+
+        [Fact]
+        public void Should_ACK()
+        {
+            channel.Received().BasicAck(42, false);
         }
     }
 }

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_failed.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_failed.cs
@@ -28,8 +28,7 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
         public When_a_user_handler_is_failed()
         {
             consumerErrorStrategy = Substitute.For<IConsumerErrorStrategy>();
-            consumerErrorStrategy.HandleConsumerError(Arg.Any<ConsumerExecutionContext>(), Arg.Any<Exception>())
-                                 .Returns(AckStrategies.Ack);
+            consumerErrorStrategy.HandleConsumerError(null, null).ReturnsForAnyArgs(AckStrategies.Ack);
 
             var handlerRunner = new HandlerRunner(consumerErrorStrategy);
 

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_failed.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_failed.cs
@@ -50,7 +50,7 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
                     return ackStrategy(channel, 42);
                 })
                 .Unwrap()
-                .Wait();
+                .Wait(1000);
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/Integration/DefaultConsumerErrorStrategyTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/DefaultConsumerErrorStrategyTests.cs
@@ -44,8 +44,8 @@ namespace EasyNetQ.Tests.Integration
                 serializer, 
                 conventions,
                 typeNameSerializer,
-                errorMessageSerializer);
-         
+                errorMessageSerializer
+            );
         }
 
         /// <summary>
@@ -67,9 +67,8 @@ namespace EasyNetQ.Tests.Integration
                     CorrelationId = "123",
                     AppId = "456"
                 },
-                originalMessageBody,
-                Substitute.For<IBasicConsumer>()
-                );
+                originalMessageBody
+            );
 
             consumerErrorStrategy.HandleConsumerError(context, exception);
 
@@ -115,9 +114,8 @@ namespace EasyNetQ.Tests.Integration
                     CorrelationId = "123",
                     AppId = "456"
                 },
-                originalMessageBody,
-                Substitute.For<IBasicConsumer>()
-                );
+                originalMessageBody
+            );
 
             connectionFactory = Substitute.For<IConnectionFactory>();
 

--- a/Source/EasyNetQ.Tests/SubscribeTests.cs
+++ b/Source/EasyNetQ.Tests/SubscribeTests.cs
@@ -234,9 +234,7 @@ namespace EasyNetQ.Tests
                 ConsumerTagConvention = () => consumerTag
             };
 
-            mockBuilder = new MockBuilder(x => x
-                .Register<IConventions>(conventions)
-                );
+            mockBuilder = new MockBuilder(x => x.Register<IConventions>(conventions));
 
             var autoResetEvent = new AutoResetEvent(false);
             mockBuilder.EventBus.Subscribe<AckEvent>(x => autoResetEvent.Set());
@@ -331,11 +329,7 @@ namespace EasyNetQ.Tests
                 .Register(consumerErrorStrategy)
                 );
 
-            mockBuilder.Bus.Subscribe<MyMessage>(subscriptionId, message =>
-            {
-                throw originalException;
-            });
-
+            mockBuilder.Bus.Subscribe<MyMessage>(subscriptionId, message => throw originalException);
 
             const string text = "Hello there, I am the text!";
             originalMessage = new MyMessage { Text = text };
@@ -382,9 +376,7 @@ namespace EasyNetQ.Tests
         [Fact]
         public void Should_pass_the_exception_to_consumerErrorStrategy()
         {
-            raisedException.Should().NotBeNull();
-            raisedException.InnerException.Should().NotBeNull();
-            raisedException.InnerException.Should().BeSameAs(originalException);
+            raisedException.Should().BeSameAs(originalException);
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
+++ b/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
@@ -31,7 +31,8 @@ namespace EasyNetQ.Tests
                 new JsonSerializer(), 
                 customConventions,
                 new DefaultTypeNameSerializer(),
-                new DefaultErrorMessageSerializer());
+                new DefaultErrorMessageSerializer()
+            );
 
             const string originalMessage = "";
             var originalMessageBody = Encoding.UTF8.GetBytes(originalMessage);

--- a/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
+++ b/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
@@ -44,8 +44,7 @@ namespace EasyNetQ.Tests
                     CorrelationId = string.Empty,
                     AppId = string.Empty
                 },
-                originalMessageBody,
-                Substitute.For<IBasicConsumer>()
+                originalMessageBody
             );
 
             try

--- a/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
@@ -19,8 +19,7 @@ namespace EasyNetQ.Consumer
 
             var thread = new Thread(_ =>
             {
-                Action action;
-                while (!disposed && queue.TryTake(out action, -1))
+                while (!disposed && queue.TryTake(out var action, -1))
                 {
                     try
                     {
@@ -45,8 +44,7 @@ namespace EasyNetQ.Consumer
         {
             // throw away any queued actions. RabbitMQ will redeliver any in-flight
             // messages that have not been acked when the connection is lost.
-            Action result;
-            while (queue.TryTake(out result))
+            while (queue.TryTake(out _))
             {
             }
         }

--- a/Source/EasyNetQ/Consumer/ConsumerExecutionContext.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerExecutionContext.cs
@@ -10,26 +10,23 @@ namespace EasyNetQ.Consumer
         public MessageReceivedInfo Info { get; }
         public MessageProperties Properties { get; }
         public byte[] Body { get; }
-        public IBasicConsumer Consumer { get; }
 
         public ConsumerExecutionContext(
             Func<byte[], MessageProperties, MessageReceivedInfo, Task> userHandler, 
             MessageReceivedInfo info, 
             MessageProperties properties, 
-            byte[] body, 
-            IBasicConsumer consumer)
+            byte[] body
+        )
         {
             Preconditions.CheckNotNull(userHandler, "userHandler");
             Preconditions.CheckNotNull(info, "info");
             Preconditions.CheckNotNull(properties, "properties");
             Preconditions.CheckNotNull(body, "body");
-            Preconditions.CheckNotNull(consumer, "consumer");
 
             UserHandler = userHandler;
             Info = info;
             Properties = properties;
             Body = body;
-            Consumer = consumer;
         }
     }
 }

--- a/Source/EasyNetQ/Consumer/HandlerRunner.cs
+++ b/Source/EasyNetQ/Consumer/HandlerRunner.cs
@@ -35,7 +35,7 @@ namespace EasyNetQ.Consumer
                 logger.DebugFormat("Received message with receivedInfo={receivedInfo}", context.Info);
             }
 
-            var ackStrategy = await InvokeUserMessageHandlerInternalAsync(context);
+            var ackStrategy = await InvokeUserMessageHandlerInternalAsync(context).ConfigureAwait(false);
             
             return (model, tag) =>
             {

--- a/Source/EasyNetQ/Consumer/HandlerRunner.cs
+++ b/Source/EasyNetQ/Consumer/HandlerRunner.cs
@@ -11,117 +11,103 @@ namespace EasyNetQ.Consumer
 {
     public interface IHandlerRunner : IDisposable
     {
-        void InvokeUserMessageHandler(ConsumerExecutionContext context);
+        Task<AckStrategy> InvokeUserMessageHandlerAsync(ConsumerExecutionContext context);
     }
 
     public class HandlerRunner : IHandlerRunner
     {
         private readonly ILog logger = LogProvider.For<HandlerRunner>();
         private readonly IConsumerErrorStrategy consumerErrorStrategy;
-        private readonly IEventBus eventBus;
 
-        public HandlerRunner(IConsumerErrorStrategy consumerErrorStrategy, IEventBus eventBus)
+        public HandlerRunner(IConsumerErrorStrategy consumerErrorStrategy)
         {
             Preconditions.CheckNotNull(consumerErrorStrategy, "consumerErrorStrategy");
-            Preconditions.CheckNotNull(eventBus, "eventBus");
 
             this.consumerErrorStrategy = consumerErrorStrategy;
-            this.eventBus = eventBus;
         }
 
-        public virtual void InvokeUserMessageHandler(ConsumerExecutionContext context)
+        public virtual async Task<AckStrategy> InvokeUserMessageHandlerAsync(ConsumerExecutionContext context)
         {
             Preconditions.CheckNotNull(context, "context");
 
-            logger.DebugFormat("Received message with receivedInfo={receivedInfo}", context.Info);
+            if (logger.IsDebugEnabled())
+            {
+                logger.DebugFormat("Received message with receivedInfo={receivedInfo}", context.Info);
+            }
 
-            Task completionTask;
+            var ackStrategy = await InvokeUserMessageHandlerInternalAsync(context);
             
-            try
+            return (model, tag) =>
             {
-                completionTask = context.UserHandler(context.Body, context.Properties, context.Info);
-            }
-            catch (Exception exception)
-            {
-                completionTask = TaskHelpers.FromException(exception);
-            }
-            
-            completionTask.ContinueWith(task => DoAck(context, GetAckStrategy(context, task)));
+                try
+                {
+                    return ackStrategy(model, tag);
+                }
+                catch (AlreadyClosedException alreadyClosedException)
+                {
+                    logger.Info(
+                        alreadyClosedException,
+                        "Failed to ACK or NACK, message will be retried, receivedInfo={receivedInfo}",
+                        context.Info
+                    );
+                }
+                catch (IOException ioException)
+                {
+                    logger.Info(
+                        ioException,
+                        "Failed to ACK or NACK, message will be retried, receivedInfo={receivedInfo}",
+                        context.Info
+                    );
+                }
+                catch (Exception exception)
+                {
+                    logger.Error(
+                        exception, 
+                        "Unexpected exception when attempting to ACK or NACK, receivedInfo={receivedInfo}",
+                        context.Info
+                    );
+                }
+                
+                return AckResult.Exception;
+            };
         }
 
-        protected virtual AckStrategy GetAckStrategy(ConsumerExecutionContext context, Task task)
+        private async Task<AckStrategy> InvokeUserMessageHandlerInternalAsync(ConsumerExecutionContext context)
         {
             try
             {
-                if (task.IsFaulted)
+                try
+                {
+                    await context.UserHandler(context.Body, context.Properties, context.Info).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    return consumerErrorStrategy.HandleConsumerCancelled(context);
+                }
+                catch (Exception exception)
                 {
                     logger.Error(
-                        task.Exception,
-                        "Exception thrown by subscription callback, receivedInfo={receivedInfo}, properties={properties}, message={message}", 
+                        exception,
+                        "Exception thrown by subscription callback, receivedInfo={receivedInfo}, properties={properties}, message={message}",
                         context.Info,
                         context.Properties,
                         Convert.ToBase64String(context.Body)
                     );
-                    return consumerErrorStrategy.HandleConsumerError(context, task.Exception);
+                    return consumerErrorStrategy.HandleConsumerError(context, exception);
                 }
-
-                if (task.IsCanceled)
-                {
-                    return consumerErrorStrategy.HandleConsumerCancelled(context);
-                }
-
-                return AckStrategies.Ack;
             }
             catch (Exception exception)
             {
                 logger.Error(exception, "Consumer error strategy has failed");
                 return AckStrategies.NackWithRequeue;
             }
-        }
 
-        protected virtual void DoAck(ConsumerExecutionContext context, AckStrategy ackStrategy)
-        {
-            var ackResult = AckResult.Exception;
-
-            try
-            {
-                Preconditions.CheckNotNull(context.Consumer.Model, "context.Consumer.Model");
-
-                ackResult = ackStrategy(context.Consumer.Model, context.Info.DeliverTag);
-            }
-            catch (AlreadyClosedException alreadyClosedException)
-            {
-                logger.Info(
-                    alreadyClosedException,
-                    "Failed to ACK or NACK, message will be retried, receivedInfo={receivedInfo}",
-                    context.Info
-                );
-            }
-            catch (IOException ioException)
-            {
-                logger.Info(
-                    ioException,
-                    "Failed to ACK or NACK, message will be retried, receivedInfo={receivedInfo}",
-                    context.Info
-                );
-            }
-            catch (Exception exception)
-            {
-                logger.Error(
-                    exception, 
-                    "Unexpected exception when attempting to ACK or NACK, receivedInfo={receivedInfo}",
-                    context.Info
-                );
-            }
-            finally
-            {
-                eventBus.Publish(new AckEvent(context.Info, context.Properties, context.Body, ackResult));
-            }
+            return AckStrategies.Ack;
         }
 
         public void Dispose()
         {
-            consumerErrorStrategy?.Dispose();
+            consumerErrorStrategy.Dispose();
         }
     }
 }

--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -131,7 +131,8 @@ namespace EasyNetQ.Consumer
                                     var ackResult = ackStrategy(Model, deliveryTag);
                                     eventBus.Publish(new AckEvent(messageReceivedInfo, messsageProperties, body, ackResult));
                                 });
-                            }
+                            },
+                            TaskContinuationOptions.ExecuteSynchronously
                          );
         }
 
@@ -295,8 +296,7 @@ namespace EasyNetQ.Consumer
                     consumerTag,
                     queue.Name,
                     configuration
-                );
-                
+                );                
                 
                 return StartConsumingStatus.Succeed;
             }

--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -18,13 +18,13 @@ namespace EasyNetQ.Consumer
             IQueue queue,
             Func<byte[], MessageProperties, MessageReceivedInfo, Task> onMessage,
             IConsumerConfiguration configuration
-            );
+        );
 
         StartConsumingStatus StartConsuming(
             IPersistentConnection connection,
             ICollection<Tuple<IQueue, Func<byte[], MessageProperties, MessageReceivedInfo, Task>>> queueConsumerPairs,
             IConsumerConfiguration configuration
-            );
+        );
 
         event Action<IInternalConsumer> Cancelled;
     }
@@ -100,7 +100,10 @@ namespace EasyNetQ.Consumer
         
         public void HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, IBasicProperties properties, byte[] body)
         {
-            logger.DebugFormat("Message delivered to consumer {consumerTag} with deliveryTag {deliveryTag}", consumerTag, deliveryTag);
+            if (logger.IsDebugEnabled())
+            {
+                logger.DebugFormat("Message delivered to consumer {consumerTag} with deliveryTag {deliveryTag}", consumerTag, deliveryTag);
+            }
 
             if (disposed)
             {
@@ -116,16 +119,21 @@ namespace EasyNetQ.Consumer
 
             var messageReceivedInfo = new MessageReceivedInfo(consumerTag, deliveryTag, redelivered, exchange, routingKey, Queue.Name);
             var messsageProperties = new MessageProperties(properties);
-            var context = new ConsumerExecutionContext(OnMessage, messageReceivedInfo, messsageProperties, body, this);
+            var context = new ConsumerExecutionContext(OnMessage, messageReceivedInfo, messsageProperties, body);
 
-            consumerDispatcher.QueueAction(() =>
-            {
-                eventBus.Publish(new DeliveredMessageEvent(messageReceivedInfo, messsageProperties, body));
-                handlerRunner.InvokeUserMessageHandler(context);
-            });
+            eventBus.Publish(new DeliveredMessageEvent(messageReceivedInfo, messsageProperties, body));
+            handlerRunner.InvokeUserMessageHandlerAsync(context)
+                         .ContinueWith(async x =>
+                            {
+                                var ackStrategy = await x.ConfigureAwait(false);
+                                consumerDispatcher.QueueAction(() =>
+                                {
+                                    var ackResult = ackStrategy(Model, deliveryTag);
+                                    eventBus.Publish(new AckEvent(messageReceivedInfo, messsageProperties, body, ackResult));
+                                });
+                            }
+                         );
         }
-
-        
 
         public IModel Model { get; }
         public event EventHandler<ConsumerEventArgs> ConsumerCancelled;


### PR DESCRIPTION
Related issues are #723 and #758.

It seems we have concurrency issue connected with usage of IModel from multiple threads:
1. One thread is Consumer Dispatcher Thread
2. During sending acks to messages model can be used from multiple thread pool threads.

It will happen more likely if `IAdvancedBus.ConsumeAsync` is used, because if not - messages will be processed one by one and acks will be sent one by one too. But in case of using `IAdvancedBus.ConsumeAsync` messages will be acked in parallel from thread pool threads.

Acking of messages in parallel does not cause an issue itself(or I can't reproduce). It causes an issue only with combination of disposing IModel from Consumer Dispatcher Thread(it can happen because of disconnect or manual disposal of subscription).

Also increasing PrefetchCount helps to observe the issue more likely too.

PS Will attach examples soon.


