### PR TITLE
EasyNetQ 3.3.0

### DIFF
--- a/Source/EasyNetQ.Hosepipe.Tests/ErrorRetryTests.cs
+++ b/Source/EasyNetQ.Hosepipe.Tests/ErrorRetryTests.cs
@@ -31,7 +31,7 @@ namespace EasyNetQ.Hosepipe.Tests
             };
 
             var rawErrorMessages = new MessageReader()
-                .ReadMessages(parameters, conventions.ErrorQueueNamingConvention());
+                .ReadMessages(parameters, conventions.ErrorQueueNamingConvention(new MessageReceivedInfo()));
 
             errorRetry.RetryErrors(rawErrorMessages, parameters);
         }

--- a/Source/EasyNetQ.Hosepipe.Tests/MessageReaderTests.cs
+++ b/Source/EasyNetQ.Hosepipe.Tests/MessageReaderTests.cs
@@ -48,7 +48,7 @@ namespace EasyNetQ.Hosepipe.Tests
                 MessagesOutputDirectory = @"C:\temp\MessageOutput"
             };
 
-            var messages = messageReader.ReadMessages(parameters, conventions.ErrorQueueNamingConvention());
+            var messages = messageReader.ReadMessages(parameters, conventions.ErrorQueueNamingConvention(new MessageReceivedInfo()));
             foreach (var message in messages)
             {
                 Console.WriteLine(message.Body);

--- a/Source/EasyNetQ.Hosepipe/Program.cs
+++ b/Source/EasyNetQ.Hosepipe/Program.cs
@@ -149,14 +149,14 @@ namespace EasyNetQ.Hosepipe
         private void ErrorDump(QueueParameters parameters)
         {
             if(parameters.QueueName == null)
-                parameters.QueueName = conventions.ErrorQueueNamingConvention();
+                parameters.QueueName = conventions.ErrorQueueNamingConvention(new MessageReceivedInfo());
             Dump(parameters);
         }
 
         private void Retry(QueueParameters parameters)
         {
             var count = 0;
-            var queueName = parameters.QueueName ?? conventions.ErrorQueueNamingConvention();
+            var queueName = parameters.QueueName ?? conventions.ErrorQueueNamingConvention(new MessageReceivedInfo());
             
             errorRetry.RetryErrors(
                 WithEach(

--- a/Source/EasyNetQ.Tests/ConsumeTests/AckStrategyTests.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/AckStrategyTests.cs
@@ -85,31 +85,4 @@ namespace EasyNetQ.Tests.ConsumeTests
             Assert.Equal(AckResult.Nack, result);
         }
     }
-
-    public class Nothing_strategy
-    {
-        private IModel model;
-        private AckResult result;
-        private const ulong deliveryTag = 1234;
-
-        public Nothing_strategy()
-        {
-            model = Substitute.For<IModel>();
-
-            result = AckStrategies.Nothing(model, deliveryTag);
-        }
-
-        [Fact]
-        public void Should_have_no_interaction_with_model()
-        {
-            var rec = model.ReceivedCalls();
-            Assert.False(rec.GetEnumerator().MoveNext());
-        }
-
-        [Fact]
-        public void Should_return_Nothing()
-        {
-            Assert.Equal(AckResult.Nothing, result);
-        }
-    }
 }

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_has_multiple_handlers.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_has_multiple_handlers.cs
@@ -47,7 +47,10 @@ namespace EasyNetQ.Tests.ConsumeTests
             Deliver(new MyOtherMessage { Text = "Hello Isomorphs!" });
             Deliver(new Dog());
 
-            countdownEvent.Wait(1000);
+            if (!countdownEvent.Wait(5000))
+            {
+                throw new TimeoutException();
+            }
         }
 
         public void Dispose()
@@ -55,7 +58,7 @@ namespace EasyNetQ.Tests.ConsumeTests
             mockBuilder.Bus.Dispose();
         }
 
-        void Deliver<T>(T message) where T : class
+        private void Deliver<T>(T message) where T : class
         {
             var body = new JsonSerializer().MessageToBytes(message);
             var properties = new BasicProperties
@@ -71,7 +74,7 @@ namespace EasyNetQ.Tests.ConsumeTests
                 "routing_key",
                 properties,
                 body
-                );
+            );
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_by_the_broker.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_by_the_broker.cs
@@ -20,14 +20,17 @@ namespace EasyNetQ.Tests.ConsumeTests
 
             var queue = new Queue("my_queue", false);
 
-            mockBuilder.Bus.Advanced.Consume(queue, (bytes, properties, arg3) => Task.Factory.StartNew(() => { }));
+            mockBuilder.Bus.Advanced.Consume(queue, (bytes, properties, arg3) => Task.Run(() => { }));
 
             var are = new AutoResetEvent(false);
             mockBuilder.EventBus.Subscribe<ConsumerModelDisposedEvent>(x => are.Set());
 
             mockBuilder.Consumers[0].HandleBasicCancel("consumer_tag");
 
-            are.WaitOne(500);
+            if (!are.WaitOne(5000))
+            {
+                throw new TimeoutException();
+            }
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_by_the_user.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_by_the_user.cs
@@ -22,14 +22,17 @@ namespace EasyNetQ.Tests.ConsumeTests
             var queue = new Queue("my_queue", false);
 
             var cancelSubscription = mockBuilder.Bus.Advanced
-                .Consume(queue, (bytes, properties, arg3) => Task.Factory.StartNew(() => { }));
+                .Consume(queue, (bytes, properties, arg3) => Task.Run(() => { }));
 
             var are = new AutoResetEvent(false);
             mockBuilder.EventBus.Subscribe<ConsumerModelDisposedEvent>(x => are.Set());
 
             cancelSubscription.Dispose();
 
-            are.WaitOne(500);
+            if (!are.WaitOne(5000))
+            {
+                throw new TimeoutException();
+            }
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_received.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_received.cs
@@ -59,6 +59,8 @@ namespace EasyNetQ.Tests.ConsumeTests
             };
             var body = Encoding.UTF8.GetBytes(message);
 
+            var autoResetEvent = new AutoResetEvent(false);
+            mockBuilder.EventBus.Subscribe<AckEvent>(x => autoResetEvent.Set());
             mockBuilder.Consumers[0].HandleBasicDeliver(
                 "consumer tag",
                 0,
@@ -68,17 +70,12 @@ namespace EasyNetQ.Tests.ConsumeTests
                 properties,
                 body
                 );
-
-            WaitForMessageDispatchToComplete();
-        }
-
-        private void WaitForMessageDispatchToComplete()
-        {
-            // wait for the subscription thread to handle the message ...
-            var autoResetEvent = new AutoResetEvent(false);
-            mockBuilder.EventBus.Subscribe<AckEvent>(x => autoResetEvent.Set());
-            autoResetEvent.WaitOne(1000);
-        }        
+            
+            if (!autoResetEvent.WaitOne(5000))
+            {
+                throw new TimeoutException();
+            }
+        }       
     }
 }
 

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_polymorphic_message_is_delivered_to_the_consumer.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_polymorphic_message_is_delivered_to_the_consumer.cs
@@ -45,7 +45,10 @@ namespace EasyNetQ.Tests.ConsumeTests
                 body
                 );
 
-            are.WaitOne(1000);
+            if (!are.WaitOne(5000))
+            {
+                throw new TimeoutException();
+            }
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_an_error_occurs_in_the_message_handler.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_an_error_occurs_in_the_message_handler.cs
@@ -17,10 +17,7 @@ namespace EasyNetQ.Tests.ConsumeTests
                      .ReturnsForAnyArgs(AckStrategies.Ack);
 
             exception = new Exception("I've had a bad day :(");
-            StartConsumer((body, properties, info) =>
-                {
-                    throw exception;
-                });
+            StartConsumer((body, properties, info) => throw exception);
             DeliverMessage();
         }
 
@@ -32,10 +29,8 @@ namespace EasyNetQ.Tests.ConsumeTests
                                                            args.Info.DeliverTag == DeliverTag &&
                                                            args.Info.Exchange == "the_exchange" &&
                                                            args.Body == OriginalBody),
-                Arg.Is<Exception>(ex => ex.InnerException == exception));
-
-            ConsumerErrorStrategy.DidNotReceive()
-                .HandleConsumerCancelled(Arg.Any<ConsumerExecutionContext>());
+                Arg.Is<Exception>(e => e == exception)
+            );
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_cancellation_of_message_handler_occurs.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_cancellation_of_message_handler_occurs.cs
@@ -30,8 +30,6 @@ namespace EasyNetQ.Tests.ConsumeTests
                                                         args.Info.DeliverTag == DeliverTag &&
                                                         args.Info.Exchange == "the_exchange" &&
                                                         args.Body == OriginalBody));
-
-            ConsumerErrorStrategy.DidNotReceive().HandleConsumerError(Arg.Any<ConsumerExecutionContext>(), Arg.Any<Exception>());
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/ConventionsTests.cs
+++ b/Source/EasyNetQ.Tests/ConventionsTests.cs
@@ -47,7 +47,7 @@ namespace EasyNetQ.Tests
         [Fact]
         public void The_default_error_queue_name_should_be()
         {
-            var result = conventions.ErrorQueueNamingConvention();
+            var result = conventions.ErrorQueueNamingConvention(new MessageReceivedInfo());
             result.Should().Be("EasyNetQ_Default_Error_Queue");
         }
 

--- a/Source/EasyNetQ.Tests/EventBusTests.cs
+++ b/Source/EasyNetQ.Tests/EventBusTests.cs
@@ -1,5 +1,6 @@
 ﻿// ReSharper disable InconsistentNaming
 
+using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Xunit;
@@ -55,12 +56,12 @@ namespace EasyNetQ.Tests
         {
             var stringsPublished = new List<string>();
 
-            var cancelSubscription = eventBus.Subscribe<string>(stringsPublished.Add);
-            cancelSubscription.Should().NotBeNull();
+            var subscription = eventBus.Subscribe<string>(stringsPublished.Add);
+            subscription.Should().NotBeNull();
 
             eventBus.Publish("Before cancellation");
 
-            cancelSubscription();
+            subscription.Dispose();
 
             eventBus.Publish("Hello World");
 
@@ -94,11 +95,11 @@ namespace EasyNetQ.Tests
         {
             Event1 eventFromSubscription = null;
 
-            CancelSubscription cancelEvent = null;
+            IDisposable subscription = null;
 
-            cancelEvent = eventBus.Subscribe<Event1>(@event =>
+            subscription = eventBus.Subscribe<Event1>(@event =>
             {
-                cancelEvent();
+                subscription.Dispose();
                 eventFromSubscription = @event;
             });
 

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_cancelled.cs
@@ -1,12 +1,9 @@
 ﻿// ReSharper disable InconsistentNaming
 
 using System;
-using System.Data;
-using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.Consumer;
 using EasyNetQ.Events;
-using FluentAssertions;
 using Xunit;
 using RabbitMQ.Client;
 using NSubstitute;
@@ -19,40 +16,55 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
             {
                 CorrelationId = "correlation_id"
             };
-        private readonly MessageReceivedInfo messageInfo = new MessageReceivedInfo("consumer_tag", 123, false, "exchange", "routingKey", "queue");
+        private readonly MessageReceivedInfo messageInfo = new MessageReceivedInfo("consumer_tag", 42, false, "exchange", "routingKey", "queue");
         private readonly byte[] messageBody = new byte[0];
 
         private readonly IConsumerErrorStrategy consumerErrorStrategy;
         private readonly ConsumerExecutionContext context;
+        private readonly IModel channel;
 
         public When_a_user_handler_is_cancelled()
         {
             consumerErrorStrategy = Substitute.For<IConsumerErrorStrategy>();
-            var eventBus = new EventBus();
+            consumerErrorStrategy.HandleConsumerCancelled(null).ReturnsForAnyArgs(AckStrategies.Ack);
 
-            var handlerRunner = new HandlerRunner(consumerErrorStrategy, eventBus);
-
-            Func<byte[], MessageProperties, MessageReceivedInfo, Task> userHandler = (body, properties, info) => 
-                Task.Run(() => throw new OperationCanceledException());
+            var handlerRunner = new HandlerRunner(consumerErrorStrategy);
 
             var consumer = Substitute.For<IBasicConsumer>();
-            var channel = Substitute.For<IModel>();
+            channel = Substitute.For<IModel>();
             consumer.Model.Returns(channel);
 
-            context = new ConsumerExecutionContext(userHandler, messageInfo, messageProperties, messageBody, consumer);
+            context = new ConsumerExecutionContext(
+                async (body, properties, info) => throw new OperationCanceledException(),
+                messageInfo,
+                messageProperties,
+                messageBody
+            );
 
-            var autoResetEvent = new AutoResetEvent(false);
-            eventBus.Subscribe<AckEvent>(x => autoResetEvent.Set());
+            var handlerTask = handlerRunner.InvokeUserMessageHandlerAsync(context)
+                .ContinueWith(async x =>
+                {
+                    var ackStrategy = await x.ConfigureAwait(false);
+                    return ackStrategy(channel, 42);
+                }, TaskContinuationOptions.ExecuteSynchronously)
+                .Unwrap();
 
-            handlerRunner.InvokeUserMessageHandler(context);
-
-            autoResetEvent.WaitOne(1000);
+            if (!handlerTask.Wait(5000))
+            {
+                throw new TimeoutException();
+            }
         }
-
+    
         [Fact]
         public void Should_handle_consumer_cancelled()
         {
             consumerErrorStrategy.Received().HandleConsumerCancelled(context);
+        }
+
+        [Fact]
+        public void Should_Ack()
+        {
+            channel.Received().BasicAck(42, false);
         }
     }
 }

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_failed.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_failed.cs
@@ -23,35 +23,50 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
 
         private readonly IConsumerErrorStrategy consumerErrorStrategy;
         private readonly ConsumerExecutionContext context;
+        private readonly IModel channel;
 
         public When_a_user_handler_is_failed()
         {
             consumerErrorStrategy = Substitute.For<IConsumerErrorStrategy>();
-            var eventBus = new EventBus();
+            consumerErrorStrategy.HandleConsumerError(null, null).ReturnsForAnyArgs(AckStrategies.Ack);
 
-            var handlerRunner = new HandlerRunner(consumerErrorStrategy, eventBus);
-
-            Func<byte[], MessageProperties, MessageReceivedInfo, Task> userHandler = (body, properties, info) => 
-                Task.Run(() => throw new Exception());
+            var handlerRunner = new HandlerRunner(consumerErrorStrategy);
 
             var consumer = Substitute.For<IBasicConsumer>();
-            var channel = Substitute.For<IModel>();
+            channel = Substitute.For<IModel>();
             consumer.Model.Returns(channel);
 
-            context = new ConsumerExecutionContext(userHandler, messageInfo, messageProperties, messageBody, consumer);
+            context = new ConsumerExecutionContext(
+                async (body, properties, info) => throw new Exception(),
+                messageInfo,
+                messageProperties,
+                messageBody
+            );
 
-            var autoResetEvent = new AutoResetEvent(false);
-            eventBus.Subscribe<AckEvent>(x => autoResetEvent.Set());
+            var handlerTask = handlerRunner.InvokeUserMessageHandlerAsync(context)
+                .ContinueWith(async x =>
+                {
+                    var ackStrategy = await x.ConfigureAwait(false);
+                    return ackStrategy(channel, 42);
+                }, TaskContinuationOptions.ExecuteSynchronously)
+                .Unwrap();
 
-            handlerRunner.InvokeUserMessageHandler(context);
-
-            autoResetEvent.WaitOne(1000);
+            if (!handlerTask.Wait(5000))
+            {
+                throw new TimeoutException();
+            }
         }
 
         [Fact]
         public void Should_handle_consumer_error()
         {
             consumerErrorStrategy.Received().HandleConsumerError(context, Arg.Any<Exception>());
+        }
+
+        [Fact]
+        public void Should_ACK()
+        {
+            channel.Received().BasicAck(42, false);
         }
     }
 }

--- a/Source/EasyNetQ.Tests/Integration/ConsumerErrorConditionsTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/ConsumerErrorConditionsTests.cs
@@ -66,7 +66,7 @@ namespace EasyNetQ.Tests
             var serializer = bus.Advanced.Container.Resolve<ISerializer>();
             var conventions = bus.Advanced.Container.Resolve<IConventions>();
 
-            var errorQueue = new Queue(conventions.ErrorQueueNamingConvention(), false);
+            var errorQueue = new Queue(conventions.ErrorQueueNamingConvention(new MessageReceivedInfo()), false);
             bus.Advanced.QueuePurge(errorQueue);
 
             var typeName = typeNameSerializer.Serialize(typeof(MyErrorTestMessage));

--- a/Source/EasyNetQ.Tests/Integration/DefaultConsumerErrorStrategyTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/DefaultConsumerErrorStrategyTests.cs
@@ -79,7 +79,7 @@ namespace EasyNetQ.Tests.Integration
             using(var connection = connectionFactory.CreateConnection())
             using(var model = connection.CreateModel())
             {
-                var getArgs = model.BasicGet(conventions.ErrorQueueNamingConvention(), true);
+                var getArgs = model.BasicGet(conventions.ErrorQueueNamingConvention(new MessageReceivedInfo()), true);
                 if (getArgs == null)
                 {
                     Assert.True(false, "Nothing on the error queue");

--- a/Source/EasyNetQ.Tests/Integration/DefaultConsumerErrorStrategyTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/DefaultConsumerErrorStrategyTests.cs
@@ -44,8 +44,8 @@ namespace EasyNetQ.Tests.Integration
                 serializer, 
                 conventions,
                 typeNameSerializer,
-                errorMessageSerializer);
-         
+                errorMessageSerializer
+            );
         }
 
         /// <summary>
@@ -67,9 +67,8 @@ namespace EasyNetQ.Tests.Integration
                     CorrelationId = "123",
                     AppId = "456"
                 },
-                originalMessageBody,
-                Substitute.For<IBasicConsumer>()
-                );
+                originalMessageBody
+            );
 
             consumerErrorStrategy.HandleConsumerError(context, exception);
 
@@ -115,9 +114,8 @@ namespace EasyNetQ.Tests.Integration
                     CorrelationId = "123",
                     AppId = "456"
                 },
-                originalMessageBody,
-                Substitute.For<IBasicConsumer>()
-                );
+                originalMessageBody
+            );
 
             connectionFactory = Substitute.For<IConnectionFactory>();
 

--- a/Source/EasyNetQ.Tests/Integration/SubscribeToErrorQueueSpike.cs
+++ b/Source/EasyNetQ.Tests/Integration/SubscribeToErrorQueueSpike.cs
@@ -41,7 +41,7 @@ namespace EasyNetQ.Tests.Integration
         [Explicit("Requires a RabbitMQ server on localhost")]
         public void Should_be_able_to_subscribe_to_error_messages()
         {
-            var errorQueueName = new Conventions(new DefaultTypeNameSerializer()).ErrorQueueNamingConvention();
+            var errorQueueName = new Conventions(new DefaultTypeNameSerializer()).ErrorQueueNamingConvention(new MessageReceivedInfo());
 
             var queue = bus.Advanced.QueueDeclare(errorQueueName);
             var autoResetEvent = new AutoResetEvent(false);

--- a/Source/EasyNetQ.Tests/SubscribeTests.cs
+++ b/Source/EasyNetQ.Tests/SubscribeTests.cs
@@ -234,9 +234,7 @@ namespace EasyNetQ.Tests
                 ConsumerTagConvention = () => consumerTag
             };
 
-            mockBuilder = new MockBuilder(x => x
-                .Register<IConventions>(conventions)
-                );
+            mockBuilder = new MockBuilder(x => x.Register<IConventions>(conventions));
 
             var autoResetEvent = new AutoResetEvent(false);
             mockBuilder.EventBus.Subscribe<AckEvent>(x => autoResetEvent.Set());
@@ -331,11 +329,7 @@ namespace EasyNetQ.Tests
                 .Register(consumerErrorStrategy)
                 );
 
-            mockBuilder.Bus.Subscribe<MyMessage>(subscriptionId, message =>
-            {
-                throw originalException;
-            });
-
+            mockBuilder.Bus.Subscribe<MyMessage>(subscriptionId, message => throw originalException);
 
             const string text = "Hello there, I am the text!";
             originalMessage = new MyMessage { Text = text };
@@ -382,9 +376,7 @@ namespace EasyNetQ.Tests
         [Fact]
         public void Should_pass_the_exception_to_consumerErrorStrategy()
         {
-            raisedException.Should().NotBeNull();
-            raisedException.InnerException.Should().NotBeNull();
-            raisedException.InnerException.Should().BeSameAs(originalException);
+            raisedException.Should().BeSameAs(originalException);
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
+++ b/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
@@ -20,7 +20,7 @@ namespace EasyNetQ.Tests
         {
             var customConventions = new Conventions(new DefaultTypeNameSerializer())
             {
-                ErrorQueueNamingConvention = () => "CustomEasyNetQErrorQueueName",
+                ErrorQueueNamingConvention = info => "CustomEasyNetQErrorQueueName",
                 ErrorExchangeNamingConvention = info => "CustomErrorExchangePrefixName." + info.RoutingKey
             };
 

--- a/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
+++ b/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
@@ -31,7 +31,8 @@ namespace EasyNetQ.Tests
                 new JsonSerializer(), 
                 customConventions,
                 new DefaultTypeNameSerializer(),
-                new DefaultErrorMessageSerializer());
+                new DefaultErrorMessageSerializer()
+            );
 
             const string originalMessage = "";
             var originalMessageBody = Encoding.UTF8.GetBytes(originalMessage);
@@ -44,8 +45,7 @@ namespace EasyNetQ.Tests
                     CorrelationId = string.Empty,
                     AppId = string.Empty
                 },
-                originalMessageBody,
-                Substitute.For<IBasicConsumer>()
+                originalMessageBody
             );
 
             try

--- a/Source/EasyNetQ/Consumer/AckStrategies.cs
+++ b/Source/EasyNetQ/Consumer/AckStrategies.cs
@@ -10,6 +10,5 @@ namespace EasyNetQ.Consumer
         public static AckStrategy Ack = (model, tag) => { model.BasicAck(tag, false); return AckResult.Ack; };
         public static AckStrategy NackWithoutRequeue = (model, tag) => { model.BasicNack(tag, false, false); return AckResult.Nack; };
         public static AckStrategy NackWithRequeue = (model, tag) => { model.BasicNack(tag, false, true); return AckResult.Nack; };
-        public static AckStrategy Nothing = (model, tag) => AckResult.Nothing; 
     }
 }

--- a/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
@@ -19,8 +19,7 @@ namespace EasyNetQ.Consumer
 
             var thread = new Thread(_ =>
             {
-                Action action;
-                while (!disposed && queue.TryTake(out action, -1))
+                while (!disposed && queue.TryTake(out var action, -1))
                 {
                     try
                     {
@@ -45,8 +44,7 @@ namespace EasyNetQ.Consumer
         {
             // throw away any queued actions. RabbitMQ will redeliver any in-flight
             // messages that have not been acked when the connection is lost.
-            Action result;
-            while (queue.TryTake(out result))
+            while (queue.TryTake(out _))
             {
             }
         }

--- a/Source/EasyNetQ/Consumer/ConsumerExecutionContext.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerExecutionContext.cs
@@ -10,26 +10,23 @@ namespace EasyNetQ.Consumer
         public MessageReceivedInfo Info { get; }
         public MessageProperties Properties { get; }
         public byte[] Body { get; }
-        public IBasicConsumer Consumer { get; }
 
         public ConsumerExecutionContext(
             Func<byte[], MessageProperties, MessageReceivedInfo, Task> userHandler, 
             MessageReceivedInfo info, 
             MessageProperties properties, 
-            byte[] body, 
-            IBasicConsumer consumer)
+            byte[] body
+        )
         {
             Preconditions.CheckNotNull(userHandler, "userHandler");
             Preconditions.CheckNotNull(info, "info");
             Preconditions.CheckNotNull(properties, "properties");
             Preconditions.CheckNotNull(body, "body");
-            Preconditions.CheckNotNull(consumer, "consumer");
 
             UserHandler = userHandler;
             Info = info;
             Properties = properties;
             Body = body;
-            Consumer = consumer;
         }
     }
 }

--- a/Source/EasyNetQ/Consumer/ExclusiveConsumer.cs
+++ b/Source/EasyNetQ/Consumer/ExclusiveConsumer.cs
@@ -1,15 +1,17 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.Events;
+using EasyNetQ.Internals;
 using EasyNetQ.Topology;
 
 namespace EasyNetQ.Consumer
 {
     public class ExclusiveConsumer : IConsumer
     {
+        private static readonly TimeSpan RestartConsumingPeriod = TimeSpan.FromSeconds(10);
+        
         private readonly object syncLock = new object();
         private volatile bool isStarted;
 
@@ -23,7 +25,7 @@ namespace EasyNetQ.Consumer
   
         private readonly ConcurrentDictionary<IInternalConsumer, object> internalConsumers = new ConcurrentDictionary<IInternalConsumer, object>();
 
-        private readonly IList<CancelSubscription> eventCancellations = new List<CancelSubscription>();
+        private readonly IList<IDisposable> disposables = new List<IDisposable>();
 
         public ExclusiveConsumer(
             IQueue queue,
@@ -32,7 +34,7 @@ namespace EasyNetQ.Consumer
             IConsumerConfiguration configuration,
             IInternalConsumerFactory internalConsumerFactory,
             IEventBus eventBus
-            )
+        )
         {
             Preconditions.CheckNotNull(queue, "queue");
             Preconditions.CheckNotNull(onMessage, "onMessage");
@@ -47,32 +49,20 @@ namespace EasyNetQ.Consumer
             this.configuration = configuration;
             this.internalConsumerFactory = internalConsumerFactory;
             this.eventBus = eventBus;
-#if !NETFX
-            timer = new Timer(s =>
-                {
-                    StartConsumer();
-                    timer.Change(10000, -1);
-                }, null, 10000, Timeout.Infinite);
-#else
-            timer = new Timer(s =>
-                {
-                    StartConsumer();
-                    ((Timer)s).Change(10000, -1);
-                });
-
-             timer.Change(10000, -1);
-#endif
         }
 
         public IDisposable StartConsuming()
         {
-            eventCancellations.Add(eventBus.Subscribe<ConnectionCreatedEvent>(e => ConnectionOnConnected()));
-            eventCancellations.Add(eventBus.Subscribe<ConnectionDisconnectedEvent>(e => ConnectionOnDisconnected()));
-            StartConsumer();
+            disposables.Add(eventBus.Subscribe<ConnectionCreatedEvent>(e => ConnectionOnConnected()));
+            disposables.Add(eventBus.Subscribe<ConnectionDisconnectedEvent>(e => ConnectionOnDisconnected()));
+            disposables.Add(Timers.Start(s => StartConsumingInternal(), RestartConsumingPeriod, RestartConsumingPeriod));
+            
+            StartConsumingInternal();
+            
             return new ConsumerCancellation(Dispose);   
         }
 
-        private void StartConsumer()
+        private void StartConsumingInternal()
         {
             if (disposed)
                 return;
@@ -83,6 +73,7 @@ namespace EasyNetQ.Consumer
             {
                 if (isStarted)
                     return;
+                
                 var internalConsumer = internalConsumerFactory.CreateConsumer();
                 internalConsumers.TryAdd(internalConsumer, null);
                 internalConsumer.Cancelled += consumer => Dispose();
@@ -94,10 +85,9 @@ namespace EasyNetQ.Consumer
                 }
                 else
                 {
-                    eventBus.Publish(new StartConsumingFailedEvent(this, queue));
                     internalConsumer.Dispose();
-                    object value;
-                    internalConsumers.TryRemove(internalConsumer, out value);
+                    internalConsumers.TryRemove(internalConsumer, out _);
+                    eventBus.Publish(new StartConsumingFailedEvent(this, queue));
                 }
             }
         }
@@ -114,23 +104,25 @@ namespace EasyNetQ.Consumer
 
         private void ConnectionOnConnected()
         {
-            StartConsumer();
+            StartConsumingInternal();
         }
 
         private bool disposed;
-        private readonly Timer timer;
 
         public void Dispose()
         {
             if (disposed)
                 return;
+            
             disposed = true;
-            timer.Dispose();
+            
             eventBus.Publish(new StoppedConsumingEvent(this));
-            foreach (var cancelSubscription in eventCancellations)
+            
+            foreach (var disposal in disposables)
             {
-                cancelSubscription();
+                disposal.Dispose();
             }
+            
             foreach (var internalConsumer in internalConsumers.Keys)
             {
                 internalConsumer.Dispose();

--- a/Source/EasyNetQ/Consumer/HandlerRunner.cs
+++ b/Source/EasyNetQ/Consumer/HandlerRunner.cs
@@ -11,117 +11,103 @@ namespace EasyNetQ.Consumer
 {
     public interface IHandlerRunner : IDisposable
     {
-        void InvokeUserMessageHandler(ConsumerExecutionContext context);
+        Task<AckStrategy> InvokeUserMessageHandlerAsync(ConsumerExecutionContext context);
     }
 
     public class HandlerRunner : IHandlerRunner
     {
         private readonly ILog logger = LogProvider.For<HandlerRunner>();
         private readonly IConsumerErrorStrategy consumerErrorStrategy;
-        private readonly IEventBus eventBus;
 
-        public HandlerRunner(IConsumerErrorStrategy consumerErrorStrategy, IEventBus eventBus)
+        public HandlerRunner(IConsumerErrorStrategy consumerErrorStrategy)
         {
             Preconditions.CheckNotNull(consumerErrorStrategy, "consumerErrorStrategy");
-            Preconditions.CheckNotNull(eventBus, "eventBus");
 
             this.consumerErrorStrategy = consumerErrorStrategy;
-            this.eventBus = eventBus;
         }
 
-        public virtual void InvokeUserMessageHandler(ConsumerExecutionContext context)
+        public virtual async Task<AckStrategy> InvokeUserMessageHandlerAsync(ConsumerExecutionContext context)
         {
             Preconditions.CheckNotNull(context, "context");
 
-            logger.DebugFormat("Received message with receivedInfo={receivedInfo}", context.Info);
+            if (logger.IsDebugEnabled())
+            {
+                logger.DebugFormat("Received message with receivedInfo={receivedInfo}", context.Info);
+            }
 
-            Task completionTask;
+            var ackStrategy = await InvokeUserMessageHandlerInternalAsync(context).ConfigureAwait(false);
             
-            try
+            return (model, tag) =>
             {
-                completionTask = context.UserHandler(context.Body, context.Properties, context.Info);
-            }
-            catch (Exception exception)
-            {
-                completionTask = TaskHelpers.FromException(exception);
-            }
-            
-            completionTask.ContinueWith(task => DoAck(context, GetAckStrategy(context, task)));
+                try
+                {
+                    return ackStrategy(model, tag);
+                }
+                catch (AlreadyClosedException alreadyClosedException)
+                {
+                    logger.Info(
+                        alreadyClosedException,
+                        "Failed to ACK or NACK, message will be retried, receivedInfo={receivedInfo}",
+                        context.Info
+                    );
+                }
+                catch (IOException ioException)
+                {
+                    logger.Info(
+                        ioException,
+                        "Failed to ACK or NACK, message will be retried, receivedInfo={receivedInfo}",
+                        context.Info
+                    );
+                }
+                catch (Exception exception)
+                {
+                    logger.Error(
+                        exception, 
+                        "Unexpected exception when attempting to ACK or NACK, receivedInfo={receivedInfo}",
+                        context.Info
+                    );
+                }
+                
+                return AckResult.Exception;
+            };
         }
 
-        protected virtual AckStrategy GetAckStrategy(ConsumerExecutionContext context, Task task)
+        private async Task<AckStrategy> InvokeUserMessageHandlerInternalAsync(ConsumerExecutionContext context)
         {
             try
             {
-                if (task.IsFaulted)
+                try
+                {
+                    await context.UserHandler(context.Body, context.Properties, context.Info).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    return consumerErrorStrategy.HandleConsumerCancelled(context);
+                }
+                catch (Exception exception)
                 {
                     logger.Error(
-                        task.Exception,
-                        "Exception thrown by subscription callback, receivedInfo={receivedInfo}, properties={properties}, message={message}", 
+                        exception,
+                        "Exception thrown by subscription callback, receivedInfo={receivedInfo}, properties={properties}, message={message}",
                         context.Info,
                         context.Properties,
                         Convert.ToBase64String(context.Body)
                     );
-                    return consumerErrorStrategy.HandleConsumerError(context, task.Exception);
+                    return consumerErrorStrategy.HandleConsumerError(context, exception);
                 }
-
-                if (task.IsCanceled)
-                {
-                    return consumerErrorStrategy.HandleConsumerCancelled(context);
-                }
-
-                return AckStrategies.Ack;
             }
             catch (Exception exception)
             {
                 logger.Error(exception, "Consumer error strategy has failed");
                 return AckStrategies.NackWithRequeue;
             }
-        }
 
-        protected virtual void DoAck(ConsumerExecutionContext context, AckStrategy ackStrategy)
-        {
-            var ackResult = AckResult.Exception;
-
-            try
-            {
-                Preconditions.CheckNotNull(context.Consumer.Model, "context.Consumer.Model");
-
-                ackResult = ackStrategy(context.Consumer.Model, context.Info.DeliverTag);
-            }
-            catch (AlreadyClosedException alreadyClosedException)
-            {
-                logger.Info(
-                    alreadyClosedException,
-                    "Failed to ACK or NACK, message will be retried, receivedInfo={receivedInfo}",
-                    context.Info
-                );
-            }
-            catch (IOException ioException)
-            {
-                logger.Info(
-                    ioException,
-                    "Failed to ACK or NACK, message will be retried, receivedInfo={receivedInfo}",
-                    context.Info
-                );
-            }
-            catch (Exception exception)
-            {
-                logger.Error(
-                    exception, 
-                    "Unexpected exception when attempting to ACK or NACK, receivedInfo={receivedInfo}",
-                    context.Info
-                );
-            }
-            finally
-            {
-                eventBus.Publish(new AckEvent(context.Info, context.Properties, context.Body, ackResult));
-            }
+            return AckStrategies.Ack;
         }
 
         public void Dispose()
         {
-            consumerErrorStrategy?.Dispose();
+            consumerErrorStrategy.Dispose();
         }
     }
 }

--- a/Source/EasyNetQ/Consumer/IConsumerFactory.cs
+++ b/Source/EasyNetQ/Consumer/IConsumerFactory.cs
@@ -8,13 +8,13 @@ namespace EasyNetQ.Consumer
     public interface IConsumerFactory : IDisposable
     {
         IConsumer CreateConsumer(
-            ICollection<Tuple<IQueue, Func<Byte[], MessageProperties, MessageReceivedInfo, Task>>> queueConsumerPairs,
+            ICollection<Tuple<IQueue, Func<byte[], MessageProperties, MessageReceivedInfo, Task>>> queueConsumerPairs,
             IPersistentConnection connection,
             IConsumerConfiguration configuration);
 
         IConsumer CreateConsumer(
             IQueue queue, 
-            Func<Byte[], MessageProperties, MessageReceivedInfo, Task> onMessage, 
+            Func<byte[], MessageProperties, MessageReceivedInfo, Task> onMessage, 
             IPersistentConnection connection,
             IConsumerConfiguration configuration
             );

--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -148,12 +148,9 @@ namespace EasyNetQ.Consumer
         private readonly IConsumerDispatcher consumerDispatcher;
         private readonly IConventions conventions;
         private readonly IEventBus eventBus;
-
         private ICollection<BasicConsumer> basicConsumers;
 
         public IModel Model { get; private set; }
-        public event EventHandler<ConsumerEventArgs> ConsumerCancelled;
-
 
         public event Action<IInternalConsumer> Cancelled;
 

--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -18,13 +18,13 @@ namespace EasyNetQ.Consumer
             IQueue queue,
             Func<byte[], MessageProperties, MessageReceivedInfo, Task> onMessage,
             IConsumerConfiguration configuration
-            );
+        );
 
         StartConsumingStatus StartConsuming(
             IPersistentConnection connection,
             ICollection<Tuple<IQueue, Func<byte[], MessageProperties, MessageReceivedInfo, Task>>> queueConsumerPairs,
             IConsumerConfiguration configuration
-            );
+        );
 
         event Action<IInternalConsumer> Cancelled;
     }
@@ -100,7 +100,10 @@ namespace EasyNetQ.Consumer
         
         public void HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, IBasicProperties properties, byte[] body)
         {
-            logger.DebugFormat("Message delivered to consumer {consumerTag} with deliveryTag {deliveryTag}", consumerTag, deliveryTag);
+            if (logger.IsDebugEnabled())
+            {
+                logger.DebugFormat("Message delivered to consumer {consumerTag} with deliveryTag {deliveryTag}", consumerTag, deliveryTag);
+            }
 
             if (disposed)
             {
@@ -116,16 +119,22 @@ namespace EasyNetQ.Consumer
 
             var messageReceivedInfo = new MessageReceivedInfo(consumerTag, deliveryTag, redelivered, exchange, routingKey, Queue.Name);
             var messsageProperties = new MessageProperties(properties);
-            var context = new ConsumerExecutionContext(OnMessage, messageReceivedInfo, messsageProperties, body, this);
+            var context = new ConsumerExecutionContext(OnMessage, messageReceivedInfo, messsageProperties, body);
 
-            consumerDispatcher.QueueAction(() =>
-            {
-                eventBus.Publish(new DeliveredMessageEvent(messageReceivedInfo, messsageProperties, body));
-                handlerRunner.InvokeUserMessageHandler(context);
-            });
+            eventBus.Publish(new DeliveredMessageEvent(messageReceivedInfo, messsageProperties, body));
+            handlerRunner.InvokeUserMessageHandlerAsync(context)
+                         .ContinueWith(async x =>
+                            {
+                                var ackStrategy = await x.ConfigureAwait(false);
+                                consumerDispatcher.QueueAction(() =>
+                                {
+                                    var ackResult = ackStrategy(Model, deliveryTag);
+                                    eventBus.Publish(new AckEvent(messageReceivedInfo, messsageProperties, body, ackResult));
+                                });
+                            },
+                            TaskContinuationOptions.ExecuteSynchronously
+                         );
         }
-
-        
 
         public IModel Model { get; }
         public event EventHandler<ConsumerEventArgs> ConsumerCancelled;
@@ -284,8 +293,7 @@ namespace EasyNetQ.Consumer
                     consumerTag,
                     queue.Name,
                     configuration
-                );
-                
+                );                
                 
                 return StartConsumingStatus.Succeed;
             }

--- a/Source/EasyNetQ/Consumer/TransientConsumer.cs
+++ b/Source/EasyNetQ/Consumer/TransientConsumer.cs
@@ -8,7 +8,7 @@ namespace EasyNetQ.Consumer
     public class TransientConsumer : IConsumer
     {
         private readonly IQueue queue;
-        private readonly Func<Byte[], MessageProperties, MessageReceivedInfo, Task> onMessage;
+        private readonly Func<byte[], MessageProperties, MessageReceivedInfo, Task> onMessage;
         private readonly IPersistentConnection connection;
         private readonly IConsumerConfiguration configuration;
         private readonly IInternalConsumerFactory internalConsumerFactory;
@@ -22,7 +22,8 @@ namespace EasyNetQ.Consumer
             IPersistentConnection connection, 
             IConsumerConfiguration configuration,
             IInternalConsumerFactory internalConsumerFactory, 
-            IEventBus eventBus)
+            IEventBus eventBus
+        )
         {
             Preconditions.CheckNotNull(queue, "queue");
             Preconditions.CheckNotNull(onMessage, "onMessage");
@@ -49,7 +50,8 @@ namespace EasyNetQ.Consumer
                 connection,
                 queue,
                 onMessage,
-                configuration);
+                configuration
+            );
 
             if (status == StartConsumingStatus.Succeed)
                 eventBus.Publish(new StartConsumingSucceededEvent(this, queue));
@@ -67,10 +69,8 @@ namespace EasyNetQ.Consumer
             disposed = true;
 
             eventBus.Publish(new StoppedConsumingEvent(this));
-            if (internalConsumer != null)
-            {
-                internalConsumer.Dispose();
-            }
+            
+            internalConsumer?.Dispose();
         }
     }
 }

--- a/Source/EasyNetQ/Conventions.cs
+++ b/Source/EasyNetQ/Conventions.cs
@@ -8,7 +8,7 @@ namespace EasyNetQ
     public delegate string QueueNameConvention(Type messageType, string subscriberId);
     public delegate string RpcRoutingKeyNamingConvention(Type messageType);
 
-    public delegate string ErrorQueueNameConvention();
+    public delegate string ErrorQueueNameConvention(MessageReceivedInfo info);
     public delegate string ErrorExchangeNameConvention(MessageReceivedInfo info);
     public delegate string RpcExchangeNameConvention(Type messageType);
 
@@ -70,7 +70,7 @@ namespace EasyNetQ
 					};
             RpcRoutingKeyNamingConvention = typeNameSerializer.Serialize;
 
-            ErrorQueueNamingConvention = () => "EasyNetQ_Default_Error_Queue";
+            ErrorQueueNamingConvention = info => "EasyNetQ_Default_Error_Queue";
 		    ErrorExchangeNamingConvention = info => "ErrorExchange_" + info.RoutingKey;
             RpcRequestExchangeNamingConvention = (type) => "easy_net_q_rpc";
 		    RpcResponseExchangeNamingConvention = (type) => "easy_net_q_rpc";

--- a/Source/EasyNetQ/Events/AckEvent.cs
+++ b/Source/EasyNetQ/Events/AckEvent.cs
@@ -20,7 +20,6 @@
     {
         Ack,
         Nack,
-        Exception,
-        Nothing
+        Exception
     }
 }

--- a/Source/EasyNetQ/Extensions.cs
+++ b/Source/EasyNetQ/Extensions.cs
@@ -7,11 +7,6 @@ namespace EasyNetQ
 {
     public static class Extensions
     {
-        public static TimeSpan Double(this TimeSpan timeSpan)
-        {
-            return timeSpan + timeSpan;
-        }
-
         public static void Remove<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> source, TKey key)
         {
             ((IDictionary<TKey, TValue>) source).Remove(key);

--- a/Source/EasyNetQ/Interception/RawMessage.cs
+++ b/Source/EasyNetQ/Interception/RawMessage.cs
@@ -1,6 +1,6 @@
 ﻿namespace EasyNetQ.Interception
 {
-    public class RawMessage
+    public struct RawMessage
     {
         public RawMessage(MessageProperties properties, byte[] body)
         {

--- a/Source/EasyNetQ/Internals/Timers.cs
+++ b/Source/EasyNetQ/Internals/Timers.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Threading;
+
+namespace EasyNetQ.Internals
+{
+    //https://stackoverflow.com/questions/4962172/why-does-a-system-timers-timer-survive-gc-but-not-system-threading-timer
+    public static class Timers
+    {
+        public static IDisposable Start(TimerCallback callback, TimeSpan dueTime, TimeSpan period)
+        {
+            var callbackLock = new object();
+            var timer = new Timer(state =>
+            {
+                if (!Monitor.TryEnter(callbackLock)) return;
+                try
+                {
+                    callback.Invoke(state);
+                }
+                finally
+                {
+                    Monitor.Exit(callbackLock);
+                }
+            });
+            timer.Change(dueTime, period);
+            return timer;
+        }
+
+        public static void RunOnce(TimerCallback callback, TimeSpan dueTime)
+        {
+            var timer = new Timer(state =>
+            {
+                ((Timer) state).Dispose();
+                callback(state);
+            });
+            timer.Change(dueTime, Timeout.InfiniteTimeSpan);
+        }
+    }
+}

--- a/Source/EasyNetQ/TimeBudget.cs
+++ b/Source/EasyNetQ/TimeBudget.cs
@@ -1,36 +1,52 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Threading;
 
 namespace EasyNetQ
 {
     public sealed class TimeBudget
-    {
+    {   
+        private static readonly TimeSpan Precision = TimeSpan.FromMilliseconds(1);
+        
         private readonly TimeSpan budget;
-        private readonly TimeSpan precision;
         private readonly Stopwatch watch;
 
-        private TimeBudget(Stopwatch watch, TimeSpan budget, TimeSpan precision)
+        private TimeBudget(Stopwatch watch, TimeSpan budget)
         {
             this.watch = watch;
             this.budget = budget;
-            this.precision = precision;
+        }
+
+        public static TimeBudget Infinite()
+        {
+            return new TimeBudget(Stopwatch.StartNew(), Timeout.InfiniteTimeSpan);
         }
 
         public static TimeBudget Start(TimeSpan budget)
         {
-            return new TimeBudget(Stopwatch.StartNew(), budget, TimeSpan.FromMilliseconds(1));
+            return new TimeBudget(Stopwatch.StartNew(), budget);
         }
 
         public bool IsExpired()
         {
+            if (budget == Timeout.InfiniteTimeSpan)
+            {
+                return false;
+            }
+
             var remaining = budget - watch.Elapsed;
-            return remaining < precision;
+            return remaining < Precision;
         }
 
         public static implicit operator TimeSpan(TimeBudget source)
         {
+            if (source.budget == Timeout.InfiniteTimeSpan)
+            {
+                return Timeout.InfiniteTimeSpan;
+            }
+
             var remaining = source.budget - source.watch.Elapsed;
-            return remaining < source.precision ? TimeSpan.Zero : remaining;
+            return remaining < Precision ? TimeSpan.Zero : remaining;
         }
     }
 }


### PR DESCRIPTION
* [X] [Remove AckStrategy.Nothing](https://github.com/EasyNetQ/EasyNetQ/pull/825)
* [X] [Allow to use MessageReceivedInfo for custom ErrorQueueNaming convention](https://github.com/EasyNetQ/EasyNetQ/pull/824)
* [X] [Ack on model should be called from Consumer Dispatcher Thread](https://github.com/EasyNetQ/EasyNetQ/pull/826)
* [X] [Simplify usages of timer and change disposal of IEventBus's subscription](https://github.com/EasyNetQ/EasyNetQ/pull/830)
* [X] [Limit retryTimeoutMs to MaxRetryTimeoutMs](https://github.com/EasyNetQ/EasyNetQ/pull/831)