### PR TITLE
Simplify usages of timer and change disposal of IEventBus's subscription

### DIFF
--- a/Source/EasyNetQ.Tests/EventBusTests.cs
+++ b/Source/EasyNetQ.Tests/EventBusTests.cs
@@ -1,5 +1,6 @@
 ﻿// ReSharper disable InconsistentNaming
 
+using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Xunit;
@@ -55,12 +56,12 @@ namespace EasyNetQ.Tests
         {
             var stringsPublished = new List<string>();
 
-            var cancelSubscription = eventBus.Subscribe<string>(stringsPublished.Add);
-            cancelSubscription.Should().NotBeNull();
+            var subscription = eventBus.Subscribe<string>(stringsPublished.Add);
+            subscription.Should().NotBeNull();
 
             eventBus.Publish("Before cancellation");
 
-            cancelSubscription();
+            subscription.Dispose();
 
             eventBus.Publish("Hello World");
 
@@ -94,11 +95,11 @@ namespace EasyNetQ.Tests
         {
             Event1 eventFromSubscription = null;
 
-            CancelSubscription cancelEvent = null;
+            IDisposable subscription = null;
 
-            cancelEvent = eventBus.Subscribe<Event1>(@event =>
+            subscription = eventBus.Subscribe<Event1>(@event =>
             {
-                cancelEvent();
+                subscription.Dispose();
                 eventFromSubscription = @event;
             });
 

--- a/Source/EasyNetQ/Consumer/ExclusiveConsumer.cs
+++ b/Source/EasyNetQ/Consumer/ExclusiveConsumer.cs
@@ -1,15 +1,17 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.Events;
+using EasyNetQ.Internals;
 using EasyNetQ.Topology;
 
 namespace EasyNetQ.Consumer
 {
     public class ExclusiveConsumer : IConsumer
     {
+        private static readonly TimeSpan RestartConsumingPeriod = TimeSpan.FromSeconds(10);
+        
         private readonly object syncLock = new object();
         private volatile bool isStarted;
 
@@ -23,7 +25,7 @@ namespace EasyNetQ.Consumer
   
         private readonly ConcurrentDictionary<IInternalConsumer, object> internalConsumers = new ConcurrentDictionary<IInternalConsumer, object>();
 
-        private readonly IList<CancelSubscription> eventCancellations = new List<CancelSubscription>();
+        private readonly IList<IDisposable> disposables = new List<IDisposable>();
 
         public ExclusiveConsumer(
             IQueue queue,
@@ -32,7 +34,7 @@ namespace EasyNetQ.Consumer
             IConsumerConfiguration configuration,
             IInternalConsumerFactory internalConsumerFactory,
             IEventBus eventBus
-            )
+        )
         {
             Preconditions.CheckNotNull(queue, "queue");
             Preconditions.CheckNotNull(onMessage, "onMessage");
@@ -47,32 +49,20 @@ namespace EasyNetQ.Consumer
             this.configuration = configuration;
             this.internalConsumerFactory = internalConsumerFactory;
             this.eventBus = eventBus;
-#if !NETFX
-            timer = new Timer(s =>
-                {
-                    StartConsumer();
-                    timer.Change(10000, -1);
-                }, null, 10000, Timeout.Infinite);
-#else
-            timer = new Timer(s =>
-                {
-                    StartConsumer();
-                    ((Timer)s).Change(10000, -1);
-                });
-
-             timer.Change(10000, -1);
-#endif
         }
 
         public IDisposable StartConsuming()
         {
-            eventCancellations.Add(eventBus.Subscribe<ConnectionCreatedEvent>(e => ConnectionOnConnected()));
-            eventCancellations.Add(eventBus.Subscribe<ConnectionDisconnectedEvent>(e => ConnectionOnDisconnected()));
-            StartConsumer();
+            disposables.Add(eventBus.Subscribe<ConnectionCreatedEvent>(e => ConnectionOnConnected()));
+            disposables.Add(eventBus.Subscribe<ConnectionDisconnectedEvent>(e => ConnectionOnDisconnected()));
+            disposables.Add(Timers.Start(s => StartConsumingInternal(), RestartConsumingPeriod, RestartConsumingPeriod));
+            
+            StartConsumingInternal();
+            
             return new ConsumerCancellation(Dispose);   
         }
 
-        private void StartConsumer()
+        private void StartConsumingInternal()
         {
             if (disposed)
                 return;
@@ -83,6 +73,7 @@ namespace EasyNetQ.Consumer
             {
                 if (isStarted)
                     return;
+                
                 var internalConsumer = internalConsumerFactory.CreateConsumer();
                 internalConsumers.TryAdd(internalConsumer, null);
                 internalConsumer.Cancelled += consumer => Dispose();
@@ -94,10 +85,9 @@ namespace EasyNetQ.Consumer
                 }
                 else
                 {
-                    eventBus.Publish(new StartConsumingFailedEvent(this, queue));
                     internalConsumer.Dispose();
-                    object value;
-                    internalConsumers.TryRemove(internalConsumer, out value);
+                    internalConsumers.TryRemove(internalConsumer, out _);
+                    eventBus.Publish(new StartConsumingFailedEvent(this, queue));
                 }
             }
         }
@@ -114,23 +104,25 @@ namespace EasyNetQ.Consumer
 
         private void ConnectionOnConnected()
         {
-            StartConsumer();
+            StartConsumingInternal();
         }
 
         private bool disposed;
-        private readonly Timer timer;
 
         public void Dispose()
         {
             if (disposed)
                 return;
+            
             disposed = true;
-            timer.Dispose();
+            
             eventBus.Publish(new StoppedConsumingEvent(this));
-            foreach (var cancelSubscription in eventCancellations)
+            
+            foreach (var disposal in disposables)
             {
-                cancelSubscription();
+                disposal.Dispose();
             }
+            
             foreach (var internalConsumer in internalConsumers.Keys)
             {
                 internalConsumer.Dispose();

--- a/Source/EasyNetQ/Consumer/TransientConsumer.cs
+++ b/Source/EasyNetQ/Consumer/TransientConsumer.cs
@@ -8,7 +8,7 @@ namespace EasyNetQ.Consumer
     public class TransientConsumer : IConsumer
     {
         private readonly IQueue queue;
-        private readonly Func<Byte[], MessageProperties, MessageReceivedInfo, Task> onMessage;
+        private readonly Func<byte[], MessageProperties, MessageReceivedInfo, Task> onMessage;
         private readonly IPersistentConnection connection;
         private readonly IConsumerConfiguration configuration;
         private readonly IInternalConsumerFactory internalConsumerFactory;
@@ -22,7 +22,8 @@ namespace EasyNetQ.Consumer
             IPersistentConnection connection, 
             IConsumerConfiguration configuration,
             IInternalConsumerFactory internalConsumerFactory, 
-            IEventBus eventBus)
+            IEventBus eventBus
+        )
         {
             Preconditions.CheckNotNull(queue, "queue");
             Preconditions.CheckNotNull(onMessage, "onMessage");
@@ -49,7 +50,8 @@ namespace EasyNetQ.Consumer
                 connection,
                 queue,
                 onMessage,
-                configuration);
+                configuration
+            );
 
             if (status == StartConsumingStatus.Succeed)
                 eventBus.Publish(new StartConsumingSucceededEvent(this, queue));
@@ -67,10 +69,8 @@ namespace EasyNetQ.Consumer
             disposed = true;
 
             eventBus.Publish(new StoppedConsumingEvent(this));
-            if (internalConsumer != null)
-            {
-                internalConsumer.Dispose();
-            }
+            
+            internalConsumer?.Dispose();
         }
     }
 }

--- a/Source/EasyNetQ/Internals/Timers.cs
+++ b/Source/EasyNetQ/Internals/Timers.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Threading;
+
+namespace EasyNetQ.Internals
+{
+    //https://stackoverflow.com/questions/4962172/why-does-a-system-timers-timer-survive-gc-but-not-system-threading-timer
+    public static class Timers
+    {
+        public static IDisposable Start(TimerCallback callback, TimeSpan dueTime, TimeSpan period)
+        {
+            var callbackLock = new object();
+            var timer = new Timer(state =>
+            {
+                if (!Monitor.TryEnter(callbackLock)) return;
+                try
+                {
+                    callback.Invoke(state);
+                }
+                finally
+                {
+                    Monitor.Exit(callbackLock);
+                }
+            });
+            timer.Change(dueTime, period);
+            return timer;
+        }
+
+        public static void RunOnce(TimerCallback callback, TimeSpan dueTime)
+        {
+            var timer = new Timer(state =>
+            {
+                ((Timer) state).Dispose();
+                callback(state);
+            });
+            timer.Change(dueTime, Timeout.InfiniteTimeSpan);
+        }
+    }
+}


### PR DESCRIPTION
The goal of this PR was to fix #762, but there are several unrelated changes:

1. Return type of `IEventBus.Subsribe` was changed from `CancelSubscription` delegate to `IDisposable`.
2. Usage of `Timer` in `PersistentConnection` was refactored.
