### PR TITLE
Auto subscribe: Create nested container per message handled for StructureMap

### DIFF
--- a/Source/EasyNetQ.DI.StructureMap/StructureMapAdapter.cs
+++ b/Source/EasyNetQ.DI.StructureMap/StructureMapAdapter.cs
@@ -27,7 +27,7 @@ namespace EasyNetQ.DI.StructureMap
                     return this;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(lifetime), lifetime, null);
-            } 
+            }
         }
 
         public IServiceRegister Register<TService>(TService instance) where TService : class
@@ -37,7 +37,7 @@ namespace EasyNetQ.DI.StructureMap
         }
 
         public IServiceRegister Register<TService>(Func<IServiceResolver, TService> factory, Lifetime lifetime = Lifetime.Singleton) where TService : class
-        { 
+        {
             switch (lifetime)
             {
                 case Lifetime.Transient:
@@ -48,26 +48,38 @@ namespace EasyNetQ.DI.StructureMap
                     return this;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(lifetime), lifetime, null);
-            } 
+            }
         }
 
         private class StructureMapResolver : IServiceResolver
         {
-            private readonly IContainer container;
+            protected readonly IContainer Container;
 
             public StructureMapResolver(IContainer container)
             {
-                this.container = container;
+                this.Container = container;
             }
 
             public TService Resolve<TService>() where TService : class
             {
-                return container.GetInstance<TService>();
+                return Container.GetInstance<TService>();
             }
 
             public IServiceResolverScope CreateScope()
             {
-                return new ServiceResolverScope(this);
+                return new StructureMapResolverScope(Container.GetNestedContainer());
+            }
+        }
+
+        private class StructureMapResolverScope : StructureMapResolver, IServiceResolverScope
+        {
+            public StructureMapResolverScope(IContainer container) : base(container)
+            {
+            }
+
+            public void Dispose()
+            {
+                Container.Dispose();
             }
         }
     }

--- a/Source/EasyNetQ.DI.Tests/StructureMapDependencyScopeTests.cs
+++ b/Source/EasyNetQ.DI.Tests/StructureMapDependencyScopeTests.cs
@@ -1,0 +1,78 @@
+using System;
+using EasyNetQ.DI.StructureMap;
+using StructureMap;
+using Xunit;
+
+namespace EasyNetQ.DI.Tests
+{
+    public class StructureMapDependencyScopeTests
+    {
+        [Theory]
+        [InlineData(Lifetime.Transient, true)]
+        [InlineData(Lifetime.Singleton, false)]
+        public void CreateScope_TransientService_ShouldBeDisposed(Lifetime lifetime, bool shouldBeDisposed)
+        {
+            var resolver = CreateResolver(c => c.Register<IService, Service>(lifetime));
+
+            var service = ResolveFromScope(resolver);
+
+            Assert.Equal(shouldBeDisposed, service.Disposed);
+        }
+
+        [Fact]
+        public void CreateScope_TransientServiceInSameScope_ShouldBeSingleton()
+        {
+            var resolver = CreateResolver(c => c.Register<IService, Service>(Lifetime.Transient));
+
+            IService service1;
+            IService service2;
+            using (var scope = resolver.CreateScope())
+            {
+                service1 = scope.Resolve<IService>();
+                service2 = scope.Resolve<IService>();
+            }
+
+            Assert.Same(service1, service2);
+        }
+
+        [Fact]
+        public void CreateScope_TransientServiceInDifferentScopes_ShouldNotBeSame()
+        {
+            var resolver = CreateResolver(c => c.Register<IService, Service>(Lifetime.Transient));
+
+            var service1 = ResolveFromScope(resolver);
+            var service2 = ResolveFromScope(resolver);
+
+            Assert.NotSame(service1, service2);
+        }
+
+        private static IService ResolveFromScope(IServiceResolver resolver)
+        {
+            using (var scope = resolver.CreateScope())
+            {
+                return scope.Resolve<IService>();
+            }
+        }
+
+        private IServiceResolver CreateResolver(Action<IServiceRegister> configure)
+        {
+            var container = new Container(r => configure(new StructureMapAdapter(r)));
+            return container.GetInstance<IServiceResolver>();
+        }
+
+        private interface IService : IDisposable
+        {
+            bool Disposed { get; set; }
+        }
+
+        private class Service : IService
+        {
+            public bool Disposed { get; set; }
+
+            public void Dispose()
+            {
+                Disposed = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds correct implementation of IServiceResolverScope for StructureMap container. Transient instances are now disposed of when we finish handling message in `DefaultAutoSubscriberMessageDispatcher.Dispatch`