### PR TITLE
Add ability to declare transient server-named queues asynchronously

### DIFF
--- a/Source/EasyNetQ.Tests/Mocking/MockBuilder.cs
+++ b/Source/EasyNetQ.Tests/Mocking/MockBuilder.cs
@@ -69,6 +69,13 @@ namespace EasyNetQ.Tests.Mocking
                         consumers.Add(consumer);
                         return string.Empty;
                     });
+                channel.QueueDeclare(null, true, false, false, null)
+                    .ReturnsForAnyArgs(queueDeclareInvocation =>
+                    {
+                        var queueName = (string) queueDeclareInvocation[0];
+
+                        return new QueueDeclareOk(queueName, 0, 0);
+                    });
 
                 return channel;
             });

--- a/Source/EasyNetQ/IAdvancedBus.cs
+++ b/Source/EasyNetQ/IAdvancedBus.cs
@@ -517,5 +517,13 @@ namespace EasyNetQ
         /// </summary>
         /// <returns>The queue</returns>
         IQueue QueueDeclare();
+
+        /// <summary>
+        /// Declare a transient server named queue. Note, this queue will only last for duration of the
+        /// connection. If there is a connection outage, EasyNetQ will not attempt to recreate
+        /// consumers.
+        /// </summary>
+        /// <returns>The queue</returns>
+        Task<IQueue> QueueDeclareAsync();
     }
 }

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -397,14 +397,12 @@ namespace EasyNetQ
         // ---------------------------------- Exchange / Queue / Binding -----------------------------------
         public virtual IQueue QueueDeclare()
         {
-            var queueDeclareOk = clientCommandDispatcher.Invoke(x => x.QueueDeclare("", true, true, true, null));
-            
-            if (logger.IsDebugEnabled())
-            {
-                logger.DebugFormat("Declared server generated queue {queue}", queueDeclareOk.QueueName);
-            }
+            return QueueDeclare(string.Empty, durable: true, exclusive: true, autoDelete: true);
+        }
 
-            return new Queue(queueDeclareOk.QueueName, true);
+        public Task<IQueue> QueueDeclareAsync()
+        {
+            return QueueDeclareAsync(string.Empty, durable: true, exclusive: true, autoDelete: true);
         }
 
         public virtual IQueue QueueDeclare(

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -463,13 +463,13 @@ namespace EasyNetQ
                 arguments.Add("x-max-length-bytes", maxLengthBytes.Value);
             }
 
-            clientCommandDispatcher.Invoke(x => x.QueueDeclare(name, durable, exclusive, autoDelete, arguments));
+            var queueDeclareOk = clientCommandDispatcher.Invoke(x => x.QueueDeclare(name, durable, exclusive, autoDelete, arguments));
 
             if (logger.IsDebugEnabled())
             {
                 logger.DebugFormat(
                     "Declared queue {queue}: durable={durable}, exclusive={exclusive}, autoDelete={autoDelete}, arguments={arguments}",
-                    name,
+                    queueDeclareOk.QueueName,
                     durable,
                     exclusive,
                     autoDelete,
@@ -477,7 +477,7 @@ namespace EasyNetQ
                 );
             }
 
-            return new Queue(name, exclusive);
+            return new Queue(queueDeclareOk.QueueName, exclusive);
         }
 
         public async Task<IQueue> QueueDeclareAsync(
@@ -536,13 +536,13 @@ namespace EasyNetQ
                 arguments.Add("x-max-length-bytes", maxLengthBytes.Value);
             }
 
-            await clientCommandDispatcher.InvokeAsync(x => x.QueueDeclare(name, durable, exclusive, autoDelete, arguments)).ConfigureAwait(false);
+            var queueDeclareOk = await clientCommandDispatcher.InvokeAsync(x => x.QueueDeclare(name, durable, exclusive, autoDelete, arguments)).ConfigureAwait(false);
             
             if (logger.IsDebugEnabled())
             {
                 logger.DebugFormat(
                     "Declared queue {queue}: durable={durable}, exclusive={exclusive}, autoDelete={autoDelete}, arguments={arguments}",
-                    name,
+                    queueDeclareOk.QueueName,
                     durable,
                     exclusive,
                     autoDelete,
@@ -550,7 +550,7 @@ namespace EasyNetQ
                 );
             }
 
-            return new Queue(name, exclusive);
+            return new Queue(queueDeclareOk.QueueName, exclusive);
         }
 
         public virtual void QueueDelete(IQueue queue, bool ifUnused = false, bool ifEmpty = false)


### PR DESCRIPTION
This PR does three things:

1. Allows you to declare a server-named queue through the existing `QueueDeclare` and `QueueDeclareAsync` overloads (by specifying an empty `name`). This was already allowed, but would return back a `Queue` with a blank name. I guess this was a bug?
2. Adds an async alternative to `QueueDeclare()`; `QueueDeclareAsync()`
3. Changes the implementation of the existing `QueueDeclare()` method to call into the overload with parameters.

Was this an oversight, or is my thinking wrong here?