### PR TITLE
EasyNetQ 3.3.1

### DIFF
--- a/Source/EasyNetQ.DI.Microsoft/ServiceCollectionAdapter.cs
+++ b/Source/EasyNetQ.DI.Microsoft/ServiceCollectionAdapter.cs
@@ -27,7 +27,7 @@ namespace EasyNetQ.DI.Microsoft
                 default:
                     throw new ArgumentOutOfRangeException(nameof(lifetime), lifetime, null);
             }
-            
+
             return this;
         }
 
@@ -70,7 +70,31 @@ namespace EasyNetQ.DI.Microsoft
 
             public IServiceResolverScope CreateScope()
             {
-                return new ServiceResolverScope(this);
+                return new MicrosoftServiceResolverScope(serviceProvider);
+            }
+        }
+
+        private class MicrosoftServiceResolverScope : IServiceResolverScope
+        {
+            private IServiceScope serviceScope;
+
+            public MicrosoftServiceResolverScope(IServiceProvider serviceProvider)
+            {
+                serviceScope = serviceProvider.CreateScope();
+            }
+            public IServiceResolverScope CreateScope()
+            {
+                return new MicrosoftServiceResolverScope(serviceScope.ServiceProvider);
+            }
+
+            public void Dispose()
+            {
+                serviceScope?.Dispose();
+            }
+
+            public TService Resolve<TService>() where TService : class
+            {
+                return serviceScope.ServiceProvider.GetService<TService>();
             }
         }
     }

--- a/Source/EasyNetQ.DI.StructureMap/StructureMapAdapter.cs
+++ b/Source/EasyNetQ.DI.StructureMap/StructureMapAdapter.cs
@@ -27,7 +27,7 @@ namespace EasyNetQ.DI.StructureMap
                     return this;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(lifetime), lifetime, null);
-            } 
+            }
         }
 
         public IServiceRegister Register<TService>(TService instance) where TService : class
@@ -37,7 +37,7 @@ namespace EasyNetQ.DI.StructureMap
         }
 
         public IServiceRegister Register<TService>(Func<IServiceResolver, TService> factory, Lifetime lifetime = Lifetime.Singleton) where TService : class
-        { 
+        {
             switch (lifetime)
             {
                 case Lifetime.Transient:
@@ -48,26 +48,38 @@ namespace EasyNetQ.DI.StructureMap
                     return this;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(lifetime), lifetime, null);
-            } 
+            }
         }
 
         private class StructureMapResolver : IServiceResolver
         {
-            private readonly IContainer container;
+            protected readonly IContainer Container;
 
             public StructureMapResolver(IContainer container)
             {
-                this.container = container;
+                this.Container = container;
             }
 
             public TService Resolve<TService>() where TService : class
             {
-                return container.GetInstance<TService>();
+                return Container.GetInstance<TService>();
             }
 
             public IServiceResolverScope CreateScope()
             {
-                return new ServiceResolverScope(this);
+                return new StructureMapResolverScope(Container.GetNestedContainer());
+            }
+        }
+
+        private class StructureMapResolverScope : StructureMapResolver, IServiceResolverScope
+        {
+            public StructureMapResolverScope(IContainer container) : base(container)
+            {
+            }
+
+            public void Dispose()
+            {
+                Container.Dispose();
             }
         }
     }

--- a/Source/EasyNetQ.DI.Tests/MicrosoftDependencyScopeTests.cs
+++ b/Source/EasyNetQ.DI.Tests/MicrosoftDependencyScopeTests.cs
@@ -1,0 +1,87 @@
+#if !NETFX
+
+using System;
+using EasyNetQ.DI.Microsoft;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace EasyNetQ.DI.Tests
+{
+    public class MicrosoftDependencyScopeTests
+    {
+        [Theory]
+        [InlineData(Lifetime.Transient, true)]
+        [InlineData(Lifetime.Singleton, false)]
+        public void CreateScope_TransientService_ShouldBeDisposed(Lifetime lifetime, bool shouldBeDisposed)
+        {
+            var resolver = CreateResolver(c => c.Register<IService, Service>(lifetime));
+
+            var service = ResolveFromScope(resolver);
+
+            Assert.Equal(shouldBeDisposed, service.Disposed);
+        }
+
+        [Fact]
+        public void CreateScope_TransientServiceInSameScope_ShouldBeSingleton()
+        {
+            var services = new ServiceCollection();
+            var adapter = new ServiceCollectionAdapter(services);
+            services.AddScoped<IService, Service>();
+            var resolver = services.BuildServiceProvider().GetService<IServiceResolver>(); 
+
+            IService service1;
+            IService service2;
+            using (var scope = resolver.CreateScope())
+            {
+                service1 = scope.Resolve<IService>();
+                service2 = scope.Resolve<IService>();
+            }
+
+            Assert.Same(service1, service2);
+        }
+
+        [Fact]
+        public void CreateScope_TransientServiceInDifferentScopes_ShouldNotBeSame()
+        {
+            var resolver = CreateResolver(c => c.Register<IService, Service>(Lifetime.Transient));
+
+            var service1 = ResolveFromScope(resolver);
+            var service2 = ResolveFromScope(resolver);
+
+            Assert.NotSame(service1, service2);
+        }
+
+        private static IService ResolveFromScope(IServiceResolver resolver)
+        {
+            using (var scope = resolver.CreateScope())
+            {
+                return scope.Resolve<IService>();
+            }
+        }
+
+        private IServiceResolver CreateResolver(Action<IServiceRegister> configure)
+        {
+            var services = new ServiceCollection();
+            var adapter = new ServiceCollectionAdapter(services);
+            configure.Invoke(adapter);
+            return services.BuildServiceProvider().GetService<IServiceResolver>(); 
+        }
+
+        private interface IService : IDisposable
+        {
+            bool Disposed { get; set; }
+        }
+
+        private class Service : IService
+        {
+            public bool Disposed { get; set; }
+
+            public void Dispose()
+            {
+                Disposed = true;
+            }
+        }
+    }
+}
+
+#endif

--- a/Source/EasyNetQ.DI.Tests/StructureMapDependencyScopeTests.cs
+++ b/Source/EasyNetQ.DI.Tests/StructureMapDependencyScopeTests.cs
@@ -1,0 +1,78 @@
+using System;
+using EasyNetQ.DI.StructureMap;
+using StructureMap;
+using Xunit;
+
+namespace EasyNetQ.DI.Tests
+{
+    public class StructureMapDependencyScopeTests
+    {
+        [Theory]
+        [InlineData(Lifetime.Transient, true)]
+        [InlineData(Lifetime.Singleton, false)]
+        public void CreateScope_TransientService_ShouldBeDisposed(Lifetime lifetime, bool shouldBeDisposed)
+        {
+            var resolver = CreateResolver(c => c.Register<IService, Service>(lifetime));
+
+            var service = ResolveFromScope(resolver);
+
+            Assert.Equal(shouldBeDisposed, service.Disposed);
+        }
+
+        [Fact]
+        public void CreateScope_TransientServiceInSameScope_ShouldBeSingleton()
+        {
+            var resolver = CreateResolver(c => c.Register<IService, Service>(Lifetime.Transient));
+
+            IService service1;
+            IService service2;
+            using (var scope = resolver.CreateScope())
+            {
+                service1 = scope.Resolve<IService>();
+                service2 = scope.Resolve<IService>();
+            }
+
+            Assert.Same(service1, service2);
+        }
+
+        [Fact]
+        public void CreateScope_TransientServiceInDifferentScopes_ShouldNotBeSame()
+        {
+            var resolver = CreateResolver(c => c.Register<IService, Service>(Lifetime.Transient));
+
+            var service1 = ResolveFromScope(resolver);
+            var service2 = ResolveFromScope(resolver);
+
+            Assert.NotSame(service1, service2);
+        }
+
+        private static IService ResolveFromScope(IServiceResolver resolver)
+        {
+            using (var scope = resolver.CreateScope())
+            {
+                return scope.Resolve<IService>();
+            }
+        }
+
+        private IServiceResolver CreateResolver(Action<IServiceRegister> configure)
+        {
+            var container = new Container(r => configure(new StructureMapAdapter(r)));
+            return container.GetInstance<IServiceResolver>();
+        }
+
+        private interface IService : IDisposable
+        {
+            bool Disposed { get; set; }
+        }
+
+        private class Service : IService
+        {
+            public bool Disposed { get; set; }
+
+            public void Dispose()
+            {
+                Disposed = true;
+            }
+        }
+    }
+}

--- a/Source/EasyNetQ.Tests/MessageFactoryTests.cs
+++ b/Source/EasyNetQ.Tests/MessageFactoryTests.cs
@@ -35,5 +35,11 @@ namespace EasyNetQ.Tests
             Assert.Throws<ArgumentNullException>(() => MessageFactory.CreateInstance(typeof(MyMessage), null));
             Assert.Throws<ArgumentNullException>(() => MessageFactory.CreateInstance(typeof(MyMessage), new MyMessage(), null));
         }
+
+        [Fact]
+        public void Should_support_struct_message_body()
+        {
+            MessageFactory.CreateInstance(typeof(Guid), Guid.NewGuid());
+        }
     }
 }

--- a/Source/EasyNetQ.Tests/Mocking/MockBuilder.cs
+++ b/Source/EasyNetQ.Tests/Mocking/MockBuilder.cs
@@ -69,6 +69,13 @@ namespace EasyNetQ.Tests.Mocking
                         consumers.Add(consumer);
                         return string.Empty;
                     });
+                channel.QueueDeclare(null, true, false, false, null)
+                    .ReturnsForAnyArgs(queueDeclareInvocation =>
+                    {
+                        var queueName = (string) queueDeclareInvocation[0];
+
+                        return new QueueDeclareOk(queueName, 0, 0);
+                    });
 
                 return channel;
             });

--- a/Source/EasyNetQ/IAdvancedBus.cs
+++ b/Source/EasyNetQ/IAdvancedBus.cs
@@ -517,5 +517,13 @@ namespace EasyNetQ
         /// </summary>
         /// <returns>The queue</returns>
         IQueue QueueDeclare();
+
+        /// <summary>
+        /// Declare a transient server named queue. Note, this queue will only last for duration of the
+        /// connection. If there is a connection outage, EasyNetQ will not attempt to recreate
+        /// consumers.
+        /// </summary>
+        /// <returns>The queue</returns>
+        Task<IQueue> QueueDeclareAsync();
     }
 }

--- a/Source/EasyNetQ/IMessage.cs
+++ b/Source/EasyNetQ/IMessage.cs
@@ -27,7 +27,7 @@ namespace EasyNetQ
         Type MessageType { get; }
     }
 
-    public class Message<T> : IMessage<T> where T : class
+    public class Message<T> : IMessage<T>
     {
         public MessageProperties Properties { get; private set; }
         public Type MessageType { get; }

--- a/Source/EasyNetQ/Preconditions.cs
+++ b/Source/EasyNetQ/Preconditions.cs
@@ -26,7 +26,7 @@ namespace EasyNetQ
         /// <exception cref="ArgumentException">
         /// Thrown if <paramref name="name"/> is blank.
         /// </exception>
-        public static void CheckNotNull<T>(T value, string name) where T : class
+        public static void CheckNotNull<T>(T value, string name)
         {
             CheckNotNull(value, name, string.Format("{0} must not be null", name));
         }
@@ -52,7 +52,7 @@ namespace EasyNetQ
         /// Thrown if <paramref name="name"/> or <paramref name="message"/> are
         /// blank.
         /// </exception>
-        public static void CheckNotNull<T>(T value, string name, string message) where T : class
+        public static void CheckNotNull<T>(T value, string name, string message)
         {
             if (value == null)
             {

--- a/Source/EasyNetQ/Producer/Rpc.cs
+++ b/Source/EasyNetQ/Producer/Rpc.cs
@@ -95,6 +95,7 @@ namespace EasyNetQ.Producer
                 timer = new Timer(state =>
                 {
                     tcs.TrySetException(new TimeoutException(string.Format("Request timed out. CorrelationId: {0}", correlationId.ToString())));
+                    responseActions.TryRemove(correlationId.ToString(), out ResponseAction responseAction);
                 }, null, TimeSpan.FromSeconds(timeout), disablePeriodicSignaling);
             }
 

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -757,7 +757,7 @@ namespace EasyNetQ
             if (logger.IsDebugEnabled())
             {
                 logger.DebugFormat(
-                    "Bound destination exchange {destinationExchange} to source exchange {destinationExchange} with routingKey={routingKey} and arguments={arguments}",
+                    "Bound destination exchange {destinationExchange} to source exchange {sourceExchange} with routingKey={routingKey} and arguments={arguments}",
                     destination.Name, 
                     source.Name,
                     routingKey,
@@ -785,7 +785,7 @@ namespace EasyNetQ
             if (logger.IsDebugEnabled())
             {
                 logger.DebugFormat(
-                    "Bound destination exchange {destinationExchange} to source exchange {destinationExchange} with routingKey={routingKey} and arguments={arguments}",
+                    "Bound destination exchange {destinationExchange} to source exchange {sourceExchange} with routingKey={routingKey} and arguments={arguments}",
                     destination.Name,
                     source.Name, 
                     routingKey,

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -397,14 +397,12 @@ namespace EasyNetQ
         // ---------------------------------- Exchange / Queue / Binding -----------------------------------
         public virtual IQueue QueueDeclare()
         {
-            var queueDeclareOk = clientCommandDispatcher.Invoke(x => x.QueueDeclare("", true, true, true, null));
-            
-            if (logger.IsDebugEnabled())
-            {
-                logger.DebugFormat("Declared server generated queue {queue}", queueDeclareOk.QueueName);
-            }
+            return QueueDeclare(string.Empty, durable: true, exclusive: true, autoDelete: true);
+        }
 
-            return new Queue(queueDeclareOk.QueueName, true);
+        public Task<IQueue> QueueDeclareAsync()
+        {
+            return QueueDeclareAsync(string.Empty, durable: true, exclusive: true, autoDelete: true);
         }
 
         public virtual IQueue QueueDeclare(
@@ -463,13 +461,13 @@ namespace EasyNetQ
                 arguments.Add("x-max-length-bytes", maxLengthBytes.Value);
             }
 
-            clientCommandDispatcher.Invoke(x => x.QueueDeclare(name, durable, exclusive, autoDelete, arguments));
+            var queueDeclareOk = clientCommandDispatcher.Invoke(x => x.QueueDeclare(name, durable, exclusive, autoDelete, arguments));
 
             if (logger.IsDebugEnabled())
             {
                 logger.DebugFormat(
                     "Declared queue {queue}: durable={durable}, exclusive={exclusive}, autoDelete={autoDelete}, arguments={arguments}",
-                    name,
+                    queueDeclareOk.QueueName,
                     durable,
                     exclusive,
                     autoDelete,
@@ -477,7 +475,7 @@ namespace EasyNetQ
                 );
             }
 
-            return new Queue(name, exclusive);
+            return new Queue(queueDeclareOk.QueueName, exclusive);
         }
 
         public async Task<IQueue> QueueDeclareAsync(
@@ -536,13 +534,13 @@ namespace EasyNetQ
                 arguments.Add("x-max-length-bytes", maxLengthBytes.Value);
             }
 
-            await clientCommandDispatcher.InvokeAsync(x => x.QueueDeclare(name, durable, exclusive, autoDelete, arguments)).ConfigureAwait(false);
+            var queueDeclareOk = await clientCommandDispatcher.InvokeAsync(x => x.QueueDeclare(name, durable, exclusive, autoDelete, arguments)).ConfigureAwait(false);
             
             if (logger.IsDebugEnabled())
             {
                 logger.DebugFormat(
                     "Declared queue {queue}: durable={durable}, exclusive={exclusive}, autoDelete={autoDelete}, arguments={arguments}",
-                    name,
+                    queueDeclareOk.QueueName,
                     durable,
                     exclusive,
                     autoDelete,
@@ -550,7 +548,7 @@ namespace EasyNetQ
                 );
             }
 
-            return new Queue(name, exclusive);
+            return new Queue(queueDeclareOk.QueueName, exclusive);
         }
 
         public virtual void QueueDelete(IQueue queue, bool ifUnused = false, bool ifEmpty = false)


### PR DESCRIPTION
* [X] [Add ability to declare transient server-named queues asynchronously](https://github.com/EasyNetQ/EasyNetQ/pull/848)
* [X] [Log message has a wrong token name for source exchange](https://github.com/EasyNetQ/EasyNetQ/pull/843)
* [X] [Scope support for StructureMap](https://github.com/EasyNetQ/EasyNetQ/pull/841)
* [X] [Scope support for Microsoft DI](https://github.com/EasyNetQ/EasyNetQ/pull/847)
* [X] [Remove responseAction in case of timeout](https://github.com/EasyNetQ/EasyNetQ/pull/851)
* [X] [Remove class constraint from IMessage](https://github.com/EasyNetQ/EasyNetQ/pull/850)
