### PR TITLE
Use Abstractions for Microsoft DI

### DIFF
--- a/Source/EasyNetQ.DI.Microsoft/EasyNetQ.DI.Microsoft.csproj
+++ b/Source/EasyNetQ.DI.Microsoft/EasyNetQ.DI.Microsoft.csproj
@@ -6,7 +6,7 @@
     <PackageTags>DependencyInjection;RabbitMQ;Messaging;AMQP;C#</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.1" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/EasyNetQ.DI.Microsoft/EasyNetQ.DI.Microsoft.csproj
+++ b/Source/EasyNetQ.DI.Microsoft/EasyNetQ.DI.Microsoft.csproj
@@ -6,7 +6,7 @@
     <PackageTags>DependencyInjection;RabbitMQ;Messaging;AMQP;C#</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
+++ b/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="Ninject" Version="3.3.2" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />


### PR DESCRIPTION
Using the Abstractions doesn't force users to use a particular implementation version of Microsoft's DI.
This is how it's done in other libraries as well, including Microsoft's projects. 

Examples: https://github.com/aspnet/Caching/blob/master/src/Microsoft.Extensions.Caching.Memory/Microsoft.Extensions.Caching.Memory.csproj
https://github.com/HangfireIO/Hangfire/blob/master/src/Hangfire.AspNetCore/project.json