### PR TITLE
Created ConsumerCancelled event on ConsumerCancellation

### DIFF
--- a/Source/EasyNetQ/Consumer/ConsumerCancellation.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerCancellation.cs
@@ -1,9 +1,16 @@
-﻿using System;
+﻿
+using System;
 
 namespace EasyNetQ.Consumer
 {
     public class ConsumerCancellation : IDisposable
     {
+       
+        public delegate void ConsumerCancel(object queue);
+        // This event will fire whenever this class is disposed. It is necessary in order to catch
+        // when the consumer is canceled by the broker as well as the user. 
+        public event ConsumerCancel ConsumerCancelled;
+
         private readonly Action onCancellation;
 
         public ConsumerCancellation(Action onCancellation)
@@ -16,6 +23,11 @@ namespace EasyNetQ.Consumer
         public void Dispose()
         {
             onCancellation();
+        }
+
+        public void OnCancel(object queue)
+        {
+            ConsumerCancelled?.Invoke(queue);
         }
     }
 }

--- a/Source/EasyNetQ/Consumer/PersistentConsumer.cs
+++ b/Source/EasyNetQ/Consumer/PersistentConsumer.cs
@@ -23,6 +23,8 @@ namespace EasyNetQ.Consumer
 
         private readonly IList<IDisposable> subscriptions = new List<IDisposable>();
 
+        private ConsumerCancellation consumerCancellation;
+
         public PersistentConsumer(
             IQueue queue, 
             Func<byte[], MessageProperties, MessageReceivedInfo, CancellationToken, Task> onMessage, 
@@ -54,7 +56,8 @@ namespace EasyNetQ.Consumer
 
             StartConsumingInternal();
 
-            return new ConsumerCancellation(Dispose);
+            consumerCancellation = new ConsumerCancellation(Dispose);
+            return consumerCancellation;
         }
 
         private void StartConsumingInternal()
@@ -102,6 +105,8 @@ namespace EasyNetQ.Consumer
             if (disposed) return;
 
             disposed = true;
+
+            consumerCancellation.OnCancel(queue);
 
             eventBus.Publish(new StoppedConsumingEvent(this));
             

--- a/Source/EasyNetQ/Consumer/TransientConsumer.cs
+++ b/Source/EasyNetQ/Consumer/TransientConsumer.cs
@@ -17,6 +17,8 @@ namespace EasyNetQ.Consumer
 
         private IInternalConsumer internalConsumer;
 
+        private ConsumerCancellation consumerCancellation;
+
         public TransientConsumer(
             IQueue queue, 
             Func<byte[], MessageProperties, MessageReceivedInfo, CancellationToken, Task> onMessage, 
@@ -59,7 +61,8 @@ namespace EasyNetQ.Consumer
             else
                 eventBus.Publish(new StartConsumingFailedEvent(this, queue));
 
-            return new ConsumerCancellation(Dispose);
+            consumerCancellation = new ConsumerCancellation(Dispose);
+            return consumerCancellation;
         }
 
         private bool disposed;
@@ -68,6 +71,8 @@ namespace EasyNetQ.Consumer
         {
             if (disposed) return;
             disposed = true;
+
+            consumerCancellation.OnCancel(queue);
 
             eventBus.Publish(new StoppedConsumingEvent(this));
             


### PR DESCRIPTION
Replaces #862 from @rtaylor01:

Added a ConsumerCancelled event to the ConsumerCancellation class which will be invoked whenever a consumer is canceled by the broker. The idea is that if an app is consuming a queue using the EasyNetQ Comsume() method, it will need to act on the ConsumerCancelled event if the broker cancels the consumer. A simple example of this is when the queue is deleted using RabbitMQ management website while the app is consuming the queue. If there is no notification that the consumer is canceled, the app thinks it is still waiting for a message to be delivered on the queue.