### PR TITLE
Legacy RPC conventions

### DIFF
--- a/Source/EasyNetQ.Tests/Integration/RequestResponseTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/RequestResponseTests.cs
@@ -151,16 +151,16 @@ namespace EasyNetQ.Tests.Integration
         }
 
         // First start the EasyNetQ.Tests.SimpleService console app.
-        // Run this test. You should see 1000 response messages on the SimpleService
-        // and then 1000 messages appear back here.
+        // Run this test. You should see 200 response messages on the SimpleService
+        // and then 200 messages appear back here.
         [Fact][Explicit("Needs a Rabbit instance on localhost to work")]
         public void Should_be_able_to_make_many_async_requests()
         {
-            const int numberOfCalls = 500;
+            const int numberOfCalls = 200;
             var countdownEvent = new CountdownEvent(numberOfCalls);
             var count = 0;
 
-            for (int i = 0; i < 1000; i++)
+            for (int i = 0; i < numberOfCalls; i++)
             {
                 var request = new TestAsyncRequestMessage { Text = "Hello async from the client! " + i };
 

--- a/Source/EasyNetQ.Tests/Integration/RpcTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/RpcTests.cs
@@ -60,8 +60,6 @@ namespace EasyNetQ.Tests.Integration
 
                 bus.Request<MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes, RpcRequest>(
                     new MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes());
-
-                Thread.Sleep(2000);
             });
         }
 
@@ -75,8 +73,6 @@ namespace EasyNetQ.Tests.Integration
 
                 bus.Request<RpcRequest, MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes>(
                     new RpcRequest());
-
-                Thread.Sleep(2000);
             });
         }
 
@@ -92,12 +88,9 @@ namespace EasyNetQ.Tests.Integration
                 var request = new RpcRequest { Value = 5 };
 
                 var response = bus.Request<RpcRequest, RpcResponse>(request);
-
-                Thread.Sleep(2000);
             });
-            Assert.IsType<AggregateException>(ex);
-            Assert.NotNull(ex.InnerException);
-            Assert.Equal("Simulated Exception!", ex.InnerException.Message);
+            Assert.IsType<EasyNetQResponderException>(ex);
+            Assert.Equal("Simulated Exception!", ex.Message);
         }
 
         [Fact, Explicit("Requires a RabbitMQ instance on localhost")]
@@ -112,12 +105,9 @@ namespace EasyNetQ.Tests.Integration
                 var request = "Hello";
 
                 var response = bus.Request<string, string>(request);
-
-                Thread.Sleep(2000);
             });
-            Assert.IsType<AggregateException>(ex);
-            Assert.NotNull(ex.InnerException);
-            Assert.Equal("Simulated Exception!", ex.InnerException.Message);
+            Assert.IsType<EasyNetQResponderException>(ex);
+            Assert.Equal("Simulated Exception!", ex.Message);
         }
 
         [Fact, Explicit("Requires a RabbitMQ instance on localhost")]
@@ -132,12 +122,9 @@ namespace EasyNetQ.Tests.Integration
                 var request = new RpcRequest { Value = 5 };
 
                 var response = bus.Request<RpcRequest, RpcResponseWithoutParameterlessConstructor>(request);
-
-                Thread.Sleep(2000);
             });
-            Assert.IsType<AggregateException>(ex);
-            Assert.NotNull(ex.InnerException);
-            Assert.Equal("Simulated Exception!", ex.InnerException.Message);
+            Assert.IsType<EasyNetQResponderException>(ex);
+            Assert.Equal("Simulated Exception!", ex.Message);
         }
     }
 }

--- a/Source/EasyNetQ.Tests/Integration/RpcWithLegacyConventionsTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/RpcWithLegacyConventionsTests.cs
@@ -49,12 +49,10 @@ namespace EasyNetQ.Tests.Integration.LegacyConventionsTests
             Assert.Throws<EasyNetQException>(() =>
             {
                 bus.Respond<MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes, RpcRequest>(
-                req => new RpcRequest());
+                    req => new RpcRequest());
 
                 bus.Request<MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes, RpcRequest>(
                    new MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes());
-
-                Thread.Sleep(2000);
             });
         }
 
@@ -64,12 +62,10 @@ namespace EasyNetQ.Tests.Integration.LegacyConventionsTests
             Assert.Throws<EasyNetQException>(() =>
             {
                 bus.Respond<RpcRequest, MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes>(
-                req => new MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes());
+                    req => new MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes());
 
                 bus.Request<RpcRequest, MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes>(
                    new RpcRequest());
-
-                Thread.Sleep(2000);
             });
         }
     }

--- a/Source/EasyNetQ.Tests/Integration/RpcWithLegacyConventionsTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/RpcWithLegacyConventionsTests.cs
@@ -1,0 +1,76 @@
+﻿using EasyNetQ.Logging;
+using EasyNetQ.Tests.ProducerTests.Very.Long.Namespace.Certainly.Longer.Than.The255.Char.Length.That.RabbitMQ.Likes.That.Will.Certainly.Cause.An.AMQP.Exception.If.We.Dont.Do.Something.About.It.And.Stop.It.From.Happening;
+using System;
+using System.Threading;
+using Xunit;
+
+namespace EasyNetQ.Tests.Integration.LegacyConventionsTests
+{
+    public class RpcWithLegacyConventionsTests : IDisposable
+    {
+        private class RpcRequest
+        {
+            public int Value { get; set; }
+        }
+
+        private class RpcResponse
+        {
+            public int Value { get; set; }
+        }
+
+        private IBus bus;
+
+        public RpcWithLegacyConventionsTests()
+        {
+            LogProvider.SetCurrentLogProvider(ConsoleLogProvider.Instance);
+
+            bus = RabbitHutch.CreateBus("host=localhost", x => x.EnableLegacyConventions());
+        }
+
+        public void Dispose()
+        {
+            bus.Dispose();
+        }
+
+        [Fact, Explicit("Requires a RabbitMQ instance on localhost")]
+        public void Should_be_able_to_publish_and_receive_response()
+        {
+            bus.Respond<RpcRequest, RpcResponse>(req => new RpcResponse { Value = req.Value });
+            var request = new RpcRequest { Value = 5 };
+            var response = bus.Request<RpcRequest, RpcResponse>(request);
+
+            Assert.NotNull(response);
+            Assert.True(request.Value == response.Value);
+        }
+
+        [Fact, Explicit("Requires a RabbitMQ instance on localhost")]
+        public void Should_throw_when_requesting_over_long_message()
+        {
+            Assert.Throws<EasyNetQException>(() =>
+            {
+                bus.Respond<MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes, RpcRequest>(
+                req => new RpcRequest());
+
+                bus.Request<MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes, RpcRequest>(
+                   new MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes());
+
+                Thread.Sleep(2000);
+            });
+        }
+
+        [Fact, Explicit("Requires a RabbitMQ instance on localhost")]
+        public void Should_throw_when_responding_to_over_long_message()
+        {
+            Assert.Throws<EasyNetQException>(() =>
+            {
+                bus.Respond<RpcRequest, MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes>(
+                req => new MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes());
+
+                bus.Request<RpcRequest, MessageWithVeryVEryVEryLongNameThatWillMostCertainlyBreakAmqpsSilly255CharacterNameLimitThatIsAlmostCertainToBeReachedWithGenericTypes>(
+                   new RpcRequest());
+
+                Thread.Sleep(2000);
+            });
+        }
+    }
+}

--- a/Source/EasyNetQ/ConventionsExtensions.cs
+++ b/Source/EasyNetQ/ConventionsExtensions.cs
@@ -1,0 +1,17 @@
+﻿using EasyNetQ.DI;
+
+namespace EasyNetQ
+{
+    public static class ConventionsExtensions
+    {
+        /// <summary>
+        /// Shortcut for EnableLegacyTypeNaming() + EnableLegacyRpcConventions()
+        /// </summary>
+        public static IServiceRegister EnableLegacyConventions(this IServiceRegister serviceRegister)
+        {
+            return serviceRegister
+                .EnableLegacyTypeNaming()
+                .EnableLegacyRpcConventions();
+        }
+    }
+}

--- a/Source/EasyNetQ/LegacyRpcConventions.cs
+++ b/Source/EasyNetQ/LegacyRpcConventions.cs
@@ -7,7 +7,7 @@ namespace EasyNetQ
         public LegacyRpcConventions(ITypeNameSerializer typeNameSerializer)
             : base(typeNameSerializer)
         {
-            RpcResponseExchangeNamingConvention = (type) => Exchange.GetDefault().Name;
+            RpcResponseExchangeNamingConvention = type => Exchange.GetDefault().Name;
         }
     }
 }

--- a/Source/EasyNetQ/LegacyRpcConventions.cs
+++ b/Source/EasyNetQ/LegacyRpcConventions.cs
@@ -1,0 +1,13 @@
+﻿using EasyNetQ.Topology;
+
+namespace EasyNetQ
+{
+    public class LegacyRpcConventions : Conventions
+    {
+        public LegacyRpcConventions(ITypeNameSerializer typeNameSerializer)
+            : base(typeNameSerializer)
+        {
+            RpcResponseExchangeNamingConvention = (type) => Exchange.GetDefault().Name;
+        }
+    }
+}

--- a/Source/EasyNetQ/LegacyRpcConventionsExtensions.cs
+++ b/Source/EasyNetQ/LegacyRpcConventionsExtensions.cs
@@ -1,0 +1,12 @@
+﻿using EasyNetQ.DI;
+
+namespace EasyNetQ
+{
+    public static class LegacyRpcConventionsExtensions
+    {
+        public static IServiceRegister EnableLegacyRpcConventions(this IServiceRegister serviceRegister)
+        {
+            return serviceRegister.Register<IConventions, LegacyRpcConventions>();
+        }
+    }
+}


### PR DESCRIPTION
fixes #677 
rework of #738 

now you can switch to legacy conventions simple doing this:

```csharp
var bus = RabbitHutch.CreateBus("host=localhost", x => x.EnableLegacyConventions());
```

that is a shorcut of:

```csharp
var bus = RabbitHutch.CreateBus("host=localhost", x => x
    .EnableLegacyTypeNaming()
    .EnableLegacyRpcConventions());
```

with this legacy convention enabled, both pubsub and rpc can work between old and new easynetq version, and also you can upgrade to the latest version without having to migrate all the persisted queues and exchanges on rabbitmq server.


Thanks to @xpicio for the initial work #738 !!