### PR TITLE
Fix MessageVersionStack to work with more than 2 versions

### DIFF
--- a/Source/EasyNetQ.Tests/MessageVersioningTests/MessageVersionStackTests.cs
+++ b/Source/EasyNetQ.Tests/MessageVersioningTests/MessageVersionStackTests.cs
@@ -26,6 +26,16 @@ namespace EasyNetQ.Tests.MessageVersioningTests
         }
 
         [Fact]
+        public void Versioned_message_stack_works_for_more_than_two_versions_and_types_are_ordered_oldest_first()
+        {
+            var stack = new MessageVersionStack( typeof( MyMessageV3 ));
+
+            Assert.Equal(typeof(MyMessage), stack.ElementAt( 0 ));
+            Assert.Equal(typeof(MyMessageV2), stack.ElementAt( 1 ));
+            Assert.Equal(typeof(MyMessageV3), stack.ElementAt( 2 ));
+        }
+
+        [Fact]
         public void Pop_returns_the_top_of_the_stack()
         {
             var stack = new MessageVersionStack( typeof( MyMessageV2 ) );

--- a/Source/EasyNetQ.Tests/MessageVersioningTests/MyMessageV3.cs
+++ b/Source/EasyNetQ.Tests/MessageVersioningTests/MyMessageV3.cs
@@ -1,0 +1,9 @@
+using EasyNetQ.MessageVersioning;
+
+namespace EasyNetQ.Tests.MessageVersioningTests
+{
+    public class MyMessageV3 : MyMessageV2, ISupersede<MyMessageV2>
+    {
+        public int NumberInV3 { get; set; }
+    }
+}

--- a/Source/EasyNetQ/MessageVersioning/MessageVersionStack.cs
+++ b/Source/EasyNetQ/MessageVersioning/MessageVersionStack.cs
@@ -60,7 +60,7 @@ namespace EasyNetQ.MessageVersioning
                 .GetInterfaces()
                 .Where( t => t.GetTypeInfo().IsGenericType && t.GetGenericTypeDefinition() == typeof( ISupersede<> ) )
                 .SelectMany( t => t.GetGenericArguments() )
-                .FirstOrDefault();
+                .LastOrDefault();
         }
 
         private static void EnsureVersioningValid( Type messageType, Type supersededType )


### PR DESCRIPTION
I stumbled upon a problem with how MessageVersionStack works when there are more than two versions of a message. This behavior was seen on EasyNetQ version 3.3.5, and the latest develop seems to have no changes to the relevant code, so most likely it exists there as well.

The problem: If you have three versions of a message, i.e. MyMessage, MyMessageV2 and MyMessageV3, you've got a subscriber for each of them, and publish MyMessageV3, only MyMessageV3 and MyMessage are received, MyMessageV2 never arrives.

I traced the root of the problem into how versioned exchanges are declared and bound to each other. The exchange for MyMessageV3 is bound to the relevant queues and into the exchange of MyMessage, but not into the exchange of MyMessageV2, which it should do as well. The reason for this is in MessageVersionStack.GetSupersededType [1], which takes a message type and all the ISupersede interfaces that the message implements, and returns the first in the list (if there are multiple levels of versions it should return the last).

So, if we've got classes like this:

```
class MyMessage {
}

class MyMessageV2 : MyMessage, ISupersede<MyMessage> {
}

class MyMessageV3 : MyMessageV2, ISupersede<MyMessageV2> {
}
```

and we call MessageVersionStack.GetSupersededType() with MyMessageV3, it returns MyMessageV1 instead of MyMessageV2, which results into the problem described above.

Here's the code responsible for the problem at MessageVersionStack:

```
private static Type GetSupersededType( Type type )
{
     return type
        .GetInterfaces()
        .Where( t => t.GetTypeInfo().IsGenericType && t.GetGenericTypeDefinition() == typeof( ISupersede<> ) )
        .SelectMany( t => t.GetGenericArguments() )
        .FirstOrDefault();
}
```

and here's one way to fix it:
```
private static Type GetSupersededType( Type type )
{
     return type
        .GetInterfaces()
        .Where( t => t.GetTypeInfo().IsGenericType && t.GetGenericTypeDefinition() == typeof( ISupersede<> ) )
        .SelectMany( t => t.GetGenericArguments() )
        .LastOrDefault();
}
```

[1] https://github.com/EasyNetQ/EasyNetQ/blob/e8df567cfc7aebbd09c7f1cad38418d917025322/Source/EasyNetQ/MessageVersioning/MessageVersionStack.cs#L63