### PR TITLE
Guarantee that MessageVersionStack.GetSupersededType returns the direct parent type

### DIFF
--- a/Source/EasyNetQ/MessageVersioning/MessageVersionStack.cs
+++ b/Source/EasyNetQ/MessageVersioning/MessageVersionStack.cs
@@ -60,7 +60,8 @@ namespace EasyNetQ.MessageVersioning
                 .GetInterfaces()
                 .Where( t => t.GetTypeInfo().IsGenericType && t.GetGenericTypeDefinition() == typeof( ISupersede<> ) )
                 .SelectMany( t => t.GetGenericArguments() )
-                .LastOrDefault();
+                .Where( t => type.BaseType == t)
+                .FirstOrDefault();
         }
 
         private static void EnsureVersioningValid( Type messageType, Type supersededType )


### PR DESCRIPTION
The current implementation of MessageVersionStack.GetSupersededType uses Type.GetInterfaces
to get the earlier versions of a message and then selects the last. This assumes that GetInterfaces
returns the messages in order of inheritance. However, GetInterfaces offers no guarantees
with regards to ordering, so the implementation is not reliable.

When you've got MyMessage, and make a new version of that, MyMessageV2, in EasyNetQ message versioning it is required that MyMessageV2 inherits from MyMessage and also implements ISupersede<MyMessage>.

This information can be utilized when trying to select the correct type in GetSupersededType:
If you're trying to find the superseded type for MyMessageV3, GetInterfaces returns two ISupersede
types: ISupersede<MyMessageV2> and ISupersede<MyMessage>. Having those, you can select the
correct one by comparing the template parameters to type.BaseType.