### PR TITLE
Ensure the order of superseded types in MessageVersionStack.GetSupersededType

### DIFF
--- a/Source/EasyNetQ/MessageVersioning/MessageVersionStack.cs
+++ b/Source/EasyNetQ/MessageVersioning/MessageVersionStack.cs
@@ -60,6 +60,7 @@ namespace EasyNetQ.MessageVersioning
                 .GetInterfaces()
                 .Where( t => t.GetTypeInfo().IsGenericType && t.GetGenericTypeDefinition() == typeof( ISupersede<> ) )
                 .SelectMany( t => t.GetGenericArguments() )
+                .OrderBy( t => t.Name )
                 .LastOrDefault();
         }
 


### PR DESCRIPTION
GetSupersededType uses Type.GetInterfaces which does not offer any
guarantees on ordering. Before picking the superseded type, let's order
the list of candidates so that the direct parent can be more reliably
selected.

This does introduce a restriction that the versions of a message have to
be alphabetically sortable, i.e. MyMessage, MyMessageV2, MyMessageV3, which
might not be unreasonable as it's the same syntax as shown in the documentation.