### PR TITLE
Make GetSupersededType work with any message version hierarchy

### DIFF
--- a/Source/EasyNetQ.Tests/MessageVersioningTests/MessageVersionStackTests.cs
+++ b/Source/EasyNetQ.Tests/MessageVersioningTests/MessageVersionStackTests.cs
@@ -46,6 +46,14 @@ namespace EasyNetQ.Tests.MessageVersioningTests
         }
 
         [Fact]
+        public void If_given_just_an_object_the_stack_can_handle_it_without_exceptions()
+        {
+            var stack = new MessageVersionStack( typeof( object ));
+        
+            Assert.Equal(typeof(object), stack.ElementAt( 0 ));
+        }
+
+        [Fact]
         public void Pop_returns_the_top_of_the_stack()
         {
             var stack = new MessageVersionStack( typeof( MyMessageV2 ) );

--- a/Source/EasyNetQ.Tests/MessageVersioningTests/MessageVersionStackTests.cs
+++ b/Source/EasyNetQ.Tests/MessageVersioningTests/MessageVersionStackTests.cs
@@ -36,6 +36,16 @@ namespace EasyNetQ.Tests.MessageVersioningTests
         }
 
         [Fact]
+        public void Versioned_message_stack_works_with_arbitrary_type_names()
+        {
+            var stack = new MessageVersionStack( typeof( ComplexMessage ));
+
+            Assert.Equal(typeof(SimpleMessage), stack.ElementAt( 0 ));
+            Assert.Equal(typeof(AdvancedMessage), stack.ElementAt( 1 ));
+            Assert.Equal(typeof(ComplexMessage), stack.ElementAt( 2 ));
+        }
+
+        [Fact]
         public void Pop_returns_the_top_of_the_stack()
         {
             var stack = new MessageVersionStack( typeof( MyMessageV2 ) );
@@ -73,4 +83,19 @@ namespace EasyNetQ.Tests.MessageVersioningTests
     {
         public int AnotherNumber { get; set; }
     }
+
+    public class SimpleMessage
+    {
+        public string Message { get; set; }
+    }
+
+    public class AdvancedMessage : SimpleMessage, ISupersede<SimpleMessage>
+    {
+        public string VeryAdvanced { get; set; }
+    }
+
+    public class ComplexMessage : AdvancedMessage, ISupersede<AdvancedMessage>
+    {
+        public string SoComplex { get; set; }
+    }    
 }

--- a/Source/EasyNetQ/MessageVersioning/MessageVersionStack.cs
+++ b/Source/EasyNetQ/MessageVersioning/MessageVersionStack.cs
@@ -56,10 +56,13 @@ namespace EasyNetQ.MessageVersioning
 
         private static Type GetSupersededType( Type type )
         {
+            if( type.BaseType == null )
+                return null;
+
             var types = FindSupersedes(type);
             var parentTypes = FindSupersedes(type.BaseType);
 
-            return types.FirstOrDefault(t => !parentTypes.Contains(t));
+            return types.Except(parentTypes).FirstOrDefault();
         }
 
         private static IEnumerable<Type> FindSupersedes( Type type )

--- a/Source/EasyNetQ/MessageVersioning/MessageVersionStack.cs
+++ b/Source/EasyNetQ/MessageVersioning/MessageVersionStack.cs
@@ -56,11 +56,18 @@ namespace EasyNetQ.MessageVersioning
 
         private static Type GetSupersededType( Type type )
         {
-             return type
+            var types = FindSupersedes(type);
+            var parentTypes = FindSupersedes(type.BaseType);
+
+            return types.FirstOrDefault(t => !parentTypes.Contains(t));
+        }
+
+        private static IEnumerable<Type> FindSupersedes( Type type )
+        {
+            return type
                 .GetInterfaces()
                 .Where( t => t.GetTypeInfo().IsGenericType && t.GetGenericTypeDefinition() == typeof( ISupersede<> ) )
-                .SelectMany( t => t.GetGenericArguments() )
-                .LastOrDefault();
+                .SelectMany( t => t.GetGenericArguments() );                
         }
 
         private static void EnsureVersioningValid( Type messageType, Type supersededType )


### PR DESCRIPTION
MessageVersionStack.GetSupersededType uses Type.GetInterfaces which does not
offer any order guarantees. When selecting the superseded type for a message, we could sort
by class name, but that would just introduce a limitation on message naming.

Instead of that, let's call GetInterfaces for type and type.BaseType, and grab the ISupersede
entries from those. The one that does not exist in base type's list is the correct superseded type.