### PR TITLE
Remove newtonsoft hack from rpc

### DIFF
--- a/Source/EasyNetQ.Hosepipe/ErrorRetry.cs
+++ b/Source/EasyNetQ.Hosepipe/ErrorRetry.cs
@@ -24,7 +24,7 @@ namespace EasyNetQ.Hosepipe
         {
             foreach (var rawErrorMessage in rawErrorMessages)
             {
-                var error = serializer.BytesToMessage<Error>(errorMessageSerializer.Deserialize(rawErrorMessage.Body));
+                var error = (Error)serializer.BytesToMessage(typeof(Error), errorMessageSerializer.Deserialize(rawErrorMessage.Body));
                 RepublishError(error, parameters);
             }
         }

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_has_multiple_handlers.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_has_multiple_handlers.cs
@@ -60,7 +60,7 @@ namespace EasyNetQ.Tests.ConsumeTests
 
         private void Deliver<T>(T message) where T : class
         {
-            var body = new JsonSerializer().MessageToBytes(message);
+            var body = new JsonSerializer().MessageToBytes(typeof(T), message);
             var properties = new BasicProperties
             {
                 Type = new DefaultTypeNameSerializer().Serialize(typeof(T))

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_polymorphic_message_is_delivered_to_the_consumer.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_polymorphic_message_is_delivered_to_the_consumer.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿// ReSharper disable InconsistentNaming
+using System;
 using FluentAssertions;
-// ReSharper disable InconsistentNaming
 using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.Tests.Mocking;
@@ -29,7 +29,7 @@ namespace EasyNetQ.Tests.ConsumeTests
                 }));
 
             var publishedMessage = new Implementation { Text = "Hello Polymorphs!" };
-            var body = new JsonSerializer().MessageToBytes(publishedMessage);
+            var body = new JsonSerializer().MessageToBytes(typeof(Implementation), publishedMessage);
             var properties = new BasicProperties
                 {
                     Type = new DefaultTypeNameSerializer().Serialize(typeof(Implementation))

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿// ReSharper disable InconsistentNaming
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.Events;
@@ -61,7 +62,7 @@ namespace EasyNetQ.Tests.ConsumeTests
                 ReplyTo = conventions.RpcReturnQueueNamingConvention()
             };
 
-            var body = serializer.MessageToBytes(request);
+            var body = serializer.MessageToBytes(typeof(RpcRequest), request);
 
             var waiter = new CountdownEvent(2);
             mockBuilder.EventBus.Subscribe<PublishedMessageEvent>(x => waiter.Signal());

--- a/Source/EasyNetQ.Tests/DefaultMessageSerializationStrategyTests.cs
+++ b/Source/EasyNetQ.Tests/DefaultMessageSerializationStrategyTests.cs
@@ -25,7 +25,7 @@ namespace EasyNetQ.Tests
         }
 
         [Fact]
-        public void When_serializing_a_message_with_a_correlationid_it_is_not_overwritten()
+        public void When_serializing_a_message_with_a_correlation_id_it_is_not_overwritten()
         {
             const string messageType = "MyMessageTypeName";
             var serializedMessageBody = Encoding.UTF8.GetBytes("Hello world!");
@@ -98,18 +98,18 @@ namespace EasyNetQ.Tests
             Assert.Equal(message.Properties.ToString(), expectedMessageProperties); //, "Deserialized message properties do not match expected value");
         }
 
-        private DefaultMessageSerializationStrategy CreateSerializationStrategy(IMessage<MyMessage> message, string messageType, byte[] messageBody, string correlationId)
+        private static DefaultMessageSerializationStrategy CreateSerializationStrategy(IMessage<MyMessage> message, string messageType, byte[] messageBody, string correlationId)
         {
             var typeNameSerializer = Substitute.For<ITypeNameSerializer>();
             typeNameSerializer.Serialize(message.MessageType).Returns(messageType);
 
             var serializer = Substitute.For<ISerializer>();
-            serializer.MessageToBytes(message.GetBody()).Returns(messageBody);
+            serializer.MessageToBytes(message.MessageType, message.GetBody()).Returns(messageBody);
 
             return new DefaultMessageSerializationStrategy(typeNameSerializer, serializer, new StaticCorrelationIdGenerationStrategy(correlationId));
         }
 
-        private DefaultMessageSerializationStrategy CreateDeserializationStrategy(IMessage<MyMessage> message, byte[] messageBody, string correlationId)
+        private static DefaultMessageSerializationStrategy CreateDeserializationStrategy(IMessage<MyMessage> message, byte[] messageBody, string correlationId)
         {
             var typeNameSerializer = Substitute.For<ITypeNameSerializer>();
             typeNameSerializer.DeSerialize(message.Properties.Type).Returns(message.Body.GetType());

--- a/Source/EasyNetQ.Tests/Integration/ConsumerErrorConditionsTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/ConsumerErrorConditionsTests.cs
@@ -95,7 +95,7 @@ namespace EasyNetQ.Tests
                 CorrelationId = correlationId
             };
 
-             bus.Advanced.Publish(exchange, typeNameSerializer.Serialize(typeof(MyErrorTestMessage)), true, props, serializer.MessageToBytes(message));
+             bus.Advanced.Publish(exchange, typeNameSerializer.Serialize(typeof(MyErrorTestMessage)), true, props, serializer.MessageToBytes(typeof(MyErrorTestMessage), message));
 
             // give the publish a chance to get to rabbit and back
             // also allow the DefaultConsumerErrorStrategy time to spin up its connection

--- a/Source/EasyNetQ.Tests/Integration/DefaultConsumerErrorStrategyTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/DefaultConsumerErrorStrategyTests.cs
@@ -85,7 +85,7 @@ namespace EasyNetQ.Tests.Integration
                 }
                 else
                 {
-                    var message = serializer.BytesToMessage<Error>(getArgs.Body);
+                    var message = (Error)serializer.BytesToMessage(typeof(Error), getArgs.Body);
 
                     message.RoutingKey.Should().Be(context.Info.RoutingKey);
                     message.Exchange.Should().Be(context.Info.Exchange);

--- a/Source/EasyNetQ.Tests/JsonSerializerTests.cs
+++ b/Source/EasyNetQ.Tests/JsonSerializerTests.cs
@@ -11,11 +11,19 @@ namespace EasyNetQ.Tests
 {
     public class JsonSerializerTests
     {
-        private ISerializer serializer;
+        private readonly ISerializer serializer;
 
         public JsonSerializerTests()
         {
             serializer = new JsonSerializer();
+        }
+        
+        [Fact]
+        public void Should_be_able_to_serialize_and_deserialize_a_default_message()
+        {
+            var binaryMessage = serializer.MessageToBytes(typeof(MyMessage), default(MyMessage));
+            var deserializedMessage = (MyMessage)serializer.BytesToMessage(typeof(MyMessage), binaryMessage);
+            deserializedMessage.Should().BeNull();
         }
 
         [Fact]
@@ -23,10 +31,10 @@ namespace EasyNetQ.Tests
         {
             var message = new MyMessage {Text = "Hello World"};
 
-            var binaryMessage = serializer.MessageToBytes(message);
-            var deseralizedMessage = serializer.BytesToMessage<MyMessage>(binaryMessage);
+            var binaryMessage = serializer.MessageToBytes(typeof(MyMessage), message);
+            var deserializedMessage = (MyMessage)serializer.BytesToMessage(typeof(MyMessage), binaryMessage);
 
-            message.Text.Should().Be(deseralizedMessage.Text);
+            message.Text.Should().Be(deserializedMessage.Text);
         }
 
         [Fact]
@@ -55,8 +63,8 @@ namespace EasyNetQ.Tests
             };
 
             var messageBasicProperties = new MessageProperties(originalProperties);
-            var binaryMessage = serializer.MessageToBytes(messageBasicProperties);
-            var deserializedMessageBasicProperties = serializer.BytesToMessage<MessageProperties>(binaryMessage);
+            var binaryMessage = serializer.MessageToBytes(typeof(MessageProperties), messageBasicProperties);
+            var deserializedMessageBasicProperties = (MessageProperties)serializer.BytesToMessage(typeof(MessageProperties), binaryMessage);
 
             var newProperties = new BasicProperties();
             deserializedMessageBasicProperties.CopyTo(newProperties);
@@ -81,9 +89,9 @@ namespace EasyNetQ.Tests
         [Fact]
         public void Should_be_able_to_serialize_and_deserialize_polymorphic_properties()
         {
-            var bytes = serializer.MessageToBytes<PolyMessage>(new PolyMessage { AorB = new B() });
+            var bytes = serializer.MessageToBytes(typeof(PolyMessage), new PolyMessage { AorB = new B() });
 
-            var result = serializer.BytesToMessage<PolyMessage>(bytes);
+            var result = (PolyMessage)serializer.BytesToMessage(typeof(PolyMessage), bytes);
 
             Assert.IsType<B>(result.AorB);
         }
@@ -91,7 +99,7 @@ namespace EasyNetQ.Tests
         [Fact]
         public void Should_be_able_to_serialize_and_deserialize_polymorphic_properties_when_using_TypeNameSerializer()
         {
-            var bytes = serializer.MessageToBytes(new PolyMessage { AorB = new B() });
+            var bytes = serializer.MessageToBytes(typeof(PolyMessage), new PolyMessage { AorB = new B() });
             var result = (PolyMessage)serializer.BytesToMessage(typeof(PolyMessage), bytes);
 
             Assert.IsType<B>(result.AorB);

--- a/Source/EasyNetQ.Tests/MessageVersioningTests/VersionedMessageSerializationStrategyTests.cs
+++ b/Source/EasyNetQ.Tests/MessageVersioningTests/VersionedMessageSerializationStrategyTests.cs
@@ -30,7 +30,7 @@ namespace EasyNetQ.Tests.MessageVersioningTests
         }
 
         [Fact]
-        public void When_serializing_a_message_with_a_correlationid_it_is_not_overwritten()
+        public void When_serializing_a_message_with_a_correlation_id_it_is_not_overwritten()
         {
             const string messageType = "MyMessageTypeName";
             var serializedMessageBody = Encoding.UTF8.GetBytes("Hello world!");
@@ -115,7 +115,7 @@ namespace EasyNetQ.Tests.MessageVersioningTests
         }
 
         [Fact]
-        public void When_serializing_a_versioned_message_with_a_correlationid_it_is_not_overwritten()
+        public void When_serializing_a_versioned_message_with_a_correlation_id_it_is_not_overwritten()
         {
             const string messageType = "MyMessageV2TypeName";
             const string supersededMessageType = "MyMessageTypeName";
@@ -220,13 +220,13 @@ namespace EasyNetQ.Tests.MessageVersioningTests
             Assert.Equal(((Message<MyMessageV2>)deserializedMessage).Body.Number, message.Body.Number);
         }
 
-        private void AssertMessageSerializedCorrectly(SerializedMessage message, byte[] expectedBody, Action<MessageProperties> assertMessagePropertiesCorrect)
+        private static void AssertMessageSerializedCorrectly(SerializedMessage message, byte[] expectedBody, Action<MessageProperties> assertMessagePropertiesCorrect)
         {
             Assert.Equal(message.Body, expectedBody); //, "Serialized message body does not match expected value");
             assertMessagePropertiesCorrect(message.Properties); //;
         }
 
-        private void AssertMessageDeserializedCorrectly(IMessage<MyMessage> message, string expectedBodyText, Type expectedMessageType, Action<MessageProperties> assertMessagePropertiesCorrect)
+        private static void AssertMessageDeserializedCorrectly(IMessage<MyMessage> message, string expectedBodyText, Type expectedMessageType, Action<MessageProperties> assertMessagePropertiesCorrect)
         {
             Assert.Equal(message.Body.Text, expectedBodyText); //, "Deserialized message body text does not match expected value");
             Assert.Equal(message.MessageType, expectedMessageType); //, "Deserialized message type does not match expected value");
@@ -234,19 +234,19 @@ namespace EasyNetQ.Tests.MessageVersioningTests
             assertMessagePropertiesCorrect(message.Properties);
         }
 
-        private void AssertDefaultMessagePropertiesCorrect(MessageProperties properties, string expectedType, string expectedCorrelationId)
+        private static void AssertDefaultMessagePropertiesCorrect(MessageProperties properties, string expectedType, string expectedCorrelationId)
         {
             Assert.Equal(properties.Type, expectedType); //, "Message type does not match expected value");
             Assert.Equal(properties.CorrelationId, expectedCorrelationId); //, "Message correlation id does not match expected value");
         }
 
-        private void AssertVersionedMessagePropertiesCorrect(MessageProperties properties, string expectedType, string expectedCorrelationId, string alternativeTypes)
+        private static void AssertVersionedMessagePropertiesCorrect(MessageProperties properties, string expectedType, string expectedCorrelationId, string alternativeTypes)
         {
             AssertDefaultMessagePropertiesCorrect(properties, expectedType, expectedCorrelationId);
             Assert.Equal(properties.Headers[AlternativeMessageTypesHeaderKey], alternativeTypes); //, "Alternative message types do not match expected value");
         }
 
-        private VersionedMessageSerializationStrategy CreateSerializationStrategy<T>(IMessage<T> message, IEnumerable<KeyValuePair<string, Type>> messageTypes, byte[] messageBody, string correlationId) where T : class
+        private static VersionedMessageSerializationStrategy CreateSerializationStrategy<T>(IMessage<T> message, IEnumerable<KeyValuePair<string, Type>> messageTypes, byte[] messageBody, string correlationId) where T : class
         {
             var typeNameSerializer = Substitute.For<ITypeNameSerializer>();
             foreach (var messageType in messageTypes)
@@ -256,12 +256,12 @@ namespace EasyNetQ.Tests.MessageVersioningTests
             }
 
             var serializer = Substitute.For<ISerializer>();
-            serializer.MessageToBytes(message.GetBody()).Returns(messageBody);
+            serializer.MessageToBytes(typeof(T), message.GetBody()).Returns(messageBody);
 
             return new VersionedMessageSerializationStrategy(typeNameSerializer, serializer, new StaticCorrelationIdGenerationStrategy(correlationId));
         }
 
-        private VersionedMessageSerializationStrategy CreateDeserializationStrategy<T>(T message, IEnumerable<KeyValuePair<string, Type>> messageTypes, Type expectedMessageType, byte[] messageBody) where T : class
+        private static VersionedMessageSerializationStrategy CreateDeserializationStrategy<T>(T message, IEnumerable<KeyValuePair<string, Type>> messageTypes, Type expectedMessageType, byte[] messageBody) where T : class
         {
             var typeNameSerializer = Substitute.For<ITypeNameSerializer>();
             foreach (var messageType in messageTypes)

--- a/Source/EasyNetQ.Tests/SubscribeTests.cs
+++ b/Source/EasyNetQ.Tests/SubscribeTests.cs
@@ -247,7 +247,7 @@ namespace EasyNetQ.Tests
             const string text = "Hello there, I am the text!";
             originalMessage = new MyMessage { Text = text };
 
-            var body = new JsonSerializer().MessageToBytes(originalMessage);
+            var body = new JsonSerializer().MessageToBytes(typeof(MyMessage), originalMessage);
 
             // deliver a message
             mockBuilder.Consumers[0].HandleBasicDeliver(
@@ -334,7 +334,7 @@ namespace EasyNetQ.Tests
             const string text = "Hello there, I am the text!";
             originalMessage = new MyMessage { Text = text };
 
-            var body = new JsonSerializer().MessageToBytes(originalMessage);
+            var body = new JsonSerializer().MessageToBytes(typeof(MyMessage), originalMessage);
 
             // deliver a message
             mockBuilder.Consumers[0].HandleBasicDeliver(

--- a/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
+++ b/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
@@ -227,7 +227,7 @@ namespace EasyNetQ.Consumer
                     kvp => kvp.Value is byte[] ? Encoding.UTF8.GetString((byte[])kvp.Value) : kvp.Value);
             }
 
-            return serializer.MessageToBytes(error);
+            return serializer.MessageToBytes(typeof(Error), error);
         }
 
         private bool disposed;

--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -118,10 +118,10 @@ namespace EasyNetQ.Consumer
             }
 
             var messageReceivedInfo = new MessageReceivedInfo(consumerTag, deliveryTag, redelivered, exchange, routingKey, Queue.Name);
-            var messsageProperties = new MessageProperties(properties);
-            var context = new ConsumerExecutionContext(OnMessage, messageReceivedInfo, messsageProperties, body);
+            var messageProperties = new MessageProperties(properties);
+            var context = new ConsumerExecutionContext(OnMessage, messageReceivedInfo, messageProperties, body);
 
-            eventBus.Publish(new DeliveredMessageEvent(messageReceivedInfo, messsageProperties, body));
+            eventBus.Publish(new DeliveredMessageEvent(messageReceivedInfo, messageProperties, body));
             handlerRunner.InvokeUserMessageHandlerAsync(context)
                          .ContinueWith(async x =>
                             {
@@ -129,7 +129,7 @@ namespace EasyNetQ.Consumer
                                 consumerDispatcher.QueueAction(() =>
                                 {
                                     var ackResult = ackStrategy(Model, deliveryTag);
-                                    eventBus.Publish(new AckEvent(messageReceivedInfo, messsageProperties, body, ackResult));
+                                    eventBus.Publish(new AckEvent(messageReceivedInfo, messageProperties, body, ackResult));
                                 });
                             },
                             TaskContinuationOptions.ExecuteSynchronously

--- a/Source/EasyNetQ/DefaultMessageSerializationStrategy.cs
+++ b/Source/EasyNetQ/DefaultMessageSerializationStrategy.cs
@@ -16,7 +16,7 @@ namespace EasyNetQ
         public SerializedMessage SerializeMessage(IMessage message)
         {
             var typeName = typeNameSerializer.Serialize(message.MessageType);
-            var messageBody = serializer.MessageToBytes(message.GetBody());
+            var messageBody = serializer.MessageToBytes(message.MessageType, message.GetBody());
             var messageProperties = message.Properties;
 
             messageProperties.Type = typeName;

--- a/Source/EasyNetQ/IMessage.cs
+++ b/Source/EasyNetQ/IMessage.cs
@@ -43,14 +43,11 @@ namespace EasyNetQ
             MessageType = body.GetType();
         }
         
-        public Message(Type messageType, T body)
+        public Message()
         {
-            Preconditions.CheckNotNull(body, "body");
-            Preconditions.CheckNotNull(messageType, "messageType");
-            
-            Body = body;
+            Body = default;
             Properties = new MessageProperties();
-            MessageType = messageType;
+            MessageType = typeof(T);
         }
 
         public Message(T body, MessageProperties properties)

--- a/Source/EasyNetQ/IMessage.cs
+++ b/Source/EasyNetQ/IMessage.cs
@@ -42,6 +42,16 @@ namespace EasyNetQ
             Properties = new MessageProperties();
             MessageType = body.GetType();
         }
+        
+        public Message(Type messageType, T body)
+        {
+            Preconditions.CheckNotNull(body, "body");
+            Preconditions.CheckNotNull(messageType, "messageType");
+            
+            Body = body;
+            Properties = new MessageProperties();
+            MessageType = messageType;
+        }
 
         public Message(T body, MessageProperties properties)
         {
@@ -50,12 +60,6 @@ namespace EasyNetQ
             Body = body;
             Properties = properties;
             MessageType = body.GetType();
-        }
-
-        public void SetProperties(MessageProperties properties)
-        {
-            Preconditions.CheckNotNull(properties, "properties");
-            Properties = properties;
         }
     }
 }

--- a/Source/EasyNetQ/ISerializer.cs
+++ b/Source/EasyNetQ/ISerializer.cs
@@ -4,8 +4,7 @@ namespace EasyNetQ
 {
     public interface ISerializer
     {
-        byte[] MessageToBytes<T>(T message) where T : class;
-        T BytesToMessage<T>(byte[] bytes);
-        object BytesToMessage(Type type, byte[] bytes);
+        byte[] MessageToBytes(Type messageType, object message);
+        object BytesToMessage(Type messageType, byte[] bytes);
     }
 }

--- a/Source/EasyNetQ/JsonSerializer.cs
+++ b/Source/EasyNetQ/JsonSerializer.cs
@@ -21,23 +21,17 @@ namespace EasyNetQ
             this.serializerSettings = serializerSettings;
         }
 
-        public byte[] MessageToBytes<T>(T message) where T : class
+        public byte[] MessageToBytes(Type messageType, object message) 
         {
-            Preconditions.CheckNotNull(message, "message");
-            return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message, serializerSettings));
+            Preconditions.CheckNotNull(messageType, "messageType");
+            return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message, messageType, serializerSettings));
         }
 
-        public T BytesToMessage<T>(byte[] bytes)
+        public object BytesToMessage(Type messageType, byte[] bytes)
         {
+            Preconditions.CheckNotNull(messageType, "messageType");
             Preconditions.CheckNotNull(bytes, "bytes");
-            return JsonConvert.DeserializeObject<T>(Encoding.UTF8.GetString(bytes), serializerSettings);
-        }
-
-        public object BytesToMessage(Type type, byte[] bytes)
-        {
-            Preconditions.CheckNotNull(type, "type");
-            Preconditions.CheckNotNull(bytes, "bytes");
-            return JsonConvert.DeserializeObject(Encoding.UTF8.GetString(bytes), type, serializerSettings);
+            return JsonConvert.DeserializeObject(Encoding.UTF8.GetString(bytes), messageType, serializerSettings);
         }
     }
 }

--- a/Source/EasyNetQ/MessageVersioning/VersionedMessageSerializationStrategy.cs
+++ b/Source/EasyNetQ/MessageVersioning/VersionedMessageSerializationStrategy.cs
@@ -16,7 +16,7 @@ namespace EasyNetQ.MessageVersioning
 
         public SerializedMessage SerializeMessage(IMessage message)
         {
-            var messageBody = serializer.MessageToBytes(message.GetBody());
+            var messageBody = serializer.MessageToBytes(message.MessageType, message.GetBody());
             var messageTypeProperties = MessageTypeProperty.CreateForMessageType(message.MessageType, typeNameSerializer);
             var messageProperties = message.Properties;
             messageTypeProperties.AppendTo(messageProperties);
@@ -26,7 +26,6 @@ namespace EasyNetQ.MessageVersioning
             }
             return new SerializedMessage(messageProperties, messageBody);
         }
-
 
         public IMessage DeserializeMessage(MessageProperties properties, byte[] body)
         {

--- a/Source/EasyNetQ/Producer/Rpc.cs
+++ b/Source/EasyNetQ/Producer/Rpc.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using EasyNetQ.Events;
 using EasyNetQ.FluentConfiguration;
 using EasyNetQ.Topology;
-using Newtonsoft.Json;
 
 namespace EasyNetQ.Producer
 {
@@ -307,13 +306,7 @@ namespace EasyNetQ.Producer
             where TRequest : class
             where TResponse : class
         {
-            // HACK: I think we can live with this, because it will run only on exception, 
-            // it tries to preserve the default serialization behavior, 
-            // being able to also deserialize POCO objects that has constructors with parameters
-            // this avoids to introduce a custom class wrapper that will change the message payload
-            var body = JsonConvert.DeserializeObject<TResponse>(typeof(TResponse) == typeof(string) ? "''" : "{}");
-
-            var responseMessage = new Message<TResponse>(body);
+            var responseMessage = new Message<TResponse>(typeof(TResponse), default);
             responseMessage.Properties.Headers.Add(isFaultedKey, true);
             responseMessage.Properties.Headers.Add(exceptionMessageKey, exceptionMessage);
             responseMessage.Properties.CorrelationId = requestMessage.Properties.CorrelationId;

--- a/Source/EasyNetQ/Producer/Rpc.cs
+++ b/Source/EasyNetQ/Producer/Rpc.cs
@@ -306,7 +306,7 @@ namespace EasyNetQ.Producer
             where TRequest : class
             where TResponse : class
         {
-            var responseMessage = new Message<TResponse>(typeof(TResponse), default);
+            var responseMessage = new Message<TResponse>();
             responseMessage.Properties.Headers.Add(isFaultedKey, true);
             responseMessage.Properties.Headers.Add(exceptionMessageKey, exceptionMessage);
             responseMessage.Properties.CorrelationId = requestMessage.Properties.CorrelationId;


### PR DESCRIPTION
The PR is related to #865.

RPC depends on the hack with `Newtonsoft.JSON` which can be fixed. 

It breaks the backward compatibility a bit(only if a custom `ISerializer` was created), but there is no serialization incompatibility here. It will be nice to ship PR as `3.4`, but may be `3.3.10` is enough.

PS @sungam3r Please review the PR too.