### PR TITLE
Revert "Created ConsumerCancelled event on ConsumerCancellation class…

### DIFF
--- a/Source/EasyNetQ/Consumer/ConsumerCancellation.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerCancellation.cs
@@ -1,16 +1,9 @@
-﻿
-using System;
+﻿using System;
 
 namespace EasyNetQ.Consumer
 {
     public class ConsumerCancellation : IDisposable
     {
-       
-        public delegate void ConsumerCancel(object queue);
-        // This event will fire whenever this class is disposed. It is necessary in order to catch
-        // when the consumer is canceled by the broker as well as the user. 
-        public event ConsumerCancel ConsumerCancelled;
-
         private readonly Action onCancellation;
 
         public ConsumerCancellation(Action onCancellation)
@@ -23,11 +16,6 @@ namespace EasyNetQ.Consumer
         public void Dispose()
         {
             onCancellation();
-        }
-
-        public void OnCancel(object queue)
-        {
-            ConsumerCancelled?.Invoke(queue);
         }
     }
 }

--- a/Source/EasyNetQ/Consumer/ExclusiveConsumer.cs
+++ b/Source/EasyNetQ/Consumer/ExclusiveConsumer.cs
@@ -27,8 +27,6 @@ namespace EasyNetQ.Consumer
 
         private readonly IList<IDisposable> disposables = new List<IDisposable>();
 
-        private ConsumerCancellation consumerCancellation;
-
         public ExclusiveConsumer(
             IQueue queue,
             Func<byte[], MessageProperties, MessageReceivedInfo, Task> onMessage,
@@ -60,9 +58,8 @@ namespace EasyNetQ.Consumer
             disposables.Add(Timers.Start(s => StartConsumingInternal(), RestartConsumingPeriod, RestartConsumingPeriod));
             
             StartConsumingInternal();
-
-            consumerCancellation = new ConsumerCancellation(Dispose);
-            return consumerCancellation;
+            
+            return new ConsumerCancellation(Dispose);   
         }
 
         private void StartConsumingInternal()
@@ -118,9 +115,7 @@ namespace EasyNetQ.Consumer
                 return;
             
             disposed = true;
-
-            consumerCancellation.OnCancel(queue);
-
+            
             eventBus.Publish(new StoppedConsumingEvent(this));
             
             foreach (var disposal in disposables)

--- a/Source/EasyNetQ/Consumer/PersistentConsumer.cs
+++ b/Source/EasyNetQ/Consumer/PersistentConsumer.cs
@@ -22,8 +22,6 @@ namespace EasyNetQ.Consumer
 
         private readonly IList<IDisposable> subscriptions = new List<IDisposable>();
 
-        private ConsumerCancellation consumerCancellation;
-
         public PersistentConsumer(
             IQueue queue, 
             Func<byte[], MessageProperties, MessageReceivedInfo, Task> onMessage, 
@@ -54,8 +52,7 @@ namespace EasyNetQ.Consumer
 
             StartConsumingInternal();
 
-            consumerCancellation = new ConsumerCancellation(Dispose);
-            return consumerCancellation;
+            return new ConsumerCancellation(Dispose);
         }
 
         private void StartConsumingInternal()
@@ -103,8 +100,6 @@ namespace EasyNetQ.Consumer
             if (disposed) return;
 
             disposed = true;
-
-            consumerCancellation.OnCancel(queue);
 
             eventBus.Publish(new StoppedConsumingEvent(this));
             

--- a/Source/EasyNetQ/Consumer/PersistentMultipleConsumer.cs
+++ b/Source/EasyNetQ/Consumer/PersistentMultipleConsumer.cs
@@ -23,8 +23,6 @@ namespace EasyNetQ.Consumer
 
         private readonly IList<IDisposable> subscriptions = new List<IDisposable>();
 
-        private ConsumerCancellation consumerCancellation;
-
         public PersistentMultipleConsumer(
             ICollection<Tuple<IQueue, Func<byte[], MessageProperties, MessageReceivedInfo, Task>>> queueConsumerPairs,
             IPersistentConnection connection,
@@ -52,8 +50,7 @@ namespace EasyNetQ.Consumer
 
             StartConsumingInternal();
 
-            consumerCancellation = new ConsumerCancellation(Dispose);
-            return consumerCancellation;
+            return new ConsumerCancellation(Dispose);
         }
 
         private void StartConsumingInternal()
@@ -95,9 +92,7 @@ namespace EasyNetQ.Consumer
             if (disposed) return;
 
             disposed = true;
-
-            consumerCancellation.OnCancel(queueConsumerPairs);
-
+            
             eventBus.Publish(new StoppedConsumingEvent(this));
             
             foreach (var subscription in subscriptions)

--- a/Source/EasyNetQ/Consumer/TransientConsumer.cs
+++ b/Source/EasyNetQ/Consumer/TransientConsumer.cs
@@ -16,8 +16,6 @@ namespace EasyNetQ.Consumer
 
         private IInternalConsumer internalConsumer;
 
-        private ConsumerCancellation consumerCancellation;
-
         public TransientConsumer(
             IQueue queue, 
             Func<byte[], MessageProperties, MessageReceivedInfo, Task> onMessage, 
@@ -60,8 +58,7 @@ namespace EasyNetQ.Consumer
             else
                 eventBus.Publish(new StartConsumingFailedEvent(this, queue));
 
-            consumerCancellation = new ConsumerCancellation(Dispose);
-            return consumerCancellation;
+            return new ConsumerCancellation(Dispose);
         }
 
         private bool disposed;
@@ -70,8 +67,6 @@ namespace EasyNetQ.Consumer
         {
             if (disposed) return;
             disposed = true;
-
-            consumerCancellation.OnCancel(queue);
 
             eventBus.Publish(new StoppedConsumingEvent(this));
             


### PR DESCRIPTION
PR reverts the feature of consumer cancellation event which was implemented in #875. The implementation was not robust and it caused #904.

I hope it's good compromise to revert it now and rework it later. Of course it's a breaking change and I offer to release it as 3.5.0.

PS Please do not merge it because I have to put the tag.