### PR TITLE
Moved extensions methods under the same namespace as IBus

### DIFF
--- a/Source/EasyNetQ/Producer/PubSubExtensions.cs
+++ b/Source/EasyNetQ/Producer/PubSubExtensions.cs
@@ -3,8 +3,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.FluentConfiguration;
 using EasyNetQ.Internals;
+using EasyNetQ.Producer;
 
-namespace EasyNetQ.Producer
+namespace EasyNetQ
 {
     public static class PubSubExtensions
     {

--- a/Source/EasyNetQ/Producer/RpcExtensions.cs
+++ b/Source/EasyNetQ/Producer/RpcExtensions.cs
@@ -3,8 +3,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.FluentConfiguration;
 using EasyNetQ.Internals;
+using EasyNetQ.Producer;
 
-namespace EasyNetQ.Producer
+namespace EasyNetQ
 {
     public static class RpcExtensions
     {

--- a/Source/EasyNetQ/Producer/SendReceiveExtensions.cs
+++ b/Source/EasyNetQ/Producer/SendReceiveExtensions.cs
@@ -3,8 +3,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.Consumer;
 using EasyNetQ.Internals;
+using EasyNetQ.Producer;
 
-namespace EasyNetQ.Producer
+namespace EasyNetQ
 {
     public static class SendReceiveExtensions
     {

--- a/Source/EasyNetQ/Scheduling/SchedulerExtensions.cs
+++ b/Source/EasyNetQ/Scheduling/SchedulerExtensions.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Threading;
+using EasyNetQ.Scheduling;
 
-namespace EasyNetQ.Scheduling
+namespace EasyNetQ
 {
     public static class SchedulerExtensions
     {


### PR DESCRIPTION
moved extensions methods under the same namespace as IBus to help developers easily discover all the public interface

now we can find methods like `bus.PubSub.PublishAsync(T message)` right away importing only `EasyNetQ` namespace that is the minimum requirements to create a bus and now also to use all the public interface provided also from extensions methods along with the interface.