### PR TITLE
Rework queue declaration. LazyQueue is introduced.

### DIFF
--- a/Source/EasyNetQ.Tests/Integration/AdvancedApiExamples.cs
+++ b/Source/EasyNetQ.Tests/Integration/AdvancedApiExamples.cs
@@ -12,8 +12,6 @@ namespace EasyNetQ.Tests.Integration
     [Explicit("Requires a RabbitMQ instance on localhost")]
     public class AdvancedApiExamples : IDisposable
     {
-        private IAdvancedBus advancedBus;
-
         public AdvancedApiExamples()
         {
             advancedBus = RabbitHutch.CreateBus("host=localhost").Advanced;
@@ -24,31 +22,41 @@ namespace EasyNetQ.Tests.Integration
             advancedBus.Dispose();
         }
 
-        [Fact][Explicit]
-        public void DeclareTopology()
+        private IAdvancedBus advancedBus;
+
+
+        [Fact]
+        [Explicit]
+        public void ConsumeFromAQueue()
         {
+            var queue = new Queue("my_queue", false);
+            advancedBus.Consume(queue, (body, properties, info) => Task.Factory.StartNew(() =>
+            {
+                var message = Encoding.UTF8.GetString(body);
+                Console.Out.WriteLine("Got message: '{0}'", message);
+            }));
+
+            Thread.Sleep(500);
+        }
+
+        [Fact]
+        [Explicit]
+        public void DeclareDelayedExchange()
+        {
+            const string bindingKey = "the-binding-key";
+
+            var delayedExchange = advancedBus.ExchangeDeclare("delayed", ExchangeType.Direct, delayed: true);
             var queue = advancedBus.QueueDeclare("my_queue");
-            var exchange = advancedBus.ExchangeDeclare("my_exchange", ExchangeType.Direct);
-            advancedBus.Bind(exchange, queue, "routing_key");
+            advancedBus.Bind(delayedExchange, queue, bindingKey);
 
+            var message = Encoding.UTF8.GetBytes("Some message");
+            var messageProperties = new MessageProperties();
+            messageProperties.Headers.Add("x-delay", 5000);
+            advancedBus.Publish(delayedExchange, bindingKey, false, messageProperties, message);
         }
 
-        [Fact][Explicit]
-        public void DeclareTopologyAndCheckPassive()
-        {
-            var queue = advancedBus.QueueDeclare("my_queue");
-            var exchange = advancedBus.ExchangeDeclare("my_exchange", ExchangeType.Direct);
-            advancedBus.Bind(exchange, queue, "routing_key");
-            advancedBus.ExchangeDeclare("my_exchange", ExchangeType.Direct, passive: true);
-        }
-
-        [Fact][Explicit]
-        public void DeclareWithTtlAndExpire()
-        {
-            advancedBus.QueueDeclare("my_queue", perQueueMessageTtl: 500, expires: 500);
-        }
-
-        [Fact][Explicit]
+        [Fact]
+        [Explicit]
         public void DeclareExchangeWithAlternate()
         {
             const string alternate = "alternate";
@@ -64,36 +72,34 @@ namespace EasyNetQ.Tests.Integration
             advancedBus.Publish(originalExchange, bindingKey, false, new MessageProperties(), message);
         }
 
-        [Fact][Explicit]
-        public void DeclareDelayedExchange()
+        [Fact]
+        [Explicit]
+        public void DeclareTopology()
         {
-            const string bindingKey = "the-binding-key";
-
-            var delayedExchange = advancedBus.ExchangeDeclare("delayed", ExchangeType.Direct, delayed: true);
             var queue = advancedBus.QueueDeclare("my_queue");
-            advancedBus.Bind(delayedExchange, queue, bindingKey);
-
-            var message = Encoding.UTF8.GetBytes("Some message");
-            var messageProperties = new MessageProperties();
-            messageProperties.Headers.Add("x-delay", 5000);
-            advancedBus.Publish(delayedExchange, bindingKey, false, messageProperties, message);
+            var exchange = advancedBus.ExchangeDeclare("my_exchange", ExchangeType.Direct);
+            advancedBus.Bind(exchange, queue, "routing_key");
         }
 
-
-        [Fact][Explicit]
-        public void ConsumeFromAQueue()
+        [Fact]
+        [Explicit]
+        public void DeclareTopologyAndCheckPassive()
         {
-            var queue = new Queue("my_queue", false);
-            advancedBus.Consume(queue, (body, properties, info) => Task.Factory.StartNew(() =>
-                {
-                    var message = Encoding.UTF8.GetString(body);
-                    Console.Out.WriteLine("Got message: '{0}'", message);
-                }));
-
-            Thread.Sleep(500);
+            var queue = advancedBus.QueueDeclare("my_queue");
+            var exchange = advancedBus.ExchangeDeclare("my_exchange", ExchangeType.Direct);
+            advancedBus.Bind(exchange, queue, "routing_key");
+            advancedBus.ExchangeDeclare("my_exchange", ExchangeType.Direct, passive: true);
         }
 
-        [Fact][Explicit]
+        [Fact]
+        [Explicit]
+        public void DeclareWithTtlAndExpire()
+        {
+            advancedBus.QueueDeclare("my_queue", configure: c => c.WithExpires(TimeSpan.FromMilliseconds(500)).WithMessageTtl(TimeSpan.FromMilliseconds(500)));
+        }
+
+        [Fact]
+        [Explicit]
         public void PublishToAnExchange()
         {
             var exchange = new Exchange("my_exchange");
@@ -104,7 +110,54 @@ namespace EasyNetQ.Tests.Integration
             Thread.Sleep(5000);
         }
 
-        [Fact][Explicit]
+        [Fact]
+        [Explicit]
+        public void Should_be_able_to_dead_letter_to_fixed_queue()
+        {
+            // create a main queue and a retry queue with retry queue dead lettering messages directly
+            // to main queue
+            var queue = advancedBus.QueueDeclare("main_queue");
+            var exchange = advancedBus.ExchangeDeclare("my_exchange", ExchangeType.Topic);
+            var retryQueue = advancedBus.QueueDeclare("retry_queue", c => c.WithDeadLetterExchange(Exchange.GetDefault()).WithDeadLetterRoutingKey("main_queue"));
+            advancedBus.Bind(exchange, retryQueue, "routing_key");
+
+            // consume from main queue to see if dead lettering is working as expected
+            advancedBus.Consume<MyMessage>(queue, (message, info) =>
+                Task.Factory.StartNew(() =>
+                    Console.WriteLine("Got message {0}", message.Body.Text)));
+
+            // publish the message to retry queue which should end up in the main queue after expiration
+            advancedBus.Publish(exchange, "routing_key", false, new Message<MyMessage>(new MyMessage() {Text = "My Message"}, new MessageProperties {Expiration = "50"}));
+
+            Thread.Sleep(1000);
+        }
+
+        [Fact]
+        [Explicit]
+        public void Should_be_able_to_dead_letter_to_given_exchange()
+        {
+            // create a main queue and a retry queue both binding to the same topic exchange with 
+            // different routing keys. Retry queue is dead lettering to the exchange with routing key
+            // of main queue binding.
+            var queue = advancedBus.QueueDeclare("main_queue");
+            var exchange = advancedBus.ExchangeDeclare("my_exchange", ExchangeType.Topic);
+            advancedBus.Bind(exchange, queue, "main_routing_key");
+            var retryQueue = advancedBus.QueueDeclare("my_retry_queue", c => c.WithDeadLetterExchange(new Exchange("my_exchange")).WithDeadLetterRoutingKey("main_routing_key"));
+            advancedBus.Bind(exchange, retryQueue, "retry_routing_key");
+
+            // consume messages from main queue
+            advancedBus.Consume<MyMessage>(queue, (message, info) =>
+                Task.Factory.StartNew(() =>
+                    Console.WriteLine("Got message {0}", message.Body.Text)));
+
+            // publish message to the retry queue which should dead letter to main queue after expiration
+            advancedBus.Publish(exchange, "retry_routing_key", false, new Message<MyMessage>(new MyMessage() {Text = "My Message"}, new MessageProperties {Expiration = "50"}));
+
+            Thread.Sleep(1000);
+        }
+
+        [Fact]
+        [Explicit]
         public void Should_be_able_to_delete_objects()
         {
             // declare some objects
@@ -118,24 +171,12 @@ namespace EasyNetQ.Tests.Integration
             advancedBus.QueueDelete(queue);
         }
 
-        [Fact][Explicit]
-        public void Should_consume_a_message()
-        {
-            var queue = advancedBus.QueueDeclare("consume_test");
-            advancedBus.Consume<MyMessage>(queue, (message, info) => 
-                Task.Factory.StartNew(() => 
-                    Console.WriteLine("Got message {0}", message.Body.Text)));
-
-            advancedBus.Publish(Exchange.GetDefault(), "consume_test", false, new Message<MyMessage>(new MyMessage{ Text = "Wotcha!"}));
-
-            Thread.Sleep(1000);
-        }
-
-        [Fact][Explicit]
+        [Fact]
+        [Explicit]
         public void Should_be_able_to_get_a_message()
         {
             var queue = advancedBus.QueueDeclare("get_test");
-            advancedBus.Publish(Exchange.GetDefault(), "get_test", false, new Message<MyMessage>(new MyMessage { Text = "Oh! Hello!" }));
+            advancedBus.Publish(Exchange.GetDefault(), "get_test", false, new Message<MyMessage>(new MyMessage {Text = "Oh! Hello!"}));
 
             var getResult = advancedBus.GetMessage<MyMessage>(queue);
 
@@ -149,7 +190,32 @@ namespace EasyNetQ.Tests.Integration
             }
         }
 
-        [Fact][Explicit]
+        [Fact]
+        [Explicit]
+        public void Should_be_able_to_get_queue_length()
+        {
+            var queue = advancedBus.QueueDeclare("count_test");
+            advancedBus.Publish(Exchange.GetDefault(), "count_test", false, new Message<MyMessage>(new MyMessage {Text = "Oh! Hello!"}));
+            var messageCount = advancedBus.GetMessagesCount(queue);
+            Console.WriteLine("{0} messages in queue", messageCount);
+        }
+
+        [Fact]
+        [Explicit]
+        public void Should_consume_a_message()
+        {
+            var queue = advancedBus.QueueDeclare("consume_test");
+            advancedBus.Consume<MyMessage>(queue, (message, info) =>
+                Task.Factory.StartNew(() =>
+                    Console.WriteLine("Got message {0}", message.Body.Text)));
+
+            advancedBus.Publish(Exchange.GetDefault(), "consume_test", false, new Message<MyMessage>(new MyMessage {Text = "Wotcha!"}));
+
+            Thread.Sleep(1000);
+        }
+
+        [Fact]
+        [Explicit]
         public void Should_set_MessageAvailable_to_false_when_queue_is_empty()
         {
             var queue = advancedBus.QueueDeclare("get_empty_queue_test");
@@ -159,59 +225,6 @@ namespace EasyNetQ.Tests.Integration
             {
                 Console.Out.WriteLine("Failed to get message!");
             }
-        }
-
-        [Fact][Explicit]
-        public void Should_be_able_to_get_queue_length()
-        {
-            var queue = advancedBus.QueueDeclare("count_test");
-            advancedBus.Publish(Exchange.GetDefault(), "count_test", false, new Message<MyMessage>(new MyMessage { Text = "Oh! Hello!" }));
-            var messageCount = advancedBus.GetMessagesCount(queue);
-            Console.WriteLine("{0} messages in queue", messageCount);
-        }
-
-        [Fact][Explicit]
-        public void Should_be_able_to_dead_letter_to_fixed_queue()
-        {
-            // create a main queue and a retry queue with retry queue dead lettering messages directly
-            // to main queue
-            var queue = advancedBus.QueueDeclare("main_queue");
-            var exchange = advancedBus.ExchangeDeclare("my_exchange", ExchangeType.Topic);
-            var retryQueue = advancedBus.QueueDeclare("retry_queue", deadLetterExchange: "", deadLetterRoutingKey: "main_queue");
-            advancedBus.Bind(exchange, retryQueue, "routing_key");
-
-            // consume from main queue to see if dead lettering is working as expected
-            advancedBus.Consume<MyMessage>(queue, (message, info) =>
-                Task.Factory.StartNew(() =>
-                    Console.WriteLine("Got message {0}", message.Body.Text)));
-
-            // publish the message to retry queue which should end up in the main queue after expiration
-            advancedBus.Publish(exchange, "routing_key", false, new Message<MyMessage>(new MyMessage() { Text = "My Message" }, new MessageProperties { Expiration = "50" }));
-
-            Thread.Sleep(1000);
-        }
-
-        [Fact][Explicit]
-        public void Should_be_able_to_dead_letter_to_given_exchange()
-        {
-            // create a main queue and a retry queue both binding to the same topic exchange with 
-            // different routing keys. Retry queue is dead lettering to the exchange with routing key
-            // of main queue binding.
-            var queue = advancedBus.QueueDeclare("main_queue");
-            var exchange = advancedBus.ExchangeDeclare("my_exchange", ExchangeType.Topic);
-            advancedBus.Bind(exchange, queue, "main_routing_key");
-            var retryQueue = advancedBus.QueueDeclare("my_retry_queue", deadLetterExchange: "my_exchange", deadLetterRoutingKey: "main_routing_key");
-            advancedBus.Bind(exchange, retryQueue, "retry_routing_key");
-
-            // consume messages from main queue
-            advancedBus.Consume<MyMessage>(queue, (message, info) =>
-                Task.Factory.StartNew(() =>
-                    Console.WriteLine("Got message {0}", message.Body.Text)));
-
-            // publish message to the retry queue which should dead letter to main queue after expiration
-            advancedBus.Publish(exchange, "retry_routing_key", false, new Message<MyMessage>(new MyMessage() { Text = "My Message" }, new MessageProperties { Expiration = "50" }));
-
-            Thread.Sleep(1000);
         }
     }
 }

--- a/Source/EasyNetQ.Tests/Integration/AdvancedBusTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/AdvancedBusTests.cs
@@ -7,32 +7,32 @@ namespace EasyNetQ.Tests.Integration
     [Explicit("Requires a RabbitMQ instance on localhost to work")]
     public class AdvancedBusTests : IDisposable
     {
-        private IBus bus;
-
         public void Dispose()
         {
             bus.Dispose();
         }
 
+        private IBus bus;
+
         [Fact]
         public void Should_be_able_to_declare_exchange_during_first_on_connected_event()
         {
-            var advancedBusEventHandlers = new AdvancedBusEventHandlers(connected: (s, e) =>
-                {
-                    var advancedBus = ((IAdvancedBus)s);
-                    advancedBus.ExchangeDeclare("my_test_exchange", "topic", autoDelete: true);
-                });
-            
+            var advancedBusEventHandlers = new AdvancedBusEventHandlers((s, e) =>
+            {
+                var advancedBus = (IAdvancedBus) s;
+                advancedBus.ExchangeDeclare("my_test_exchange", "topic", autoDelete: true);
+            });
+
             bus = RabbitHutch.CreateBus("host=localhost", c => c.Register(advancedBusEventHandlers));
         }
 
         [Fact]
         public void Should_be_able_to_declare_queue_during_first_on_connected_event()
         {
-            var advancedBusEventHandlers = new AdvancedBusEventHandlers(connected: (s, e) =>
+            var advancedBusEventHandlers = new AdvancedBusEventHandlers((s, e) =>
             {
-                var advancedBus = ((IAdvancedBus)s);
-                advancedBus.QueueDeclare("my_test_queue", autoDelete: true);
+                var advancedBus = ((IAdvancedBus) s);
+                advancedBus.QueueDeclare("my_test_queue", c => c.AsAutoDelete());
             });
             bus = RabbitHutch.CreateBus("host=localhost", c => c.Register(advancedBusEventHandlers));
         }
@@ -42,7 +42,7 @@ namespace EasyNetQ.Tests.Integration
         {
             var advancedBusEventHandlers = new AdvancedBusEventHandlers(connected: (s, e) =>
             {
-                var advancedBus = ((IAdvancedBus)s);
+                var advancedBus = ((IAdvancedBus) s);
                 var exchange = advancedBus.ExchangeDeclare("my_test_exchange", "topic", autoDelete: true);
                 advancedBus.Publish(exchange, "key", false, new MessageProperties(), Encoding.UTF8.GetBytes("Hello world"));
             });

--- a/Source/EasyNetQ/AdvancedBusExtensions.cs
+++ b/Source/EasyNetQ/AdvancedBusExtensions.cs
@@ -106,7 +106,7 @@ namespace EasyNetQ
 
             return bus.Consume(queue, onMessage, c => { });
         }
-  
+
         /// <summary>
         /// Consume raw bytes from the queue.
         /// </summary>
@@ -121,8 +121,8 @@ namespace EasyNetQ
         /// </param>
         /// <returns>A disposable to cancel the consumer</returns>
         public static IDisposable Consume(
-            this IAdvancedBus bus, 
-            IQueue queue, 
+            this IAdvancedBus bus,
+            IQueue queue,
             Action<byte[], MessageProperties, MessageReceivedInfo> onMessage,
             Action<IConsumerConfiguration> configure
         )
@@ -146,7 +146,7 @@ namespace EasyNetQ
         /// <returns>A disposable to cancel the consumer</returns>
         public static IDisposable Consume(
             this IAdvancedBus bus,
-            IQueue queue, 
+            IQueue queue,
             Func<byte[], MessageProperties, MessageReceivedInfo, Task> onMessage
         )
         {
@@ -154,7 +154,7 @@ namespace EasyNetQ
 
             return bus.Consume(queue, onMessage, c => { });
         }
-        
+
         /// <summary>
         /// Consume raw bytes from the queue.
         /// </summary>
@@ -210,8 +210,8 @@ namespace EasyNetQ
             Preconditions.CheckNotNull(bus, "bus");
 
             bus.PublishAsync(exchange, routingKey, mandatory, messageProperties, body, cancellationToken)
-               .GetAwaiter()
-               .GetResult();
+                .GetAwaiter()
+                .GetResult();
         }
 
         /// <summary>
@@ -243,8 +243,8 @@ namespace EasyNetQ
             Preconditions.CheckNotNull(bus, "bus");
 
             bus.PublishAsync(exchange, routingKey, mandatory, message, cancellationToken)
-               .GetAwaiter()
-               .GetResult();
+                .GetAwaiter()
+                .GetResult();
         }
 
         /// <summary>
@@ -258,10 +258,10 @@ namespace EasyNetQ
         public static IBasicGetResult<T> GetMessage<T>(this IAdvancedBus bus, IQueue queue, CancellationToken cancellationToken = default)
         {
             Preconditions.CheckNotNull(bus, "bus");
-            
+
             return bus.GetMessageAsync<T>(queue, cancellationToken)
-                      .GetAwaiter()
-                      .GetResult();
+                .GetAwaiter()
+                .GetResult();
         }
 
         /// <summary>
@@ -274,10 +274,10 @@ namespace EasyNetQ
         public static IBasicGetResult GetMessage(this IAdvancedBus bus, IQueue queue, CancellationToken cancellationToken = default)
         {
             Preconditions.CheckNotNull(bus, "bus");
-            
+
             return bus.GetMessageAsync(queue, cancellationToken)
-                      .GetAwaiter()
-                      .GetResult();
+                .GetAwaiter()
+                .GetResult();
         }
 
         /// <summary>
@@ -290,10 +290,10 @@ namespace EasyNetQ
         public static uint GetMessagesCount(this IAdvancedBus bus, IQueue queue, CancellationToken cancellationToken = default)
         {
             Preconditions.CheckNotNull(bus, "bus");
-            
+
             return bus.GetMessagesCountAsync(queue, cancellationToken)
-                      .GetAwaiter()
-                      .GetResult();
+                .GetAwaiter()
+                .GetResult();
         }
 
         /// <summary>
@@ -307,10 +307,10 @@ namespace EasyNetQ
         public static IQueue QueueDeclare(this IAdvancedBus bus, CancellationToken cancellationToken = default)
         {
             Preconditions.CheckNotNull(bus, "bus");
-            
+
             return bus.QueueDeclareAsync(cancellationToken)
-                      .GetAwaiter()
-                      .GetResult();
+                .GetAwaiter()
+                .GetResult();
         }
 
         /// <summary>
@@ -318,17 +318,7 @@ namespace EasyNetQ
         /// </summary>
         /// <param name="bus">The bus instance</param>
         /// <param name="name">The name of the queue</param>
-        /// <param name="passive">Throw an exception rather than create the queue if it doesn't exist</param>
-        /// <param name="durable">Durable queues remain active when a server restarts.</param>
-        /// <param name="exclusive">Exclusive queues may only be accessed by the current connection, and are deleted when that connection closes.</param>
-        /// <param name="autoDelete">If set, the queue is deleted when all consumers have finished using it.</param>
-        /// <param name="perQueueMessageTtl">Determines how long a message published to a queue can live before it is discarded by the server.</param>
-        /// <param name="expires">Determines how long a queue can remain unused before it is automatically deleted by the server.</param>
-        /// <param name="maxPriority">Determines the maximum message priority that the queue should support.</param>
-        /// <param name="deadLetterExchange">Determines an exchange's name can remain unused before it is automatically deleted by the server.</param>
-        /// <param name="deadLetterRoutingKey">If set, will route message with the routing key specified, if not set, message will be routed with the same routing keys they were originally published with.</param>
-        /// <param name="maxLength">The maximum number of ready messages that may exist on the queue.  Messages will be dropped or dead-lettered from the front of the queue to make room for new messages once the limit is reached</param>
-        /// <param name="maxLengthBytes">The maximum size of the queue in bytes.  Messages will be dropped or dead-lettered from the front of the queue to make room for new messages once the limit is reached</param>
+        /// <param name="configuration">The configuration of the queue</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>
         /// The queue
@@ -336,25 +326,118 @@ namespace EasyNetQ
         public static IQueue QueueDeclare(
             this IAdvancedBus bus,
             string name,
-            bool passive = false,
-            bool durable = true,
-            bool exclusive = false,
-            bool autoDelete = false,
-            int? perQueueMessageTtl = null,
-            int? expires = null,
-            int? maxPriority = null,
-            string deadLetterExchange = null,
-            string deadLetterRoutingKey = null,
-            int? maxLength = null,
-            int? maxLengthBytes = null,
+            Action<IQueueDeclareConfiguration> configure,
             CancellationToken cancellationToken = default
         )
         {
             Preconditions.CheckNotNull(bus, "bus");
-            
-            return bus.QueueDeclareAsync(name, passive, durable, exclusive, autoDelete, perQueueMessageTtl, expires, maxPriority, deadLetterExchange, deadLetterRoutingKey, maxLength, maxLengthBytes, cancellationToken)
-                      .GetAwaiter()
-                      .GetResult();
+
+            return bus.QueueDeclareAsync(name, configure, cancellationToken)
+                .GetAwaiter()
+                .GetResult();
+        }
+
+
+        /// <summary>
+        /// Declare a queue. If the queue already exists this method does nothing
+        /// </summary>
+        /// <param name="bus">The bus instance</param>
+        /// <param name="name">The name of the queue</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>
+        /// The queue
+        /// </returns>
+        public static Task<IQueue> QueueDeclareAsync(
+            this IAdvancedBus bus,
+            string name,
+            CancellationToken cancellationToken = default
+        )
+        {
+            Preconditions.CheckNotNull(bus, "bus");
+
+            return bus.QueueDeclareAsync(name, c => { }, cancellationToken);
+        }
+
+        /// <summary>
+        /// Declare a queue. If the queue already exists this method does nothing
+        /// </summary>
+        /// <param name="bus">The bus instance</param>
+        /// <param name="name">The name of the queue</param>
+        /// <param name="durable">Durable queues remain active when a server restarts.</param>
+        /// <param name="exclusive">Exclusive queues may only be accessed by the current connection, and are deleted when that connection closes.</param>
+        /// <param name="autoDelete">If set, the queue is deleted when all consumers have finished using it.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>
+        /// The queue
+        /// </returns>
+        public static Task<IQueue> QueueDeclareAsync(
+            this IAdvancedBus bus,
+            string name,
+            bool durable,
+            bool exclusive,
+            bool autoDelete,
+            CancellationToken cancellationToken = default
+        )
+        {
+            Preconditions.CheckNotNull(bus, "bus");
+
+            return bus.QueueDeclareAsync(
+                name,
+                c => c.AsDurable(durable)
+                    .AsExclusive(exclusive)
+                    .AsAutoDelete(autoDelete),
+                cancellationToken
+            );
+        }
+
+        /// <summary>
+        /// Declare a queue. If the queue already exists this method does nothing
+        /// </summary>
+        /// <param name="bus">The bus instance</param>
+        /// <param name="name">The name of the queue</param>
+        /// <param name="durable">Durable queues remain active when a server restarts.</param>
+        /// <param name="exclusive">Exclusive queues may only be accessed by the current connection, and are deleted when that connection closes.</param>
+        /// <param name="autoDelete">If set, the queue is deleted when all consumers have finished using it.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>
+        /// The queue
+        /// </returns>
+        public static IQueue QueueDeclare(
+            this IAdvancedBus bus,
+            string name,
+            bool durable,
+            bool exclusive,
+            bool autoDelete,
+            CancellationToken cancellationToken = default
+        )
+        {
+            Preconditions.CheckNotNull(bus, "bus");
+
+            return bus.QueueDeclareAsync(name, durable, exclusive, autoDelete, cancellationToken)
+                .GetAwaiter()
+                .GetResult();
+        }
+
+        /// <summary>
+        /// Declare a queue. If the queue already exists this method does nothing
+        /// </summary>
+        /// <param name="bus">The bus instance</param>
+        /// <param name="name">The name of the queue</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>
+        /// The queue
+        /// </returns>
+        public static IQueue QueueDeclare(
+            this IAdvancedBus bus,
+            string name,
+            CancellationToken cancellationToken = default
+        )
+        {
+            Preconditions.CheckNotNull(bus, "bus");
+
+            return bus.QueueDeclareAsync(name, cancellationToken)
+                .GetAwaiter()
+                .GetResult();
         }
 
         /// <summary>
@@ -371,8 +454,8 @@ namespace EasyNetQ
             Preconditions.CheckNotNull(bus, "bus");
 
             return bus.BindAsync(source, destination, routingKey, cancellationToken)
-                      .GetAwaiter()
-                      .GetResult();
+                .GetAwaiter()
+                .GetResult();
         }
 
         /// <summary>
@@ -395,10 +478,10 @@ namespace EasyNetQ
         )
         {
             Preconditions.CheckNotNull(bus, "bus");
-            
+
             return bus.BindAsync(source, destination, routingKey, headers, cancellationToken)
-                      .GetAwaiter()
-                      .GetResult();
+                .GetAwaiter()
+                .GetResult();
         }
 
         /// <summary>
@@ -415,8 +498,8 @@ namespace EasyNetQ
             Preconditions.CheckNotNull(bus, "bus");
 
             return bus.BindAsync(exchange, queue, routingKey, cancellationToken)
-                      .GetAwaiter()
-                      .GetResult();
+                .GetAwaiter()
+                .GetResult();
         }
 
         /// <summary>
@@ -431,7 +514,7 @@ namespace EasyNetQ
         /// <returns>A binding</returns>
         public static IBinding Bind(
             this IAdvancedBus bus,
-            IExchange exchange, 
+            IExchange exchange,
             IQueue queue,
             string routingKey,
             IDictionary<string, object> headers,
@@ -439,7 +522,7 @@ namespace EasyNetQ
         )
         {
             Preconditions.CheckNotNull(bus, "bus");
-            
+
             return bus.BindAsync(exchange, queue, routingKey, headers, cancellationToken)
                 .GetAwaiter()
                 .GetResult();
@@ -472,10 +555,10 @@ namespace EasyNetQ
         )
         {
             Preconditions.CheckNotNull(bus, "bus");
-            
+
             return bus.ExchangeDeclareAsync(name, type, passive, durable, autoDelete, alternateExchange, delayed, cancellationToken)
-                      .GetAwaiter()
-                      .GetResult();
+                .GetAwaiter()
+                .GetResult();
         }
 
         /// <summary>
@@ -489,8 +572,8 @@ namespace EasyNetQ
             Preconditions.CheckNotNull(bus, "bus");
 
             bus.UnbindAsync(binding, cancellationToken)
-               .GetAwaiter()
-               .GetResult();
+                .GetAwaiter()
+                .GetResult();
         }
 
         /// <summary>
@@ -506,8 +589,8 @@ namespace EasyNetQ
             Preconditions.CheckNotNull(bus, "bus");
 
             bus.QueueDeleteAsync(queue, ifUnused, ifEmpty, cancellationToken)
-               .GetAwaiter()
-               .GetResult();
+                .GetAwaiter()
+                .GetResult();
         }
 
         /// <summary>
@@ -521,8 +604,8 @@ namespace EasyNetQ
             Preconditions.CheckNotNull(bus, "bus");
 
             bus.QueuePurgeAsync(queue, cancellationToken)
-               .GetAwaiter()
-               .GetResult();
+                .GetAwaiter()
+                .GetResult();
         }
 
         /// <summary>
@@ -537,8 +620,8 @@ namespace EasyNetQ
             Preconditions.CheckNotNull(bus, "bus");
 
             bus.ExchangeDeleteAsync(exchange, ifUnused, cancellationToken)
-               .GetAwaiter()
-               .GetResult();
+                .GetAwaiter()
+                .GetResult();
         }
     }
 }

--- a/Source/EasyNetQ/ConnectionConfiguration.cs
+++ b/Source/EasyNetQ/ConnectionConfiguration.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -12,33 +11,6 @@ namespace EasyNetQ
     {
         private const int DefaultPort = 5672;
         private const int DefaultAmqpsPort = 5671;
-        public ushort Port { get; set; }
-        public string VirtualHost { get; set; }
-        public string UserName { get; set; }
-        public string Password { get; set; }
-        /// <summary>
-        /// Heartbeat interval seconds. (default is 10)
-        /// </summary>
-        public ushort RequestedHeartbeat { get; set; }
-        public ushort PrefetchCount { get; set; }
-        public Uri AMQPConnectionString { get; set; }
-        public IDictionary<string, object> ClientProperties { get; } 
-
-        public IEnumerable<HostConfiguration> Hosts { get; set; }
-        public SslOption Ssl { get; }
-        /// <summary>
-        /// Operation timeout seconds. (default is 10)
-        /// </summary>
-        public ushort Timeout { get; set; }
-        public bool PublisherConfirms { get; set; }
-        public bool PersistentMessages { get; set; }
-        public string Product { get; set; }
-        public string Platform { get; set; }
-        public string Name { get; set; }
-        public bool UseBackgroundThreads { get; set; }
-        public IList<AuthMechanismFactory> AuthMechanisms { get; set; }
-        public TimeSpan ConnectIntervalAttempt { get;  set; }
-        public int DispatcherQueueSize { get; set; }
 
         public ConnectionConfiguration()
         {
@@ -54,19 +26,51 @@ namespace EasyNetQ
             UseBackgroundThreads = false;
             ConnectIntervalAttempt = TimeSpan.FromSeconds(5);
             DispatcherQueueSize = 1024;
-                         
+
             // prefetchCount determines how many messages will be allowed in the local in-memory queue
             // setting to zero makes this infinite, but risks an out-of-memory exception.
             // set to 50 based on this blog post:
             // http://www.rabbitmq.com/blog/2012/04/25/rabbitmq-performance-measurements-part-2/
             PrefetchCount = 50;
             AuthMechanisms = new AuthMechanismFactory[] {new PlainMechanismFactory()};
-            
+
             Hosts = new List<HostConfiguration>();
 
             Ssl = new SslOption();
             ClientProperties = new Dictionary<string, object>();
         }
+
+        public ushort Port { get; set; }
+        public string VirtualHost { get; set; }
+        public string UserName { get; set; }
+        public string Password { get; set; }
+
+        /// <summary>
+        /// Heartbeat interval seconds. (default is 10)
+        /// </summary>
+        public ushort RequestedHeartbeat { get; set; }
+
+        public ushort PrefetchCount { get; set; }
+        public Uri AMQPConnectionString { get; set; }
+        public IDictionary<string, object> ClientProperties { get; }
+
+        public IEnumerable<HostConfiguration> Hosts { get; set; }
+        public SslOption Ssl { get; }
+
+        /// <summary>
+        /// Operation timeout seconds. (default is 10)
+        /// </summary>
+        public ushort Timeout { get; set; }
+
+        public bool PublisherConfirms { get; set; }
+        public bool PersistentMessages { get; set; }
+        public string Product { get; set; }
+        public string Platform { get; set; }
+        public string Name { get; set; }
+        public bool UseBackgroundThreads { get; set; }
+        public IList<AuthMechanismFactory> AuthMechanisms { get; set; }
+        public TimeSpan ConnectIntervalAttempt { get; set; }
+        public int DispatcherQueueSize { get; set; }
 
         private void SetDefaultClientProperties(IDictionary<string, object> clientProperties)
         {
@@ -92,8 +96,12 @@ namespace EasyNetQ
                     applicationName = Path.GetFileName(applicationNameAndPath);
                     applicationPath = Path.GetDirectoryName(applicationNameAndPath);
                 }
-                catch (ArgumentException) { }
-                catch (PathTooLongException) { }
+                catch (ArgumentException)
+                {
+                }
+                catch (PathTooLongException)
+                {
+                }
             }
 
             var hostname = Environment.MachineName;
@@ -132,20 +140,24 @@ namespace EasyNetQ
                 if (Port == DefaultPort)
                 {
                     if (AMQPConnectionString.Port > 0)
-                        Port = (ushort)AMQPConnectionString.Port;
-                    else if(AMQPConnectionString.Scheme.Equals("amqps", StringComparison.OrdinalIgnoreCase))
+                        Port = (ushort) AMQPConnectionString.Port;
+                    else if (AMQPConnectionString.Scheme.Equals("amqps", StringComparison.OrdinalIgnoreCase))
                         Port = DefaultAmqpsPort;
                 }
+
                 if (AMQPConnectionString.Segments.Length > 1)
                 {
                     VirtualHost = AMQPConnectionString.Segments.Last();
                 }
+
                 Hosts = Hosts.Concat(new[] {new HostConfiguration {Host = AMQPConnectionString.Host}});
             }
+
             if (!Hosts.Any())
             {
                 throw new EasyNetQException("Invalid connection string. 'host' value must be supplied. e.g: \"host=myserver\"");
             }
+
             foreach (var hostConfiguration in Hosts)
             {
                 if (hostConfiguration.Port == 0)

--- a/Source/EasyNetQ/IAdvancedBus.cs
+++ b/Source/EasyNetQ/IAdvancedBus.cs
@@ -17,6 +17,21 @@ namespace EasyNetQ
     public interface IAdvancedBus : IDisposable
     {
         /// <summary>
+        /// True if the bus is connected, False if it is not.
+        /// </summary>
+        bool IsConnected { get; }
+
+        /// <summary>
+        /// The IoC container that EasyNetQ uses to resolve its services.
+        /// </summary>
+        IServiceResolver Container { get; }
+
+        /// <summary>
+        /// The conventions used by EasyNetQ to name its routing topology elements.
+        /// </summary>
+        IConventions Conventions { get; }
+
+        /// <summary>
         /// Consume a stream of messages
         /// </summary>
         /// <param name="queueConsumerPairs">Multiple queue - consumer pairs</param>
@@ -154,20 +169,9 @@ namespace EasyNetQ
         /// <returns>The queue</returns>
         Task<IQueue> QueueDeclareAsync(
             string name,
-            bool passive = false,
-            bool durable = true,
-            bool exclusive = false,
-            bool autoDelete = false,
-            int? perQueueMessageTtl  = null,
-            int? expires = null,
-            int? maxPriority = null,
-            string deadLetterExchange = null,
-            string deadLetterRoutingKey = null,
-            int? maxLength = null,
-            int? maxLengthBytes = null,
+            Action<IQueueDeclareConfiguration> configure,
             CancellationToken cancellationToken = default
         );
-
 
         /// <summary>
         /// Declare a transient server named queue. Note, this queue will only last for duration of the
@@ -177,7 +181,10 @@ namespace EasyNetQ
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The queue</returns>
         Task<IQueue> QueueDeclareAsync(CancellationToken cancellationToken = default);
-        
+
+
+        Task QueueDeclarePassiveAsync(string name, CancellationToken cancellationToken = default);
+
         /// <summary>
         /// Delete a queue
         /// </summary>
@@ -282,7 +289,7 @@ namespace EasyNetQ
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>An IBasicGetResult.</returns>
         Task<IBasicGetResult<T>> GetMessageAsync<T>(IQueue queue, CancellationToken cancellationToken = default);
- 
+
         /// <summary>
         /// Get the raw message from the given queue.
         /// </summary>
@@ -298,11 +305,6 @@ namespace EasyNetQ
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The number of counted messages</returns>
         Task<uint> GetMessagesCountAsync(IQueue queue, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// True if the bus is connected, False if it is not.
-        /// </summary>
-        bool IsConnected { get; }
 
         /// <summary>
         /// Event fires when the bus has connected to a RabbitMQ broker.
@@ -328,15 +330,5 @@ namespace EasyNetQ
         /// Event fires when a mandatory or immediate message is returned as un-routable
         /// </summary>
         event EventHandler<MessageReturnedEventArgs> MessageReturned;
-
-        /// <summary>
-        /// The IoC container that EasyNetQ uses to resolve its services.
-        /// </summary>
-        IServiceResolver Container { get; }
-
-        /// <summary>
-        /// The conventions used by EasyNetQ to name its routing topology elements.
-        /// </summary>
-        IConventions Conventions { get; }
     }
 }

--- a/Source/EasyNetQ/Producer/DefaultPubSub.cs
+++ b/Source/EasyNetQ/Producer/DefaultPubSub.cs
@@ -10,11 +10,11 @@ namespace EasyNetQ.Producer
 {
     public class DefaultPubSub : IPubSub
     {
+        private readonly IAdvancedBus advancedBus;
         private readonly ConnectionConfiguration connectionConfiguration;
         private readonly IConventions conventions;
-        private readonly IPublishExchangeDeclareStrategy publishExchangeDeclareStrategy;
         private readonly IMessageDeliveryModeStrategy messageDeliveryModeStrategy;
-        private readonly IAdvancedBus advancedBus;
+        private readonly IPublishExchangeDeclareStrategy publishExchangeDeclareStrategy;
 
         public DefaultPubSub(
             ConnectionConfiguration connectionConfiguration,
@@ -29,7 +29,7 @@ namespace EasyNetQ.Producer
             Preconditions.CheckNotNull(publishExchangeDeclareStrategy, "publishExchangeDeclareStrategy");
             Preconditions.CheckNotNull(messageDeliveryModeStrategy, "messageDeliveryModeStrategy");
             Preconditions.CheckNotNull(advancedBus, "advancedBus");
-            
+
             this.connectionConfiguration = connectionConfiguration;
             this.conventions = conventions;
             this.publishExchangeDeclareStrategy = publishExchangeDeclareStrategy;
@@ -78,7 +78,7 @@ namespace EasyNetQ.Producer
 
         private async Task<ISubscriptionResult> SubscribeAsyncInternal<T>(
             string subscriptionId,
-            Func<T, CancellationToken, Task> onMessage, 
+            Func<T, CancellationToken, Task> onMessage,
             Action<ISubscriptionConfiguration> configure,
             CancellationToken cancellationToken
         )
@@ -90,16 +90,19 @@ namespace EasyNetQ.Producer
             var exchangeName = conventions.ExchangeNamingConvention(typeof(T));
 
             var queue = await advancedBus.QueueDeclareAsync(
-                queueName, 
-                autoDelete: configuration.AutoDelete, 
-                durable: configuration.Durable, 
-                expires: configuration.Expires, 
-                maxPriority: configuration.MaxPriority,
-                maxLength: configuration.MaxLength,
-                maxLengthBytes: configuration.MaxLengthBytes,
-                cancellationToken: cancellationToken
+                queueName,
+                c =>
+                {
+                    c.AsDurable(configuration.Durable);
+                    c.AsAutoDelete(configuration.AutoDelete);
+                    if (configuration.Expires.HasValue) c.WithExpires(TimeSpan.FromSeconds(configuration.Expires.Value));
+                    if (configuration.MaxPriority.HasValue) c.WithMaxPriority(configuration.MaxPriority.Value);
+                    if (configuration.MaxLength.HasValue) c.WithMaxLength(configuration.MaxLength.Value);
+                    if (configuration.MaxLengthBytes.HasValue) c.WithMaxLengthBytes(configuration.MaxLengthBytes.Value);
+                },
+                cancellationToken
             ).ConfigureAwait(false);
-            
+
             var exchange = await advancedBus.ExchangeDeclareAsync(exchangeName, ExchangeType.Topic, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             foreach (var topic in configuration.Topics.DefaultIfEmpty("#"))
@@ -111,10 +114,10 @@ namespace EasyNetQ.Producer
                 queue,
                 (message, messageReceivedInfo) => onMessage(message.Body, default),
                 x => x.WithPriority(configuration.Priority)
-                      .WithPrefetchCount(configuration.PrefetchCount)
-                      .WithExclusive(configuration.IsExclusive)
+                    .WithPrefetchCount(configuration.PrefetchCount)
+                    .WithExclusive(configuration.IsExclusive)
             );
-            
+
             return new SubscriptionResult(exchange, queue, consumerCancellation);
         }
     }

--- a/Source/EasyNetQ/Producer/DefaultPubSub.cs
+++ b/Source/EasyNetQ/Producer/DefaultPubSub.cs
@@ -95,7 +95,7 @@ namespace EasyNetQ.Producer
                 {
                     c.AsDurable(configuration.Durable);
                     c.AsAutoDelete(configuration.AutoDelete);
-                    if (configuration.Expires.HasValue) c.WithExpires(TimeSpan.FromSeconds(configuration.Expires.Value));
+                    if (configuration.Expires.HasValue) c.WithExpires(TimeSpan.FromMilliseconds(configuration.Expires.Value));
                     if (configuration.MaxPriority.HasValue) c.WithMaxPriority(configuration.MaxPriority.Value);
                     if (configuration.MaxLength.HasValue) c.WithMaxLength(configuration.MaxLength.Value);
                     if (configuration.MaxLengthBytes.HasValue) c.WithMaxLengthBytes(configuration.MaxLengthBytes.Value);

--- a/Source/EasyNetQ/QueueDeclareConfiguration.cs
+++ b/Source/EasyNetQ/QueueDeclareConfiguration.cs
@@ -40,8 +40,8 @@ namespace EasyNetQ
                 c.AsDurable(durable);
                 c.AsExclusive(exclusive);
                 c.AsAutoDelete(autoDelete);
-                if (perQueueMessageTtl.HasValue) c.WithMessageTtl(TimeSpan.FromSeconds(perQueueMessageTtl.Value));
-                if (expires.HasValue) c.WithExpires(TimeSpan.FromSeconds(expires.Value));
+                if (perQueueMessageTtl.HasValue) c.WithMessageTtl(TimeSpan.FromMilliseconds(perQueueMessageTtl.Value));
+                if (expires.HasValue) c.WithExpires(TimeSpan.FromMilliseconds(expires.Value));
                 if (maxPriority.HasValue) c.WithMaxPriority(maxPriority.Value);
                 if (deadLetterExchange != null) c.WithDeadLetterExchange(new Exchange(deadLetterExchange));
                 if (deadLetterRoutingKey != null) c.WithDeadLetterRoutingKey(deadLetterRoutingKey);

--- a/Source/EasyNetQ/QueueDeclareConfiguration.cs
+++ b/Source/EasyNetQ/QueueDeclareConfiguration.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using EasyNetQ.Topology;
+
+namespace EasyNetQ
+{
+    public static class QueueDeclareConfigurationActions
+    {
+        /// <summary>
+        /// Create the action to configure queue
+        /// </summary>
+        /// <param name="durable">Durable queues remain active when a server restarts.</param>
+        /// <param name="exclusive">Exclusive queues may only be accessed by the current connection, and are deleted when that connection closes.</param>
+        /// <param name="autoDelete">If set, the queue is deleted when all consumers have finished using it.</param>
+        /// <param name="perQueueMessageTtl">Determines how long a message published to a queue can live before it is discarded by the server.</param>
+        /// <param name="expires">Determines how long a queue can remain unused before it is automatically deleted by the server.</param>
+        /// <param name="maxPriority">Determines the maximum message priority that the queue should support.</param>
+        /// <param name="deadLetterExchange">Determines an exchange's name can remain unused before it is automatically deleted by the server.</param>
+        /// <param name="deadLetterRoutingKey">If set, will route message with the routing key specified, if not set, message will be routed with the same routing keys they were originally published with.</param>
+        /// <param name="maxLength">The maximum number of ready messages that may exist on the queue.  Messages will be dropped or dead-lettered from the front of the queue to make room for new messages once the limit is reached</param>
+        /// <param name="maxLengthBytes">The maximum size of the queue in bytes.  Messages will be dropped or dead-lettered from the front of the queue to make room for new messages once the limit is reached</param>
+        /// <returns>
+        /// The configuration action
+        /// </returns>
+        public static Action<IQueueDeclareConfiguration> From(
+            bool durable = true,
+            bool exclusive = false,
+            bool autoDelete = false,
+            int? perQueueMessageTtl = null,
+            int? expires = null,
+            int? maxPriority = null,
+            string deadLetterExchange = null,
+            string deadLetterRoutingKey = null,
+            int? maxLength = null,
+            int? maxLengthBytes = null
+        )
+        {
+            return c =>
+            {
+                c.AsDurable(durable);
+                c.AsExclusive(exclusive);
+                c.AsAutoDelete(autoDelete);
+                if (perQueueMessageTtl.HasValue) c.WithMessageTtl(TimeSpan.FromSeconds(perQueueMessageTtl.Value));
+                if (expires.HasValue) c.WithExpires(TimeSpan.FromSeconds(expires.Value));
+                if (maxPriority.HasValue) c.WithMaxPriority(maxPriority.Value);
+                if (deadLetterExchange != null) c.WithDeadLetterExchange(new Exchange(deadLetterExchange));
+                if (deadLetterRoutingKey != null) c.WithDeadLetterRoutingKey(deadLetterRoutingKey);
+                if (maxLength.HasValue) c.WithMaxLength(maxLength.Value);
+                if (maxLengthBytes.HasValue) c.WithMaxLengthBytes(maxLengthBytes.Value);
+            };
+        }
+    }
+
+    /// <summary>
+    /// Allows queue declaration configuration to be fluently extended without adding overloads to IBus
+    /// 
+    /// e.g.
+    /// x => x.WithMaxPriority(42)
+    /// </summary>
+    public interface IQueueDeclareConfiguration
+    {
+        /// <summary>
+        /// Sets as durable or not. Durable queues remain active when a server restarts.
+        /// </summary>
+        /// <param name="durable">The durable flag to set</param>
+        /// <returns>IQueueDeclareConfiguration</returns>
+        IQueueDeclareConfiguration AsDurable(bool durable = true);
+
+        /// <summary>
+        /// Sets as exclusive or not. Exclusive queues may only be accessed by the current connection, and are deleted when that connection closes.
+        /// </summary>
+        /// <param name="exclusive">The exclusive flag to set</param>
+        /// <returns>IQueueDeclareConfiguration</returns>
+        IQueueDeclareConfiguration AsExclusive(bool exclusive = true);
+
+        /// <summary>
+        /// Sets as autoDelete or not. If set, the queue is deleted when all consumers have finished using it.
+        /// </summary>
+        /// <param name="autoDelete">The autoDelete flag to set</param>
+        /// <returns>IQueueDeclareConfiguration</returns>
+        IQueueDeclareConfiguration AsAutoDelete(bool autoDelete = true);
+
+        /// <summary>
+        /// Sets queue as autoDelete or not. If set, the queue is deleted when all consumers have finished using it.
+        /// </summary>
+        /// <param name="maxPriority">The autoDelete flag to set</param>
+        /// <returns>IQueueDeclareConfiguration</returns>
+        IQueueDeclareConfiguration WithMaxPriority(int maxPriority);
+
+        /// <summary>
+        /// Sets maxLength. The maximum number of ready messages that may exist on the queue. Messages will be dropped or dead-lettered from the front of the queue to make room for new messages once the limit is reached.
+        /// </summary>
+        /// <param name="maxLength">The maxLength to set</param>
+        /// <returns>IQueueDeclareConfiguration</returns>
+        IQueueDeclareConfiguration WithMaxLength(int maxLength);
+
+        /// <summary>
+        /// Sets maxLengthBytes. The maximum size of the queue in bytes.  Messages will be dropped or dead-lettered from the front of the queue to make room for new messages once the limit is reached.
+        /// </summary>
+        /// <param name="maxLengthBytes">The maxLengthBytes flag to set</param>
+        /// <returns>IQueueDeclareConfiguration</returns>
+        IQueueDeclareConfiguration WithMaxLengthBytes(int maxLengthBytes);
+
+        /// <summary>
+        /// Sets expires of the queue. Determines how long a queue can remain unused before it is automatically deleted by the server.
+        /// </summary>
+        /// <param name="expires">The autoDelete flag to set</param>
+        /// <returns>IQueueDeclareConfiguration</returns>
+        IQueueDeclareConfiguration WithExpires(TimeSpan expires);
+
+        /// <summary>
+        /// Sets messageTtl. Determines how long a message published to a queue can live before it is discarded by the server.
+        /// </summary>
+        /// <param name="messageTtl">The messageTtl to set</param>
+        /// <returns>IQueueDeclareConfiguration</returns>
+        IQueueDeclareConfiguration WithMessageTtl(TimeSpan messageTtl);
+
+        /// <summary>
+        /// Sets deadLetterExchange. Determines an exchange's name can remain unused before it is automatically deleted by the server.
+        /// </summary>
+        /// <param name="deadLetterExchange">The deadLetterExchange to set</param>
+        /// <returns>IQueueDeclareConfiguration</returns>
+        IQueueDeclareConfiguration WithDeadLetterExchange(IExchange deadLetterExchange);
+
+        /// <summary>
+        /// Sets deadLetterRoutingKey. If set, will route message with the routing key specified, if not set, message will be routed with the same routing keys they were originally published with.
+        /// </summary>
+        /// <param name="deadLetterRoutingKey">The deadLetterRoutingKey to set</param>
+        /// <returns>IQueueDeclareConfiguration</returns>
+        IQueueDeclareConfiguration WithDeadLetterRoutingKey(string deadLetterRoutingKey);
+
+        /// <summary>
+        /// Sets queueMode. Valid modes are default and lazy.
+        /// </summary>
+        /// <param name="queueMode">The queueMode to set</param>
+        /// <returns>IQueueDeclareConfiguration</returns>
+        IQueueDeclareConfiguration WithQueueMode(string queueMode = QueueMode.Default);
+    }
+
+    public static class QueueMode
+    {
+        public const string Default = "default";
+
+        public const string Lazy = "lazy";
+    }
+
+    public class QueueDeclareConfiguration : IQueueDeclareConfiguration
+    {
+        public bool Durable { get; private set; } = true;
+        public bool Exclusive { get; private set; }
+        public bool AutoDelete { get; private set; }
+
+        public IDictionary<string, object> Arguments { get; } = new Dictionary<string, object>();
+
+        public IQueueDeclareConfiguration AsDurable(bool durable = true)
+        {
+            Durable = durable;
+            return this;
+        }
+
+        public IQueueDeclareConfiguration AsExclusive(bool exclusive = true)
+        {
+            Exclusive = exclusive;
+            return this;
+        }
+
+        public IQueueDeclareConfiguration AsAutoDelete(bool autoDelete = true)
+        {
+            AutoDelete = autoDelete;
+            return this;
+        }
+
+        public IQueueDeclareConfiguration WithMaxPriority(int maxPriority)
+        {
+            Arguments["x-max-priority"] = maxPriority.ToString();
+            return this;
+        }
+
+        public IQueueDeclareConfiguration WithMaxLength(int maxLength)
+        {
+            Arguments["x-max-length"] = maxLength.ToString();
+            return this;
+        }
+
+        public IQueueDeclareConfiguration WithMaxLengthBytes(int maxLengthBytes)
+        {
+            Arguments["x-max-length-bytes"] = maxLengthBytes.ToString();
+            return this;
+        }
+
+        public IQueueDeclareConfiguration WithExpires(TimeSpan expires)
+        {
+            Arguments["x-expires"] = ((long) expires.TotalSeconds).ToString();
+            return this;
+        }
+
+        public IQueueDeclareConfiguration WithMessageTtl(TimeSpan messageTtl)
+        {
+            Arguments["x-message-ttl"] = ((long) messageTtl.TotalSeconds).ToString();
+            return this;
+        }
+
+        public IQueueDeclareConfiguration WithDeadLetterExchange(IExchange deadLetterExchange)
+        {
+            Arguments["x-dead-letter-exchange"] = deadLetterExchange.Name;
+            return this;
+        }
+
+        public IQueueDeclareConfiguration WithDeadLetterRoutingKey(string deadLetterRoutingKey)
+        {
+            Arguments["x-dead-letter-routing-key"] = deadLetterRoutingKey;
+            return this;
+        }
+
+        public IQueueDeclareConfiguration WithQueueMode(string queueMode = QueueMode.Default)
+        {
+            Arguments["x-queue-mode"] = queueMode;
+            return this;
+        }
+    }
+}

--- a/Source/EasyNetQ/QueueDeclareConfiguration.cs
+++ b/Source/EasyNetQ/QueueDeclareConfiguration.cs
@@ -137,13 +137,6 @@ namespace EasyNetQ
         IQueueDeclareConfiguration WithQueueMode(string queueMode = QueueMode.Default);
     }
 
-    public static class QueueMode
-    {
-        public const string Default = "default";
-
-        public const string Lazy = "lazy";
-    }
-
     public class QueueDeclareConfiguration : IQueueDeclareConfiguration
     {
         public bool Durable { get; private set; } = true;
@@ -172,31 +165,31 @@ namespace EasyNetQ
 
         public IQueueDeclareConfiguration WithMaxPriority(int maxPriority)
         {
-            Arguments["x-max-priority"] = maxPriority.ToString();
+            Arguments["x-max-priority"] = maxPriority;
             return this;
         }
 
         public IQueueDeclareConfiguration WithMaxLength(int maxLength)
         {
-            Arguments["x-max-length"] = maxLength.ToString();
+            Arguments["x-max-length"] = maxLength;
             return this;
         }
 
         public IQueueDeclareConfiguration WithMaxLengthBytes(int maxLengthBytes)
         {
-            Arguments["x-max-length-bytes"] = maxLengthBytes.ToString();
+            Arguments["x-max-length-bytes"] = maxLengthBytes;
             return this;
         }
 
         public IQueueDeclareConfiguration WithExpires(TimeSpan expires)
         {
-            Arguments["x-expires"] = ((long) expires.TotalSeconds).ToString();
+            Arguments["x-expires"] = (int) expires.TotalMilliseconds;
             return this;
         }
 
         public IQueueDeclareConfiguration WithMessageTtl(TimeSpan messageTtl)
         {
-            Arguments["x-message-ttl"] = ((long) messageTtl.TotalSeconds).ToString();
+            Arguments["x-message-ttl"] = (int) messageTtl.TotalMilliseconds;
             return this;
         }
 

--- a/Source/EasyNetQ/QueueMode.cs
+++ b/Source/EasyNetQ/QueueMode.cs
@@ -1,0 +1,9 @@
+namespace EasyNetQ
+{
+    public static class QueueMode
+    {
+        public const string Default = "default";
+
+        public const string Lazy = "lazy";
+    }
+}

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -16,16 +16,18 @@ namespace EasyNetQ
 {
     public class RabbitAdvancedBus : IAdvancedBus
     {
-        private readonly ILog logger = LogProvider.For<RabbitAdvancedBus>();
-        private readonly IConsumerFactory consumerFactory;
+        private readonly IClientCommandDispatcher clientCommandDispatcher;
         private readonly IPublishConfirmationListener confirmationListener;
         private readonly IPersistentConnection connection;
-        private readonly IClientCommandDispatcher clientCommandDispatcher;
+        private readonly ConnectionConfiguration connectionConfiguration;
+        private readonly IConsumerFactory consumerFactory;
         private readonly IEventBus eventBus;
         private readonly IHandlerCollectionFactory handlerCollectionFactory;
-        private readonly ConnectionConfiguration connectionConfiguration;
-        private readonly IProduceConsumeInterceptor produceConsumeInterceptor;
+        private readonly ILog logger = LogProvider.For<RabbitAdvancedBus>();
         private readonly IMessageSerializationStrategy messageSerializationStrategy;
+        private readonly IProduceConsumeInterceptor produceConsumeInterceptor;
+
+        private bool disposed;
 
         public RabbitAdvancedBus(
             IConnectionFactory connectionFactory,
@@ -70,21 +72,25 @@ namespace EasyNetQ
             {
                 Connected += advancedBusEventHandlers.Connected;
             }
+
             this.eventBus.Subscribe<ConnectionDisconnectedEvent>(e => OnDisconnected());
             if (advancedBusEventHandlers.Disconnected != null)
             {
                 Disconnected += advancedBusEventHandlers.Disconnected;
             }
+
             this.eventBus.Subscribe<ConnectionBlockedEvent>(OnBlocked);
             if (advancedBusEventHandlers.Blocked != null)
             {
                 Blocked += advancedBusEventHandlers.Blocked;
             }
+
             this.eventBus.Subscribe<ConnectionUnblockedEvent>(e => OnUnblocked());
             if (advancedBusEventHandlers.Unblocked != null)
             {
                 Unblocked += advancedBusEventHandlers.Unblocked;
             }
+
             this.eventBus.Subscribe<ReturnedMessageEvent>(OnMessageReturned);
             if (advancedBusEventHandlers.MessageReturned != null)
             {
@@ -120,6 +126,7 @@ namespace EasyNetQ
                         return handler(deserializedMessage, i, c);
                     };
                 }
+
                 return Tuple.Create(x.Queue, onMessage);
             }).ToList();
 
@@ -168,10 +175,10 @@ namespace EasyNetQ
             var consumerConfiguration = new ConsumerConfiguration(connectionConfiguration.PrefetchCount);
             configure(consumerConfiguration);
             var consumer = consumerFactory.CreateConsumer(queue, (body, properties, receivedInfo, cancellationToken) =>
-                {
-                    var rawMessage = produceConsumeInterceptor.OnConsume(new RawMessage(properties, body));
-                    return onMessage(rawMessage.Body, rawMessage.Properties, receivedInfo, cancellationToken);
-                }, connection, consumerConfiguration);
+            {
+                var rawMessage = produceConsumeInterceptor.OnConsume(new RawMessage(properties, body));
+                return onMessage(rawMessage.Body, rawMessage.Properties, receivedInfo, cancellationToken);
+            }, connection, consumerConfiguration);
             return consumer.StartConsuming();
         }
 
@@ -266,14 +273,14 @@ namespace EasyNetQ
                     model.BasicPublish(exchange.Name, routingKey, mandatory, properties, rawMessage.Body);
                 }, cancellationToken).ConfigureAwait(false);
             }
-            
+
             eventBus.Publish(new PublishedMessageEvent(exchange.Name, routingKey, rawMessage.Properties, rawMessage.Body));
 
             if (logger.IsDebugEnabled())
             {
                 logger.DebugFormat(
                     "Published to exchange {exchange} with routingKey={routingKey} and correlationId={correlationId}",
-                    exchange.Name, 
+                    exchange.Name,
                     routingKey,
                     messageProperties.CorrelationId
                 );
@@ -286,65 +293,43 @@ namespace EasyNetQ
 
         public Task<IQueue> QueueDeclareAsync(CancellationToken cancellationToken)
         {
-            return QueueDeclareAsync(string.Empty, durable: true, exclusive: true, autoDelete: true, cancellationToken: cancellationToken);
+            return QueueDeclareAsync(
+                string.Empty,
+                c => c.AsDurable()
+                    .AsExclusive()
+                    .AsAutoDelete(),
+                cancellationToken
+            );
+        }
+
+        public async Task QueueDeclarePassiveAsync(string name, CancellationToken cancellationToken = default)
+        {
+            Preconditions.CheckNotNull(name, "name");
+
+            await clientCommandDispatcher.InvokeAsync(x => x.QueueDeclarePassive(name), cancellationToken).ConfigureAwait(false);
+
+            if (logger.IsDebugEnabled())
+            {
+                logger.DebugFormat("Passive declared queue {queue}", name);
+            }
         }
 
         public async Task<IQueue> QueueDeclareAsync(
             string name,
-            bool passive = false,
-            bool durable = true,
-            bool exclusive = false,
-            bool autoDelete = false,
-            int? perQueueMessageTtl  = null,
-            int? expires = null,
-            int? maxPriority = null,
-            string deadLetterExchange = null,
-            string deadLetterRoutingKey = null,
-            int? maxLength = null,
-            int? maxLengthBytes = null,
+            Action<IQueueDeclareConfiguration> configure,
             CancellationToken cancellationToken = default
         )
         {
-            Preconditions.CheckNotNull(name, "name");
+            var queueDeclareConfiguration = new QueueDeclareConfiguration();
+            configure?.Invoke(queueDeclareConfiguration);
+            var durable = queueDeclareConfiguration.Durable;
+            var exclusive = queueDeclareConfiguration.Exclusive;
+            var autoDelete = queueDeclareConfiguration.AutoDelete;
+            var arguments = queueDeclareConfiguration.Arguments;
 
-            if (passive)
-            {
-                await clientCommandDispatcher.InvokeAsync(x => x.QueueDeclarePassive(name), cancellationToken).ConfigureAwait(false);
-                return new Queue(name, exclusive);
-            }
+            var queueDeclareOk = await clientCommandDispatcher.InvokeAsync(x => x.QueueDeclare(name, durable, exclusive, autoDelete, arguments), cancellationToken)
+                .ConfigureAwait(false);
 
-            var arguments = new Dictionary<string, object>();
-            if (perQueueMessageTtl.HasValue)
-            {
-                arguments.Add("x-message-ttl", perQueueMessageTtl.Value);
-            }
-            if (expires.HasValue)
-            {
-                arguments.Add("x-expires", expires);
-            }
-            if (maxPriority.HasValue)
-            {
-                arguments.Add("x-max-priority", maxPriority.Value);
-            }
-            if (deadLetterExchange != null)
-            {
-                arguments.Add("x-dead-letter-exchange", deadLetterExchange);
-            }
-            if (!string.IsNullOrEmpty(deadLetterRoutingKey))
-            {
-                arguments.Add("x-dead-letter-routing-key", deadLetterRoutingKey);
-            }
-            if (maxLength.HasValue)
-            {
-                arguments.Add("x-max-length", maxLength.Value);
-            }
-            if (maxLengthBytes.HasValue)
-            {
-                arguments.Add("x-max-length-bytes", maxLengthBytes.Value);
-            }
-
-            var queueDeclareOk = await clientCommandDispatcher.InvokeAsync(x => x.QueueDeclare(name, durable, exclusive, autoDelete, arguments), cancellationToken).ConfigureAwait(false);
-            
             if (logger.IsDebugEnabled())
             {
                 logger.DebugFormat(
@@ -403,18 +388,19 @@ namespace EasyNetQ
                 await clientCommandDispatcher.InvokeAsync(x => x.ExchangeDeclarePassive(name), cancellationToken).ConfigureAwait(false);
                 return new Exchange(name);
             }
-            
+
             IDictionary<string, object> arguments = new Dictionary<string, object>();
             if (alternateExchange != null)
             {
                 arguments.Add("alternate-exchange", alternateExchange);
             }
+
             if (delayed)
             {
                 arguments.Add("x-delayed-type", type);
                 type = "x-delayed-message";
             }
-            
+
             await clientCommandDispatcher.InvokeAsync(x => x.ExchangeDeclare(name, type, durable, autoDelete, arguments), cancellationToken).ConfigureAwait(false);
 
             if (logger.IsDebugEnabled())
@@ -430,7 +416,7 @@ namespace EasyNetQ
             }
 
             return new Exchange(name);
-       }
+        }
 
         public virtual async Task ExchangeDeleteAsync(IExchange exchange, bool ifUnused = false, CancellationToken cancellationToken = default)
         {
@@ -491,7 +477,7 @@ namespace EasyNetQ
                 logger.DebugFormat(
                     "Bound destination exchange {destinationExchange} to source exchange {sourceExchange} with routingKey={routingKey} and arguments={arguments}",
                     destination.Name,
-                    source.Name, 
+                    source.Name,
                     routingKey,
                     arguments.Stringify()
                 );
@@ -518,14 +504,16 @@ namespace EasyNetQ
                     );
                 }
             }
-            else if(binding.Bindable is IExchange destination)
+            else if (binding.Bindable is IExchange destination)
             {
-                await clientCommandDispatcher.InvokeAsync(x => x.ExchangeUnbind(destination.Name, binding.Exchange.Name, binding.RoutingKey, new Dictionary<string, object>()), cancellationToken).ConfigureAwait(false);
+                await clientCommandDispatcher
+                    .InvokeAsync(x => x.ExchangeUnbind(destination.Name, binding.Exchange.Name, binding.RoutingKey, new Dictionary<string, object>()), cancellationToken)
+                    .ConfigureAwait(false);
 
                 if (logger.IsDebugEnabled())
                 {
                     logger.DebugFormat(
-                        "Unbound destination exchange {destinationExchange} from source exchange {sourceExchange} with routing key {routingKey}", 
+                        "Unbound destination exchange {destinationExchange} from source exchange {sourceExchange} with routing key {routingKey}",
                         destination.Name,
                         binding.Exchange.Name,
                         binding.RoutingKey
@@ -542,7 +530,7 @@ namespace EasyNetQ
             {
                 return null;
             }
-            
+
             var message = messageSerializationStrategy.DeserializeMessage(result.Properties, result.Body);
             if (typeof(T).IsAssignableFrom(message.MessageType))
             {
@@ -572,8 +560,8 @@ namespace EasyNetQ
                     result.Exchange,
                     result.RoutingKey,
                     queue.Name
-                    )
-                );
+                )
+            );
 
             if (logger.IsDebugEnabled())
             {
@@ -586,7 +574,7 @@ namespace EasyNetQ
         public async Task<uint> GetMessagesCountAsync(IQueue queue, CancellationToken cancellationToken)
         {
             Preconditions.CheckNotNull(queue, "queue");
-            
+
             var declareResult = await clientCommandDispatcher.InvokeAsync(x => x.QueueDeclarePassive(queue.Name), cancellationToken).ConfigureAwait(false);
 
             if (logger.IsDebugEnabled())
@@ -600,31 +588,19 @@ namespace EasyNetQ
         //------------------------------------------------------------------------------------------
         public virtual event EventHandler Connected;
 
-        protected void OnConnected() => Connected?.Invoke(this, EventArgs.Empty);
-
         public virtual event EventHandler Disconnected;
-
-        protected void OnDisconnected() => Disconnected?.Invoke(this, EventArgs.Empty);
 
         public virtual event EventHandler<ConnectionBlockedEventArgs> Blocked;
 
-        protected void OnBlocked(ConnectionBlockedEvent args) => Blocked?.Invoke(this, new ConnectionBlockedEventArgs(args.Reason));
-
         public virtual event EventHandler Unblocked;
 
-        protected void OnUnblocked() => Unblocked?.Invoke(this, EventArgs.Empty);
-
         public virtual event EventHandler<MessageReturnedEventArgs> MessageReturned;
-
-        protected void OnMessageReturned(ReturnedMessageEvent args) => MessageReturned?.Invoke(this, new MessageReturnedEventArgs(args.Body, args.Properties, args.Info));
 
         public virtual bool IsConnected => connection.IsConnected;
 
         public IServiceResolver Container { get; }
 
         public IConventions Conventions { get; }
-
-        private bool disposed;
 
         public virtual void Dispose()
         {
@@ -637,5 +613,15 @@ namespace EasyNetQ
 
             disposed = true;
         }
+
+        protected void OnConnected() => Connected?.Invoke(this, EventArgs.Empty);
+
+        protected void OnDisconnected() => Disconnected?.Invoke(this, EventArgs.Empty);
+
+        protected void OnBlocked(ConnectionBlockedEvent args) => Blocked?.Invoke(this, new ConnectionBlockedEventArgs(args.Reason));
+
+        protected void OnUnblocked() => Unblocked?.Invoke(this, EventArgs.Empty);
+
+        protected void OnMessageReturned(ReturnedMessageEvent args) => MessageReturned?.Invoke(this, new MessageReturnedEventArgs(args.Body, args.Properties, args.Info));
     }
 }

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -320,8 +320,11 @@ namespace EasyNetQ
             CancellationToken cancellationToken = default
         )
         {
+            Preconditions.CheckNotNull(name, "name");
+            Preconditions.CheckNotNull(configure, "configure");
+
             var queueDeclareConfiguration = new QueueDeclareConfiguration();
-            configure?.Invoke(queueDeclareConfiguration);
+            configure.Invoke(queueDeclareConfiguration);
             var durable = queueDeclareConfiguration.Durable;
             var exclusive = queueDeclareConfiguration.Exclusive;
             var autoDelete = queueDeclareConfiguration.AutoDelete;

--- a/Source/EasyNetQ/Scheduling/DeadLetterExchangeAndMessageTtlScheduler.cs
+++ b/Source/EasyNetQ/Scheduling/DeadLetterExchangeAndMessageTtlScheduler.cs
@@ -25,30 +25,30 @@ namespace EasyNetQ.Scheduling
             this.conventions = conventions;
             this.messageDeliveryModeStrategy = messageDeliveryModeStrategy;
         }
-        
+
         //TODO Cache exchange/queue/bind
         public async Task FuturePublishAsync<T>(T message, TimeSpan delay, string topic = null, CancellationToken cancellationToken = default)
         {
             Preconditions.CheckNotNull(message, "message");
 
             var delayString = delay.ToString(@"dd\_hh\_mm\_ss");
-            var exchangeName = conventions.ExchangeNamingConvention(typeof (T));
+            var exchangeName = conventions.ExchangeNamingConvention(typeof(T));
             var futureExchangeName = exchangeName + "_" + delayString;
-            var futureQueueName = conventions.QueueNamingConvention(typeof (T), delayString);
+            var futureQueueName = conventions.QueueNamingConvention(typeof(T), delayString);
             var futureExchange = await advancedBus.ExchangeDeclareAsync(futureExchangeName, ExchangeType.Topic, cancellationToken: cancellationToken).ConfigureAwait(false);
             var futureQueue = await advancedBus.QueueDeclareAsync(
                 futureQueueName,
-                perQueueMessageTtl: (int) delay.TotalMilliseconds, 
-                deadLetterExchange: exchangeName,
-                deadLetterRoutingKey: topic,
-                cancellationToken: cancellationToken
+                c => c.WithMessageTtl(delay)
+                    .WithDeadLetterExchange(futureExchange)
+                    .WithDeadLetterRoutingKey(topic),
+                cancellationToken
             ).ConfigureAwait(false);
             await advancedBus.BindAsync(futureExchange, futureQueue, topic, cancellationToken).ConfigureAwait(false);
             var easyNetQMessage = new Message<T>(message)
             {
                 Properties =
                 {
-                    DeliveryMode = messageDeliveryModeStrategy.GetDeliveryMode(typeof (T))
+                    DeliveryMode = messageDeliveryModeStrategy.GetDeliveryMode(typeof(T))
                 }
             };
             await advancedBus.PublishAsync(futureExchange, topic, false, easyNetQMessage, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
It's very hard to extend the way how queues are declared.

``` 
       Task<IQueue> QueueDeclareAsync(
            string name,
            bool passive = false,
            bool durable = true,		
            bool exclusive = false,		
            bool autoDelete = false,		
            int? perQueueMessageTtl  = null,		
            int? expires = null,		
            int? maxPriority = null,		
            string deadLetterExchange = null,		
            string deadLetterRoutingKey = null,		
            int? maxLength = null,		
            int? maxLengthBytes = null,		
            CancellationToken cancellationToken = default
        );
```

The PR proposes the fluent configuration of declaration as it was done in case of publish and consume. Also it introduces `Lazy Queue` declaration.

PS I had to split passive declaration to separate method.