### PR TITLE
Durable RPC

### DIFF
--- a/Source/EasyNetQ/Producer/Rpc.cs
+++ b/Source/EasyNetQ/Producer/Rpc.cs
@@ -150,11 +150,11 @@ namespace EasyNetQ.Producer
                     return queueName;
 
                 var queue = advancedBus.QueueDeclare(
-                        conventions.RpcReturnQueueNamingConvention(),
-                        passive: false,
-                        durable: true,
-                        exclusive: false,
-                        autoDelete: false);
+                            conventions.RpcReturnQueueNamingConvention(),
+                            passive: false,
+                            durable: true,
+                            exclusive: false,
+                            autoDelete: false);
 
                 var exchange = DeclareAndBindRpcExchange(
                     conventions.RpcResponseExchangeNamingConvention(responseType),


### PR DESCRIPTION
RPC that uses durable queues and can survive HA fail-overs. This is a PoC, not actually ready for direct merging.

Changed:
- RPC return queues are created using durable(true), exclusive(false) and auto-delete(false)
- Removed cleanup of created queues cache and response actions on "ConnectionCreatedEvent"

Todo:
- Cleanup RPC return queues when application stops (Dispose() would be a start, but it wouldn't account for forced app stops).

I'd love to know your opinion, as we have a ton of request/reply-style traffic on our service. Changing the RPC component of EasyNetQ to allow for single nodes to go down would help a lot. The implementation seems to specifically disallow fail-overs, so I'm curious about there being any specific reasons for this.