### PR TITLE
RPC WithPriority

### DIFF
--- a/Source/EasyNetQ/Producer/DefaultRpc.cs
+++ b/Source/EasyNetQ/Producer/DefaultRpc.cs
@@ -260,7 +260,7 @@ namespace EasyNetQ.Producer
             return advancedBus.Consume<TRequest>(
                 queue,
                 (m, i, c) => RespondToMessageAsync(responder, m, c),
-                c => c.WithPrefetchCount(configuration.PrefetchCount)
+                c => c.WithPrefetchCount(configuration.PrefetchCount).WithPriority(configuration.Priority)
             );
         }
 

--- a/Source/EasyNetQ/Producer/IResponderConfiguration.cs
+++ b/Source/EasyNetQ/Producer/IResponderConfiguration.cs
@@ -2,6 +2,7 @@
 {
     public interface IResponderConfiguration
     {
+        IResponderConfiguration WithPriority(int priority);
         IResponderConfiguration WithPrefetchCount(ushort prefetchCount);
         IResponderConfiguration WithQueueName(string queueName);
     }
@@ -10,11 +11,19 @@
     {
         public ResponderConfiguration(ushort defaultPrefetchCount)
         {
+            Priority = 0;
             PrefetchCount = defaultPrefetchCount;
         }
 
+        public int Priority { get; private set; }
         public ushort PrefetchCount { get; private set; }
         public string QueueName { get; private set; }
+
+        public IResponderConfiguration WithPriority(int priority)
+        {
+            Priority = priority;
+            return this;
+        }
 
         public IResponderConfiguration WithPrefetchCount(ushort prefetchCount)
         {


### PR DESCRIPTION
Added possibility to set responder queue priority (x-max-priority) in `ResponderConfiguration` which sets priority in `ConsumerConfiguration`.