### PR TITLE
Bump dependencies

### DIFF
--- a/Source/EasyNetQ.DI.Autofac/EasyNetQ.DI.Autofac.csproj
+++ b/Source/EasyNetQ.DI.Autofac/EasyNetQ.DI.Autofac.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\EasyNetQ\EasyNetQ.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.6.1" />
+    <PackageReference Include="Autofac" Version="4.9.3" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/EasyNetQ.DI.LightInject/EasyNetQ.DI.LightInject.csproj
+++ b/Source/EasyNetQ.DI.LightInject/EasyNetQ.DI.LightInject.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\EasyNetQ\EasyNetQ.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="LightInject" Version="4.0.11" />
+    <PackageReference Include="LightInject" Version="5.5.0" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/EasyNetQ.DI.Microsoft/EasyNetQ.DI.Microsoft.csproj
+++ b/Source/EasyNetQ.DI.Microsoft/EasyNetQ.DI.Microsoft.csproj
@@ -6,7 +6,7 @@
     <PackageTags>DependencyInjection;RabbitMQ;Messaging;AMQP;C#</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/EasyNetQ.DI.Ninject/EasyNetQ.DI.Ninject.csproj
+++ b/Source/EasyNetQ.DI.Ninject/EasyNetQ.DI.Ninject.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\EasyNetQ\EasyNetQ.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ninject" Version="3.3.2" />
+    <PackageReference Include="Ninject" Version="3.3.4" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/EasyNetQ.DI.SimpleInjector/EasyNetQ.DI.SimpleInjector.csproj
+++ b/Source/EasyNetQ.DI.SimpleInjector/EasyNetQ.DI.SimpleInjector.csproj
@@ -12,7 +12,7 @@
     <ProjectReference Include="..\EasyNetQ\EasyNetQ.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SimpleInjector" Version="3.2.7" />
+    <PackageReference Include="SimpleInjector" Version="4.6.2" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/EasyNetQ.DI.StructureMap/EasyNetQ.DI.StructureMap.csproj
+++ b/Source/EasyNetQ.DI.StructureMap/EasyNetQ.DI.StructureMap.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\EasyNetQ\EasyNetQ.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="structuremap" Version="4.4.0" />
+    <PackageReference Include="structuremap" Version="4.7.1" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/EasyNetQ.DI.Tests/ContainerAdapterTests.cs
+++ b/Source/EasyNetQ.DI.Tests/ContainerAdapterTests.cs
@@ -25,23 +25,23 @@ namespace EasyNetQ.DI.Tests
     public class ContainerAdapterTests
     {
         public delegate IServiceResolver ResolverFactory(Action<IServiceRegister> configure);
-        
+
         [Theory]
         [MemberData(nameof(GetContainerAdapters))]
         public void Should_last_registration_win(ResolverFactory resolverFactory)
         {
             var first = new Service();
             var last = new Service();
-            
+
             var resolver = resolverFactory(c =>
             {
                 c.Register<IService>(first);
                 c.Register<IService>(last);
             });
-            
+
             Assert.Equal(last, resolver.Resolve<IService>());
         }
-         
+
         [Theory]
         [MemberData(nameof(GetContainerAdapters))]
         public void Should_singleton_created_once(ResolverFactory resolverFactory)
@@ -50,7 +50,7 @@ namespace EasyNetQ.DI.Tests
 
             var first = resolver.Resolve<IService>();
             var second = resolver.Resolve<IService>();
-            
+
             Assert.Same(first, second);
         }
 
@@ -112,7 +112,7 @@ namespace EasyNetQ.DI.Tests
             {
                 var container = new LightInjectContainer();
                 c(new LightInjectAdapter(container));
-                return container.GetInstance<IServiceResolver>();
+                return (IServiceResolver) container.GetInstance(typeof(IServiceResolver));
             })};
 
             yield return new object[] {(ResolverFactory) (c =>
@@ -135,14 +135,14 @@ namespace EasyNetQ.DI.Tests
                 var container = containerBuilder.Build();
                 return container.Resolve<IServiceResolver>();
             })};
-            
+
             yield return new object[] {(ResolverFactory) (c =>
             {
                 var container = new WindsorContainer();
                 c(new WindsorAdapter(container));
                 return container.Resolve<IServiceResolver>();
             })};
-            
+
             yield return new object[] {(ResolverFactory) (c =>
             {
                 var container = new NinjectContainer();
@@ -170,7 +170,7 @@ namespace EasyNetQ.DI.Tests
             private static volatile int sequenceNumber = 0;
 
             private readonly int number;
-            
+
             public Service()
             {
                 number = Interlocked.Increment(ref sequenceNumber);

--- a/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
+++ b/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="LightInject" Version="5.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="5.1.1" />
     <PackageReference Include="SimpleInjector" Version="4.6.2" />
     <PackageReference Include="Autofac" Version="4.9.3" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />

--- a/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
+++ b/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
@@ -22,18 +22,18 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="LightInject" Version="4.0.11" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-    <PackageReference Include="NSubstitute" Version="2.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="LightInject" Version="5.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
-    <PackageReference Include="SimpleInjector" Version="3.2.7" />
-    <PackageReference Include="Autofac" Version="4.6.1" />
+    <PackageReference Include="SimpleInjector" Version="4.6.2" />
+    <PackageReference Include="Autofac" Version="4.9.3" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />
-    <PackageReference Include="Castle.Core" Version="4.2.0" />
-    <PackageReference Include="Castle.Windsor" Version="4.1.0" />
-    <PackageReference Include="Ninject" Version="3.3.2" />
+    <PackageReference Include="Castle.Core" Version="4.4.0" />
+    <PackageReference Include="Castle.Windsor" Version="5.0.0" />
+    <PackageReference Include="Ninject" Version="3.3.4" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/Source/EasyNetQ.DI.Windsor/EasyNetQ.DI.Windsor.csproj
+++ b/Source/EasyNetQ.DI.Windsor/EasyNetQ.DI.Windsor.csproj
@@ -10,8 +10,8 @@
     <ProjectReference Include="..\EasyNetQ\EasyNetQ.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.2.0" />
-    <PackageReference Include="Castle.Windsor" Version="4.1.0" />
+    <PackageReference Include="Castle.Core" Version="4.4.0" />
+    <PackageReference Include="Castle.Windsor" Version="5.0.0" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/EasyNetQ.Hosepipe.Tests/EasyNetQ.Hosepipe.Tests.csproj
+++ b/Source/EasyNetQ.Hosepipe.Tests/EasyNetQ.Hosepipe.Tests.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -16,8 +16,8 @@
     <ProjectReference Include="..\EasyNetQ.Tests.Common\EasyNetQ.Tests.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>

--- a/Source/EasyNetQ.Hosepipe.Tests/EasyNetQ.Hosepipe.Tests.csproj
+++ b/Source/EasyNetQ.Hosepipe.Tests/EasyNetQ.Hosepipe.Tests.csproj
@@ -5,8 +5,6 @@
     <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
@@ -18,7 +16,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="RabbitMQ.Client" Version="5.1.1" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/EasyNetQ.Hosepipe/EasyNetQ.Hosepipe.csproj
+++ b/Source/EasyNetQ.Hosepipe/EasyNetQ.Hosepipe.csproj
@@ -24,7 +24,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Source/EasyNetQ.Hosepipe/EasyNetQ.Hosepipe.csproj
+++ b/Source/EasyNetQ.Hosepipe/EasyNetQ.Hosepipe.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="5.1.1" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>

--- a/Source/EasyNetQ.LogReader/EasyNetQ.LogReader.csproj
+++ b/Source/EasyNetQ.LogReader/EasyNetQ.LogReader.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\EasyNetQ\EasyNetQ.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="5.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>

--- a/Source/EasyNetQ.LogReader/EasyNetQ.LogReader.csproj
+++ b/Source/EasyNetQ.LogReader/EasyNetQ.LogReader.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/EasyNetQ.Scheduler.Mongo.Core/EasyNetQ.Scheduler.Mongo.Core.csproj
+++ b/Source/EasyNetQ.Scheduler.Mongo.Core/EasyNetQ.Scheduler.Mongo.Core.csproj
@@ -2,26 +2,27 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
   <PropertyGroup>
     <Description>EasyNetQ.Scheduler.Mongo.Core</Description>
-    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\EasyNetQ\EasyNetQ.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MongoDB.Bson" Version="2.3.0" />
-    <PackageReference Include="mongocsharpdriver" Version="2.3.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="MongoDB.Bson" Version="2.8.1" />
+    <PackageReference Include="mongocsharpdriver" Version="2.8.1" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);NET_STANDARD</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <DefineConstants>$(DefineConstants);NETFX</DefineConstants>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.targets))\build.targets" />

--- a/Source/EasyNetQ.Scheduler.Mongo.Tests/EasyNetQ.Scheduler.Mongo.Tests.csproj
+++ b/Source/EasyNetQ.Scheduler.Mongo.Tests/EasyNetQ.Scheduler.Mongo.Tests.csproj
@@ -10,14 +10,14 @@
     <ProjectReference Include="..\EasyNetQ.Tests.Common\EasyNetQ.Tests.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="NSubstitute" Version="2.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />

--- a/Source/EasyNetQ.Scheduler.Mongo/EasyNetQ.Scheduler.Mongo.csproj
+++ b/Source/EasyNetQ.Scheduler.Mongo/EasyNetQ.Scheduler.Mongo.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
   <PropertyGroup>
     <Description>EasyNetQ.Scheduler.Mongo</Description>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Update="log4net.config">
@@ -15,13 +15,13 @@
     <ProjectReference Include="..\EasyNetQ.Scheduler.Mongo.Core\EasyNetQ.Scheduler.Mongo.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.5" />
+    <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="Topshelf" Version="3.1.4" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Configuration" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/Source/EasyNetQ.Scheduler.Tests/EasyNetQ.Scheduler.Tests.csproj
+++ b/Source/EasyNetQ.Scheduler.Tests/EasyNetQ.Scheduler.Tests.csproj
@@ -10,14 +10,14 @@
     <ProjectReference Include="..\EasyNetQ.Tests.Common\EasyNetQ.Tests.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="NSubstitute" Version="2.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />

--- a/Source/EasyNetQ.Scheduler/EasyNetQ.Scheduler.csproj
+++ b/Source/EasyNetQ.Scheduler/EasyNetQ.Scheduler.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
   <PropertyGroup>
     <Description>EasyNetQ.Scheduler</Description>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
@@ -20,10 +20,10 @@
     <ProjectReference Include="..\EasyNetQ\EasyNetQ.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
-    <PackageReference Include="Topshelf" Version="3.1.4" />
+    <PackageReference Include="Topshelf" Version="4.2.1" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/EasyNetQ.Scheduler/EasyNetQ.Scheduler.csproj
+++ b/Source/EasyNetQ.Scheduler/EasyNetQ.Scheduler.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="5.1.1" />
     <PackageReference Include="Topshelf" Version="4.2.1" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>

--- a/Source/EasyNetQ.Tests.Common/EasyNetQ.Tests.Common.csproj
+++ b/Source/EasyNetQ.Tests.Common/EasyNetQ.Tests.Common.csproj
@@ -18,7 +18,7 @@
     <Compile Include="..\Version.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/Source/EasyNetQ.Tests.Tasks/EasyNetQ.Tests.Tasks.csproj
+++ b/Source/EasyNetQ.Tests.Tasks/EasyNetQ.Tests.Tasks.csproj
@@ -10,10 +10,10 @@
     <ProjectReference Include="..\EasyNetQ.Tests.Common\EasyNetQ.Tests.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.6.1" />
+    <PackageReference Include="Autofac" Version="4.9.3" />
     <PackageReference Include="Net.Autofac" Version="0.1.12" />
     <PackageReference Include="Net.Core" Version="0.1.12" />
-    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
+    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
+++ b/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
@@ -10,21 +10,19 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="EasyNetQ.Management.Client" Version="2.0.0-netcore0001" />
-    <PackageReference Include="FluentAssertions" Version="5.4.0" />
+    <PackageReference Include="FluentAssertions" Version="5.8.0" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-    <PackageReference Include="NSubstitute" Version="2.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="System.Net.Http" Version="4.3.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />

--- a/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
+++ b/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="5.1.1" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/Source/EasyNetQ.Trace/EasyNetQ.Trace.csproj
+++ b/Source/EasyNetQ.Trace/EasyNetQ.Trace.csproj
@@ -8,7 +8,7 @@
     <ProjectReference Include="..\EasyNetQ\EasyNetQ.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
+    <PackageReference Include="CommandLineParser" Version="2.6.0" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/EasyNetQ/EasyNetQ.csproj
+++ b/Source/EasyNetQ/EasyNetQ.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="5.1.1" />
     <PackageReference Include="LibLog" Version="5.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/Source/EasyNetQ/EasyNetQ.csproj
+++ b/Source/EasyNetQ/EasyNetQ.csproj
@@ -11,9 +11,9 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
-    <PackageReference Include="LibLog" Version="5.0.3">
+    <PackageReference Include="LibLog" Version="5.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: '3.4'
+services:
+  rabbitmq:
+    image: rabbitmq:3-management
+    ports:
+      - "15672:15672"
+      - "5672:5672"
+      - "5671:5671"
+
+  mongodb:
+    image: mongo
+    ports:
+     - "27017:27017"


### PR DESCRIPTION
Updated:
- Autofac 4.6.1
- LightInject 5.5.0
- Ninject 3.3.4
- SimpleInjector 3.2.7
- RabbitMQ 5.1.1

breaking: Minimal .NET version is now 4.5.2 for mongodb libraries
