### PR TITLE
Exception propagated to publisher fix

### DIFF
--- a/Source/EasyNetQ/Producer/Rpc.cs
+++ b/Source/EasyNetQ/Producer/Rpc.cs
@@ -291,7 +291,7 @@ namespace EasyNetQ.Producer
                             : task.Exception?.InnerException ?? new EasyNetQResponderException("The responder faulted while dispatching the message.");
 
 
-                        OnResponderFailure<TRequest, TResponse>(requestMessage, exception.Message, exception);
+                        OnResponderFailure<TRequest, TResponse>(requestMessage, exception.Message, exception, typeof(TResponse));
                         tcs.SetException(exception);
                     }
                     else
@@ -303,7 +303,7 @@ namespace EasyNetQ.Producer
             }
             catch (Exception e)
             {
-                OnResponderFailure<TRequest, TResponse>(requestMessage, e.Message, e);
+                OnResponderFailure<TRequest, TResponse>(requestMessage, e.Message, e, typeof(TResponse));
                 tcs.SetException(e);
             }
 
@@ -328,11 +328,11 @@ namespace EasyNetQ.Producer
             advancedBus.Publish(exchange, requestMessage.Properties.ReplyTo, false, responseMessage);
         }
 
-        protected virtual void OnResponderFailure<TRequest, TResponse>(IMessage<TRequest> requestMessage, string exceptionMessage, Exception exception)
+        protected virtual void OnResponderFailure<TRequest, TResponse>(IMessage<TRequest> requestMessage, string exceptionMessage, Exception exception, Type responseType)
             where TRequest : class
             where TResponse : class
         {
-            var responseMessage = new Message<TResponse>();
+            var responseMessage = new Message<TResponse>((TResponse)Activator.CreateInstance(responseType));
             responseMessage.Properties.Headers.Add(isFaultedKey, true);
             responseMessage.Properties.Headers.Add(exceptionMessageKey, exceptionMessage);
             responseMessage.Properties.CorrelationId = requestMessage.Properties.CorrelationId;

--- a/Source/EasyNetQ/Producer/Rpc.cs
+++ b/Source/EasyNetQ/Producer/Rpc.cs
@@ -291,7 +291,7 @@ namespace EasyNetQ.Producer
                             : task.Exception?.InnerException ?? new EasyNetQResponderException("The responder faulted while dispatching the message.");
 
 
-                        OnResponderFailure<TRequest, TResponse>(requestMessage, exception.Message, exception, typeof(TResponse));
+                        OnResponderFailure<TRequest, TResponse>(requestMessage, exception.Message, exception);
                         tcs.SetException(exception);
                     }
                     else
@@ -303,7 +303,7 @@ namespace EasyNetQ.Producer
             }
             catch (Exception e)
             {
-                OnResponderFailure<TRequest, TResponse>(requestMessage, e.Message, e, typeof(TResponse));
+                OnResponderFailure<TRequest, TResponse>(requestMessage, e.Message, e);
                 tcs.SetException(e);
             }
 
@@ -328,11 +328,11 @@ namespace EasyNetQ.Producer
             advancedBus.Publish(exchange, requestMessage.Properties.ReplyTo, false, responseMessage);
         }
 
-        protected virtual void OnResponderFailure<TRequest, TResponse>(IMessage<TRequest> requestMessage, string exceptionMessage, Exception exception, Type responseType)
+        protected virtual void OnResponderFailure<TRequest, TResponse>(IMessage<TRequest> requestMessage, string exceptionMessage, Exception exception)
             where TRequest : class
             where TResponse : class
         {
-            var responseMessage = new Message<TResponse>((TResponse)Activator.CreateInstance(responseType));
+            var responseMessage = new Message<TResponse>();
             responseMessage.Properties.Headers.Add(isFaultedKey, true);
             responseMessage.Properties.Headers.Add(exceptionMessageKey, exceptionMessage);
             responseMessage.Properties.CorrelationId = requestMessage.Properties.CorrelationId;

--- a/Source/EasyNetQ/Producer/Rpc.cs
+++ b/Source/EasyNetQ/Producer/Rpc.cs
@@ -291,7 +291,7 @@ namespace EasyNetQ.Producer
                             : task.Exception?.InnerException ?? new EasyNetQResponderException("The responder faulted while dispatching the message.");
 
 
-                        OnResponderFailure<TRequest, TResponse>(requestMessage, exception.Message, exception, typeof(TResponse));
+                        OnResponderFailure<TRequest, TResponse>(requestMessage, exception.Message, exception);
                         tcs.SetException(exception);
                     }
                     else
@@ -303,7 +303,7 @@ namespace EasyNetQ.Producer
             }
             catch (Exception e)
             {
-                OnResponderFailure<TRequest, TResponse>(requestMessage, e.Message, e, typeof(TResponse));
+                OnResponderFailure<TRequest, TResponse>(requestMessage, e.Message, e);
                 tcs.SetException(e);
             }
 
@@ -328,11 +328,11 @@ namespace EasyNetQ.Producer
             advancedBus.Publish(exchange, requestMessage.Properties.ReplyTo, false, responseMessage);
         }
 
-        protected virtual void OnResponderFailure<TRequest, TResponse>(IMessage<TRequest> requestMessage, string exceptionMessage, Exception exception, Type responseType)
+        protected virtual void OnResponderFailure<TRequest, TResponse>(IMessage<TRequest> requestMessage, string exceptionMessage, Exception exception)
             where TRequest : class
             where TResponse : class
         {
-            var responseMessage = new Message<TResponse>((TResponse)Activator.CreateInstance(responseType));
+            var responseMessage = new Message<TResponse>((TResponse)Activator.CreateInstance(typeof(TResponse)));
             responseMessage.Properties.Headers.Add(isFaultedKey, true);
             responseMessage.Properties.Headers.Add(exceptionMessageKey, exceptionMessage);
             responseMessage.Properties.CorrelationId = requestMessage.Properties.CorrelationId;


### PR DESCRIPTION
Upon exception the response message's body was always **'null'** since the message was created using an _empty_ constructor. Now the constructor with a _type_ argument is used. To it an instance of the type of the response message is passed. This allows the publisher to receive the incurred exception.

Resolves #987