### PR TITLE
Fix deadlock when disposing consumer combined with the consumerdispatcher

### DIFF
--- a/Source/EasyNetQ.Tests/ConsumerDispatcherFactoryTests.cs
+++ b/Source/EasyNetQ.Tests/ConsumerDispatcherFactoryTests.cs
@@ -49,7 +49,7 @@ namespace EasyNetQ.Tests
             var autoResetEvent = new AutoResetEvent(false);
             var threadName = "";
 
-            dispatcher.QueueTransientAction(() =>
+            dispatcher.QueueAction(() =>
                 {
                     threadName = Thread.CurrentThread.Name;
                     autoResetEvent.Set();
@@ -69,12 +69,12 @@ namespace EasyNetQ.Tests
             var actionExecuted = false;
 
             // queue first action, we're going to block on this one
-            dispatcher.QueueTransientAction(() => autoResetEvent1.WaitOne(100));
+            dispatcher.QueueAction(() => autoResetEvent1.WaitOne(100));
 
             // queue second action, this should be cleared when
             // the dispatcher factory's OnDisconnected method is called
             // and never run.
-            dispatcher.QueueTransientAction(() =>
+            dispatcher.QueueAction(() =>
                 {
                     actionExecuted = true;
                 });
@@ -86,7 +86,7 @@ namespace EasyNetQ.Tests
             autoResetEvent1.Set();
 
             // now queue up a new action and wait for it to complete
-            dispatcher.QueueTransientAction(() => autoResetEvent2.Set());
+            dispatcher.QueueAction(() => autoResetEvent2.Set());
             autoResetEvent2.WaitOne(100);
 
             // check that the second action was never run
@@ -103,15 +103,15 @@ namespace EasyNetQ.Tests
             var actionExecuted = false;
 
             // queue first action, we're going to block on this one
-            dispatcher.QueueDurableAction(() => blockingEvent.WaitOne(100));
+            dispatcher.QueueAction(() => blockingEvent.WaitOne(100), true);
 
             // queue second action, this should not be cleared when
             // the dispatcher factory's OnDisconnected method is called
             // and it should run.
-            dispatcher.QueueDurableAction(() =>
+            dispatcher.QueueAction(() =>
             {
                 actionExecuted = true;
-            });
+            }, true);
 
             // disconnect
             dispatcherFactory.OnDisconnected();
@@ -120,7 +120,7 @@ namespace EasyNetQ.Tests
             blockingEvent.Set();
 
             // now queue up a new action and wait for it to complete
-            dispatcher.QueueTransientAction(() => blockingEvent2.Set());
+            dispatcher.QueueAction(() => blockingEvent2.Set(), true);
             blockingEvent2.WaitOne(100);
 
             // check that the second action was never run

--- a/Source/EasyNetQ.Tests/ConsumerDispatcherFactoryTests.cs
+++ b/Source/EasyNetQ.Tests/ConsumerDispatcherFactoryTests.cs
@@ -47,7 +47,7 @@ namespace EasyNetQ.Tests
         {
             var dispatcher = dispatcherFactory.GetConsumerDispatcher();
             var autoResetEvent = new AutoResetEvent(false);
-            var threadName = Thread.CurrentThread.Name;
+            var threadName = "";
 
             dispatcher.QueueAction(() =>
                 {
@@ -71,7 +71,7 @@ namespace EasyNetQ.Tests
             // queue first action, we're going to block on this one
             dispatcher.QueueAction(() => autoResetEvent1.WaitOne(100));
 
-            // queue second action, this should be cleared when 
+            // queue second action, this should be cleared when
             // the dispatcher factory's OnDisconnected method is called
             // and never run.
             dispatcher.QueueAction(() =>

--- a/Source/EasyNetQ.Tests/ModelCleanupTests.cs
+++ b/Source/EasyNetQ.Tests/ModelCleanupTests.cs
@@ -55,9 +55,10 @@ namespace EasyNetQ.Tests
 
             bus.Dispose();
 
-            bool signalReceived = are.WaitOne(waitTime);
+            var signalReceived = are.WaitOne(waitTime);
             Assert.True(signalReceived, $"Set event was not received within {waitTime.TotalSeconds} seconds");
 
+            mockBuilder.Channels[0].Received().Dispose();
             mockBuilder.Channels[1].Received().Dispose();
         }
 
@@ -69,9 +70,10 @@ namespace EasyNetQ.Tests
 
             bus.Dispose();
 
-            bool signalReceived = are.WaitOne(waitTime);
+            var signalReceived = are.WaitOne(waitTime);
             Assert.True(signalReceived, $"Set event was not received within {waitTime.TotalSeconds} seconds");
 
+            mockBuilder.Channels[0].Received().Dispose();
             mockBuilder.Channels[1].Received().Dispose();
         }
 
@@ -83,9 +85,10 @@ namespace EasyNetQ.Tests
 
             bus.Dispose();
 
-            bool signalReceived = are.WaitOne(waitTime);
+            var signalReceived = are.WaitOne(waitTime);
             Assert.True(signalReceived, $"Set event was not received within {waitTime.TotalSeconds} seconds");
 
+            mockBuilder.Channels[0].Received().Dispose();
             mockBuilder.Channels[1].Received().Dispose();
         }
 
@@ -97,9 +100,10 @@ namespace EasyNetQ.Tests
 
             bus.Dispose();
 
-            bool signalReceived = are.WaitOne(waitTime);
+            var signalReceived = are.WaitOne(waitTime);
             Assert.True(signalReceived, $"Set event was not received within {waitTime.TotalSeconds} seconds");
 
+            mockBuilder.Channels[0].Received().Dispose();
             mockBuilder.Channels[1].Received().Dispose();
         }
     }

--- a/Source/EasyNetQ.Tests/ModelCleanupTests.cs
+++ b/Source/EasyNetQ.Tests/ModelCleanupTests.cs
@@ -14,7 +14,7 @@ namespace EasyNetQ.Tests
         {
             mockBuilder = new MockBuilder();
             bus = mockBuilder.Bus;
-            waitTime = TimeSpan.FromMinutes(2);
+            waitTime = TimeSpan.FromSeconds(10);
         }
 
         private readonly IBus bus;

--- a/Source/EasyNetQ/Consumer/BasicConsumer.cs
+++ b/Source/EasyNetQ/Consumer/BasicConsumer.cs
@@ -102,7 +102,7 @@ namespace EasyNetQ.Consumer
                 .ContinueWith(async x =>
                     {
                         var ackStrategy = await x.ConfigureAwait(false);
-                        consumerDispatcher.QueueAction(() =>
+                        consumerDispatcher.QueueTransientAction(() =>
                         {
                             var ackResult = ackStrategy(Model, deliveryTag);
                             eventBus.Publish(new AckEvent(messageReceivedInfo, messageProperties, body, ackResult));

--- a/Source/EasyNetQ/Consumer/BasicConsumer.cs
+++ b/Source/EasyNetQ/Consumer/BasicConsumer.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EasyNetQ.Events;
+using EasyNetQ.Logging;
+using EasyNetQ.Topology;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace EasyNetQ.Consumer
+{
+    public class BasicConsumer : IBasicConsumer, IDisposable
+    {
+        private readonly Action<BasicConsumer> cancelled;
+        private readonly IConsumerDispatcher consumerDispatcher;
+        private readonly IEventBus eventBus;
+        private readonly IHandlerRunner handlerRunner;
+        private readonly ILog logger = LogProvider.For<BasicConsumer>();
+
+        private bool disposed;
+
+        public BasicConsumer(
+            Action<BasicConsumer> cancelled,
+            IConsumerDispatcher consumerDispatcher,
+            IQueue queue,
+            IEventBus eventBus,
+            IHandlerRunner handlerRunner,
+            Func<byte[], MessageProperties, MessageReceivedInfo, CancellationToken, Task> onMessage,
+            IModel model
+        )
+        {
+            Preconditions.CheckNotNull(onMessage, "onMessage");
+
+            Queue = queue;
+            OnMessage = onMessage;
+            this.cancelled = cancelled;
+            this.consumerDispatcher = consumerDispatcher;
+            this.eventBus = eventBus;
+            this.handlerRunner = handlerRunner;
+            Model = model;
+        }
+
+        public Func<byte[], MessageProperties, MessageReceivedInfo, CancellationToken, Task> OnMessage { get; }
+        public IQueue Queue { get; }
+        public string ConsumerTag { get; private set; }
+
+        public void HandleBasicConsumeOk(string consumerTag)
+        {
+            ConsumerTag = consumerTag;
+        }
+
+        public void HandleBasicCancelOk(string consumerTag)
+        {
+            Cancel();
+        }
+
+        public void HandleBasicCancel(string consumerTag)
+        {
+            logger.InfoFormat(
+                "Consumer with consumerTag {consumerTag} has cancelled",
+                consumerTag
+            );
+            Cancel();
+        }
+
+        public void HandleModelShutdown(object model, ShutdownEventArgs reason)
+        {
+            logger.InfoFormat(
+                "Consumer with consumerTag {consumerTag} on queue {queue} has shutdown with reason {reason}",
+                ConsumerTag,
+                Queue.Name,
+                reason
+            );
+            Cancel();
+        }
+
+        public void HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, IBasicProperties properties, byte[] body)
+        {
+            if (logger.IsDebugEnabled())
+            {
+                logger.DebugFormat("Message delivered to consumer {consumerTag} with deliveryTag {deliveryTag}", consumerTag, deliveryTag);
+            }
+
+            if (disposed)
+            {
+                // this message's consumer has stopped, so just return
+                logger.InfoFormat(
+                    "Consumer with consumerTag {consumerTag} on queue {queue} has stopped running. Ignoring message",
+                    ConsumerTag,
+                    Queue.Name
+                );
+
+                return;
+            }
+
+            var messageReceivedInfo = new MessageReceivedInfo(consumerTag, deliveryTag, redelivered, exchange, routingKey, Queue.Name);
+            var messageProperties = new MessageProperties(properties);
+            var context = new ConsumerExecutionContext(OnMessage, messageReceivedInfo, messageProperties, body);
+
+            eventBus.Publish(new DeliveredMessageEvent(messageReceivedInfo, messageProperties, body));
+            handlerRunner.InvokeUserMessageHandlerAsync(context)
+                .ContinueWith(async x =>
+                    {
+                        var ackStrategy = await x.ConfigureAwait(false);
+                        consumerDispatcher.QueueAction(() =>
+                        {
+                            var ackResult = ackStrategy(Model, deliveryTag);
+                            eventBus.Publish(new AckEvent(messageReceivedInfo, messageProperties, body, ackResult));
+                        });
+                    },
+                    TaskContinuationOptions.ExecuteSynchronously
+                );
+        }
+
+        public IModel Model { get; }
+        public event EventHandler<ConsumerEventArgs> ConsumerCancelled;
+
+        public void Dispose()
+        {
+            if (disposed) return;
+            disposed = true;
+
+            eventBus.Publish(new ConsumerModelDisposedEvent(ConsumerTag));
+        }
+
+        /// <summary>
+        /// Cancel means that an external signal has requested that this consumer should
+        /// be cancelled. This is _not_ the same as when an internal consumer stops consuming
+        /// because it has lost its channel/connection.
+        /// </summary>
+        private void Cancel()
+        {
+            // copy to temp variable to be thread safe.
+            var localCancelled = cancelled;
+            localCancelled?.Invoke(this);
+
+            var consumerCancelled = ConsumerCancelled;
+            consumerCancelled?.Invoke(this, new ConsumerEventArgs(ConsumerTag));
+        }
+    }
+}

--- a/Source/EasyNetQ/Consumer/BasicConsumer.cs
+++ b/Source/EasyNetQ/Consumer/BasicConsumer.cs
@@ -102,7 +102,7 @@ namespace EasyNetQ.Consumer
                 .ContinueWith(async x =>
                     {
                         var ackStrategy = await x.ConfigureAwait(false);
-                        consumerDispatcher.QueueTransientAction(() =>
+                        consumerDispatcher.QueueAction(() =>
                         {
                             var ackResult = ackStrategy(Model, deliveryTag);
                             eventBus.Publish(new AckEvent(messageReceivedInfo, messageProperties, body, ackResult));

--- a/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
@@ -12,6 +12,7 @@ namespace EasyNetQ.Consumer
         private readonly ConcurrentQueue<Action> highPriority = new ConcurrentQueue<Action>();
         private readonly ConcurrentQueue<Action> mediumPriority = new ConcurrentQueue<Action>();
         private readonly ConcurrentQueue<Action> lowPriority = new ConcurrentQueue<Action>();
+        private readonly ManualResetEvent manualResetEvent = new ManualResetEvent(false);
         private bool disposed;
 
         public ConsumerDispatcher(ConnectionConfiguration configuration)
@@ -31,7 +32,7 @@ namespace EasyNetQ.Consumer
                         }
                         else
                         {
-                            await Task.Delay(50);
+                            manualResetEvent.WaitOne();
                         }
                     }
                     catch (Exception exception)
@@ -61,6 +62,8 @@ namespace EasyNetQ.Consumer
                 default:
                     throw new ArgumentOutOfRangeException(nameof(priority), priority, null);
             }
+
+            manualResetEvent.Set();
         }
 
         public void OnDisconnected()

--- a/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
@@ -35,24 +35,20 @@ namespace EasyNetQ.Consumer
         }
 
         public bool IsDisposed { get; private set; }
-
-        public void QueueTransientAction(Action action)
+        public void QueueAction(Action action, bool surviveDisconnect = false)
         {
             Preconditions.CheckNotNull(action, "action");
             if (IsDisposed)
                 throw new ObjectDisposedException(nameof(ConsumerDispatcher));
 
-            transientActions.Enqueue(action);
-            autoResetEvent.Set();
-        }
-
-        public void QueueDurableAction(Action action)
-        {
-            Preconditions.CheckNotNull(action, "action");
-            if (IsDisposed)
-                throw new ObjectDisposedException(nameof(ConsumerDispatcher));
-
-            durableActions.Enqueue(action);
+            if (surviveDisconnect)
+            {
+                durableActions.Enqueue(action);
+            }
+            else
+            {
+                transientActions.Enqueue(action);
+            }
             autoResetEvent.Set();
         }
 

--- a/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Threading;
+using System.Threading.Tasks;
 using EasyNetQ.Logging;
 
 namespace EasyNetQ.Consumer
@@ -17,7 +18,7 @@ namespace EasyNetQ.Consumer
         {
             Preconditions.CheckNotNull(configuration, "configuration");
 
-            var thread = new Thread(_ =>
+            var thread = new Thread(async _ =>
             {
 
                 while (!disposed)
@@ -27,6 +28,10 @@ namespace EasyNetQ.Consumer
                         if (highPriority.TryDequeue(out var action) || mediumPriority.TryDequeue(out action) || lowPriority.TryDequeue(out action))
                         {
                             action();
+                        }
+                        else
+                        {
+                            await Task.Delay(50);
                         }
                     }
                     catch (Exception exception)

--- a/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
@@ -12,7 +12,7 @@ namespace EasyNetQ.Consumer
         private readonly ConcurrentQueue<Action> highPriority = new ConcurrentQueue<Action>();
         private readonly ConcurrentQueue<Action> mediumPriority = new ConcurrentQueue<Action>();
         private readonly ConcurrentQueue<Action> lowPriority = new ConcurrentQueue<Action>();
-        private readonly ManualResetEvent manualResetEvent = new ManualResetEvent(false);
+        private readonly AutoResetEvent autoResetEvent = new AutoResetEvent(false);
         private bool disposed;
 
         public ConsumerDispatcher(ConnectionConfiguration configuration)
@@ -31,7 +31,7 @@ namespace EasyNetQ.Consumer
                         }
                         else
                         {
-                            manualResetEvent.WaitOne();
+                            autoResetEvent.WaitOne();
                         }
                     }
                     catch (Exception exception)
@@ -43,7 +43,7 @@ namespace EasyNetQ.Consumer
             thread.Start();
         }
 
-        public bool IsDone()
+        private bool IsDone()
         {
             return disposed && highPriority.IsEmpty && mediumPriority.IsEmpty && lowPriority.IsEmpty;
         }
@@ -67,7 +67,7 @@ namespace EasyNetQ.Consumer
                     throw new ArgumentOutOfRangeException(nameof(priority), priority, null);
             }
 
-            manualResetEvent.Set();
+            autoResetEvent.Set();
         }
 
         public void OnDisconnected()
@@ -85,7 +85,7 @@ namespace EasyNetQ.Consumer
         public void Dispose()
         {
             disposed = true;
-            manualResetEvent.Set();
+            autoResetEvent.Set();
         }
 
         public bool IsDisposed => disposed;

--- a/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
@@ -21,8 +21,7 @@ namespace EasyNetQ.Consumer
 
             var thread = new Thread(_ =>
             {
-
-                while (!disposed)
+                while(!IsDone())
                 {
                     try
                     {
@@ -32,8 +31,6 @@ namespace EasyNetQ.Consumer
                         }
                         else
                         {
-                            if (disposed)
-                                return;
                             manualResetEvent.WaitOne();
                         }
                     }
@@ -44,6 +41,11 @@ namespace EasyNetQ.Consumer
                 }
             }) { Name = "EasyNetQ consumer dispatch thread", IsBackground = configuration.UseBackgroundThreads };
             thread.Start();
+        }
+
+        public bool IsDone()
+        {
+            return disposed && highPriority.IsEmpty && mediumPriority.IsEmpty && lowPriority.IsEmpty;
         }
 
         public void QueueAction(Action action, Priority priority = Priority.Low)

--- a/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
@@ -19,7 +19,7 @@ namespace EasyNetQ.Consumer
         {
             Preconditions.CheckNotNull(configuration, "configuration");
 
-            var thread = new Thread(async _ =>
+            var thread = new Thread(_ =>
             {
 
                 while (!disposed)
@@ -32,6 +32,8 @@ namespace EasyNetQ.Consumer
                         }
                         else
                         {
+                            if (disposed)
+                                return;
                             manualResetEvent.WaitOne();
                         }
                     }
@@ -81,6 +83,7 @@ namespace EasyNetQ.Consumer
         public void Dispose()
         {
             disposed = true;
+            manualResetEvent.Set();
         }
 
         public bool IsDisposed => disposed;

--- a/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
@@ -37,12 +37,7 @@ namespace EasyNetQ.Consumer
         public bool IsDisposed { get; private set; }
         public void QueueAction(Action action)
         {
-            Preconditions.CheckNotNull(action, "action");
-            if (IsDisposed)
-                throw new ObjectDisposedException(nameof(ConsumerDispatcher));
-
-            transientActions.Enqueue(action);
-            autoResetEvent.Set();
+            QueueAction(action, false);
         }
 
         public void QueueAction(Action action, bool surviveDisconnect)

--- a/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
@@ -35,6 +35,16 @@ namespace EasyNetQ.Consumer
         }
 
         public bool IsDisposed { get; private set; }
+        public void QueueAction(Action action)
+        {
+            Preconditions.CheckNotNull(action, "action");
+            if (IsDisposed)
+                throw new ObjectDisposedException(nameof(ConsumerDispatcher));
+
+            transientActions.Enqueue(action);
+            autoResetEvent.Set();
+        }
+
         public void QueueAction(Action action, bool surviveDisconnect = false)
         {
             Preconditions.CheckNotNull(action, "action");

--- a/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
@@ -45,7 +45,7 @@ namespace EasyNetQ.Consumer
             autoResetEvent.Set();
         }
 
-        public void QueueAction(Action action, bool surviveDisconnect = false)
+        public void QueueAction(Action action, bool surviveDisconnect)
         {
             Preconditions.CheckNotNull(action, "action");
             if (IsDisposed)

--- a/Source/EasyNetQ/Consumer/IConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/IConsumerDispatcher.cs
@@ -4,7 +4,7 @@ namespace EasyNetQ.Consumer
 {
     public interface IConsumerDispatcher : IDisposable
     {
-        void QueueAction(Action action);
+        void QueueAction(Action action, Priority priority = Priority.Low);
         void OnDisconnected();
     }
 }

--- a/Source/EasyNetQ/Consumer/IConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/IConsumerDispatcher.cs
@@ -5,7 +5,7 @@ namespace EasyNetQ.Consumer
     public interface IConsumerDispatcher : IDisposable
     {
         void QueueAction(Action action);
-        void QueueAction(Action action, bool surviveDisconnect = false);
+        void QueueAction(Action action, bool surviveDisconnect);
         void OnDisconnected();
     }
 }

--- a/Source/EasyNetQ/Consumer/IConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/IConsumerDispatcher.cs
@@ -4,7 +4,18 @@ namespace EasyNetQ.Consumer
 {
     public interface IConsumerDispatcher : IDisposable
     {
-        void QueueAction(Action action, Priority priority = Priority.Low);
+        /// <summary>
+        /// These actions will be cleared with OnDisconnect
+        /// </summary>
+        /// <param name="action"></param>
+        void QueueTransientAction(Action action);
+
+        /// <summary>
+        /// These actions will survive OnDisconnect
+        /// </summary>
+        /// <param name="action"></param>
+        void QueueDurableAction(Action action);
+
         void OnDisconnected();
     }
 }

--- a/Source/EasyNetQ/Consumer/IConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/IConsumerDispatcher.cs
@@ -4,18 +4,7 @@ namespace EasyNetQ.Consumer
 {
     public interface IConsumerDispatcher : IDisposable
     {
-        /// <summary>
-        /// These actions will be cleared with OnDisconnect
-        /// </summary>
-        /// <param name="action"></param>
-        void QueueTransientAction(Action action);
-
-        /// <summary>
-        /// These actions will survive OnDisconnect
-        /// </summary>
-        /// <param name="action"></param>
-        void QueueDurableAction(Action action);
-
+        void QueueAction(Action action, bool surviveDisconnect = false);
         void OnDisconnected();
     }
 }

--- a/Source/EasyNetQ/Consumer/IConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/IConsumerDispatcher.cs
@@ -4,6 +4,7 @@ namespace EasyNetQ.Consumer
 {
     public interface IConsumerDispatcher : IDisposable
     {
+        void QueueAction(Action action);
         void QueueAction(Action action, bool surviveDisconnect = false);
         void OnDisconnected();
     }

--- a/Source/EasyNetQ/Consumer/IInternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/IInternalConsumer.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EasyNetQ.Topology;
+
+namespace EasyNetQ.Consumer
+{
+    public interface IInternalConsumer : IDisposable
+    {
+        StartConsumingStatus StartConsuming(
+            IQueue queue,
+            Func<byte[], MessageProperties, MessageReceivedInfo, CancellationToken, Task> onMessage,
+            IConsumerConfiguration configuration
+        );
+
+        StartConsumingStatus StartConsuming(
+            ICollection<Tuple<IQueue, Func<byte[], MessageProperties, MessageReceivedInfo, CancellationToken, Task>>> queueConsumerPairs,
+            IConsumerConfiguration configuration
+        );
+
+        event Action<IInternalConsumer> Cancelled;
+    }
+}

--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -185,12 +185,12 @@ namespace EasyNetQ.Consumer
             if (model != null)
             {
                 // Queued because we may be on the RabbitMQ.Client dispatch thread.
-                consumerDispatcher.QueueTransientAction(() =>
+                consumerDispatcher.QueueAction(() =>
                 {
                     foreach (var c in basicConsumers)
                         c.Dispose();
                     model.Dispose();
-                });
+                }, true);
             }
         }
 

--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -185,12 +185,12 @@ namespace EasyNetQ.Consumer
             if (model != null)
             {
                 // Queued because we may be on the RabbitMQ.Client dispatch thread.
-                consumerDispatcher.QueueAction(() =>
+                consumerDispatcher.QueueTransientAction(() =>
                 {
                     foreach (var c in basicConsumers)
                         c.Dispose();
                     model.Dispose();
-                }, Priority.Medium);
+                });
             }
         }
 

--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -9,22 +9,6 @@ using RabbitMQ.Client;
 
 namespace EasyNetQ.Consumer
 {
-    public interface IInternalConsumer : IDisposable
-    {
-        StartConsumingStatus StartConsuming(
-            IQueue queue,
-            Func<byte[], MessageProperties, MessageReceivedInfo, CancellationToken, Task> onMessage,
-            IConsumerConfiguration configuration
-        );
-
-        StartConsumingStatus StartConsuming(
-            ICollection<Tuple<IQueue, Func<byte[], MessageProperties, MessageReceivedInfo, CancellationToken, Task>>> queueConsumerPairs,
-            IConsumerConfiguration configuration
-        );
-
-        event Action<IInternalConsumer> Cancelled;
-    }
-
     public class InternalConsumer : IInternalConsumer
     {
         private readonly IPersistentConnection connection;
@@ -120,7 +104,6 @@ namespace EasyNetQ.Consumer
                             queue.Name,
                             consumerTag
                         );
-                        DisposeModelAndConsumers();
                         return StartConsumingStatus.Failed;
                     }
                 }
@@ -134,7 +117,6 @@ namespace EasyNetQ.Consumer
                     "Consume on queue {queue} failed",
                     string.Join(";", queueConsumerPairs.Select(x => x.Item1.Name))
                 );
-                DisposeModelAndConsumers();
                 return StartConsumingStatus.Failed;
             }
         }
@@ -189,7 +171,6 @@ namespace EasyNetQ.Consumer
                     consumerTag,
                     queue.Name
                 );
-                DisposeModelAndConsumers();
                 return StartConsumingStatus.Failed;
             }
         }
@@ -198,11 +179,6 @@ namespace EasyNetQ.Consumer
         {
             if (disposed) return;
 
-            DisposeModelAndConsumers();
-        }
-
-        private void DisposeModelAndConsumers()
-        {
             disposed = true;
 
             var model = Model;

--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -3,11 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using EasyNetQ.Events;
 using EasyNetQ.Logging;
 using EasyNetQ.Topology;
 using RabbitMQ.Client;
-using RabbitMQ.Client.Events;
 
 namespace EasyNetQ.Consumer
 {
@@ -25,136 +23,6 @@ namespace EasyNetQ.Consumer
         );
 
         event Action<IInternalConsumer> Cancelled;
-    }
-
-    public class BasicConsumer : IBasicConsumer, IDisposable
-    {
-        private readonly Action<BasicConsumer> cancelled;
-        private readonly IConsumerDispatcher consumerDispatcher;
-        private readonly IEventBus eventBus;
-        private readonly IHandlerRunner handlerRunner;
-        private readonly ILog logger = LogProvider.For<BasicConsumer>();
-
-        private bool disposed;
-
-        public BasicConsumer(
-            Action<BasicConsumer> cancelled,
-            IConsumerDispatcher consumerDispatcher,
-            IQueue queue,
-            IEventBus eventBus,
-            IHandlerRunner handlerRunner,
-            Func<byte[], MessageProperties, MessageReceivedInfo, CancellationToken, Task> onMessage,
-            IModel model
-        )
-        {
-            Preconditions.CheckNotNull(onMessage, "onMessage");
-
-            Queue = queue;
-            OnMessage = onMessage;
-            this.cancelled = cancelled;
-            this.consumerDispatcher = consumerDispatcher;
-            this.eventBus = eventBus;
-            this.handlerRunner = handlerRunner;
-            Model = model;
-        }
-
-        public Func<byte[], MessageProperties, MessageReceivedInfo, CancellationToken, Task> OnMessage { get; }
-        public IQueue Queue { get; }
-        public string ConsumerTag { get; private set; }
-
-        public void HandleBasicConsumeOk(string consumerTag)
-        {
-            ConsumerTag = consumerTag;
-        }
-
-        public void HandleBasicCancelOk(string consumerTag)
-        {
-            Cancel();
-        }
-
-        public void HandleBasicCancel(string consumerTag)
-        {
-            logger.InfoFormat(
-                "Consumer with consumerTag {consumerTag} has cancelled",
-                consumerTag
-            );
-            Cancel();
-        }
-
-        public void HandleModelShutdown(object model, ShutdownEventArgs reason)
-        {
-            logger.InfoFormat(
-                "Consumer with consumerTag {consumerTag} on queue {queue} has shutdown with reason {reason}",
-                ConsumerTag,
-                Queue.Name,
-                reason
-            );
-            Cancel();
-        }
-
-        public void HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, IBasicProperties properties, byte[] body)
-        {
-            if (logger.IsDebugEnabled())
-            {
-                logger.DebugFormat("Message delivered to consumer {consumerTag} with deliveryTag {deliveryTag}", consumerTag, deliveryTag);
-            }
-
-            if (disposed)
-            {
-                // this message's consumer has stopped, so just return
-                logger.InfoFormat(
-                    "Consumer with consumerTag {consumerTag} on queue {queue} has stopped running. Ignoring message",
-                    ConsumerTag,
-                    Queue.Name
-                );
-
-                return;
-            }
-
-            var messageReceivedInfo = new MessageReceivedInfo(consumerTag, deliveryTag, redelivered, exchange, routingKey, Queue.Name);
-            var messageProperties = new MessageProperties(properties);
-            var context = new ConsumerExecutionContext(OnMessage, messageReceivedInfo, messageProperties, body);
-
-            eventBus.Publish(new DeliveredMessageEvent(messageReceivedInfo, messageProperties, body));
-            handlerRunner.InvokeUserMessageHandlerAsync(context)
-                .ContinueWith(async x =>
-                    {
-                        var ackStrategy = await x.ConfigureAwait(false);
-                        consumerDispatcher.QueueAction(() =>
-                        {
-                            var ackResult = ackStrategy(Model, deliveryTag);
-                            eventBus.Publish(new AckEvent(messageReceivedInfo, messageProperties, body, ackResult));
-                        });
-                    },
-                    TaskContinuationOptions.ExecuteSynchronously
-                );
-        }
-
-        public IModel Model { get; }
-        public event EventHandler<ConsumerEventArgs> ConsumerCancelled;
-
-        public void Dispose()
-        {
-            if (disposed) return;
-            disposed = true;
-
-            eventBus.Publish(new ConsumerModelDisposedEvent(ConsumerTag));
-        }
-
-        /// <summary>
-        /// Cancel means that an external signal has requested that this consumer should
-        /// be cancelled. This is _not_ the same as when an internal consumer stops consuming
-        /// because it has lost its channel/connection.
-        /// </summary>
-        private void Cancel()
-        {
-            // copy to temp variable to be thread safe.
-            var localCancelled = cancelled;
-            localCancelled?.Invoke(this);
-
-            var consumerCancelled = ConsumerCancelled;
-            consumerCancelled?.Invoke(this, new ConsumerEventArgs(ConsumerTag));
-        }
     }
 
     public class InternalConsumer : IInternalConsumer

--- a/Source/EasyNetQ/Consumer/Priority.cs
+++ b/Source/EasyNetQ/Consumer/Priority.cs
@@ -1,0 +1,9 @@
+﻿namespace EasyNetQ.Consumer
+{
+    public enum Priority
+    {
+        Low,
+        Medium,
+        High
+    }
+}

--- a/Source/EasyNetQ/Consumer/Priority.cs
+++ b/Source/EasyNetQ/Consumer/Priority.cs
@@ -1,9 +1,0 @@
-﻿namespace EasyNetQ.Consumer
-{
-    public enum Priority
-    {
-        Low,
-        Medium,
-        High
-    }
-}


### PR DESCRIPTION
- Reworked the ConsumerDispatcher to improve scenarios around dispose and OnDisconnect.
- Fixed the deadlocked that happened on a Fail-over combined with Dispose of consumer from the InernalConsumer. The schedueld dispose messages was removed from the queue OnDisconnect and the AutoResetEvent was never signaled in the InternalConsumer Dispose.
- Added Cancel to HandleModelShutdown in the BasicConsumer, so subscriber of consumer event will know if the consumer is shutdown by the model