### PR TITLE
Fix publisher confirmation bug

### DIFF
--- a/Source/EasyNetQ.Tests/Integration/PublisherConfirmsIntegrationTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/PublisherConfirmsIntegrationTests.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
-using EasyNetQ.Producer;
 using Xunit;
 
 namespace EasyNetQ.Tests.Integration

--- a/Source/EasyNetQ.Tests/Integration/PublisherConfirmsIntegrationTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/PublisherConfirmsIntegrationTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace EasyNetQ.Tests.Integration
@@ -12,11 +13,7 @@ namespace EasyNetQ.Tests.Integration
     {
         public PublisherConfirmsIntegrationTests()
         {
-            bus = RabbitHutch.CreateBus(new ConnectionConfiguration
-            {
-                Hosts = new List<HostConfiguration> {new HostConfiguration {Host = "localhost", Port = 5672}},
-                PublisherConfirms = true
-            }, register => { });
+            bus = RabbitHutch.CreateBus("host=localhost;publisherConfirms=true;timeout=10");
         }
 
         public void Dispose()
@@ -27,7 +24,7 @@ namespace EasyNetQ.Tests.Integration
         private readonly IBus bus;
 
         [Fact]
-        public async void PublisherConfirmShouldNotTimeOut()
+        public async Task PublisherConfirmShouldNotTimeOut()
         {
             var resetEvent = new AutoResetEvent(false);
 

--- a/Source/EasyNetQ/Producer/PublishConfirmationListener.cs
+++ b/Source/EasyNetQ/Producer/PublishConfirmationListener.cs
@@ -54,9 +54,9 @@ namespace EasyNetQ.Producer
 
         private void OnPublishChannelCreated(PublishChannelCreatedEvent @event)
         {
-            foreach (var channel in unconfirmedChannelRequests.Keys)
+            foreach (var channelNumber in unconfirmedChannelRequests.Keys)
             {
-                if (!unconfirmedChannelRequests.TryRemove(channel, out var confirmations)) continue;
+                if (!unconfirmedChannelRequests.TryRemove(channelNumber, out var confirmations)) continue;
                 foreach (var deliveryTag in confirmations.Keys)
                 {
                     if (!confirmations.TryRemove(deliveryTag, out var confirmation)) continue;

--- a/Source/EasyNetQ/Producer/PublishConfirmationListener.cs
+++ b/Source/EasyNetQ/Producer/PublishConfirmationListener.cs
@@ -11,7 +11,7 @@ namespace EasyNetQ.Producer
     public class PublishConfirmationListener : IPublishConfirmationListener
     {
         private readonly CancellationTokenSource cancellation = new CancellationTokenSource();
-        private readonly ConcurrentDictionary<IModel, ConcurrentDictionary<ulong, TaskCompletionSource<object>>> unconfirmedChannelRequests = new ConcurrentDictionary<IModel, ConcurrentDictionary<ulong, TaskCompletionSource<object>>>();
+        private readonly ConcurrentDictionary<int, ConcurrentDictionary<ulong, TaskCompletionSource<object>>> unconfirmedChannelRequests = new ConcurrentDictionary<int, ConcurrentDictionary<ulong, TaskCompletionSource<object>>>();
 
         public PublishConfirmationListener(IEventBus eventBus)
         {
@@ -22,7 +22,7 @@ namespace EasyNetQ.Producer
         public IPublishConfirmationWaiter GetWaiter(IModel model)
         {
             var deliveryTag = model.NextPublishSeqNo;
-            var requests = unconfirmedChannelRequests.GetOrAdd(model, _ => new ConcurrentDictionary<ulong, TaskCompletionSource<object>>());
+            var requests = unconfirmedChannelRequests.GetOrAdd(model.ChannelNumber, _ => new ConcurrentDictionary<ulong, TaskCompletionSource<object>>());
             var confirmation = TaskHelpers.CreateTcs<object>();
             requests.Add(deliveryTag, confirmation);
             return new PublishConfirmationWaiter(deliveryTag, confirmation.Task, cancellation.Token, () => requests.Remove(deliveryTag));
@@ -35,7 +35,7 @@ namespace EasyNetQ.Producer
 
         private void OnMessageConfirmation(MessageConfirmationEvent @event)
         {
-            if (!unconfirmedChannelRequests.TryGetValue(@event.Channel, out var requests)) return;
+            if (!unconfirmedChannelRequests.TryGetValue(@event.Channel.ChannelNumber, out var requests)) return;
 
             var deliveryTag = @event.DeliveryTag;
             var multiple = @event.Multiple;
@@ -65,7 +65,7 @@ namespace EasyNetQ.Producer
                 }
             }
 
-            unconfirmedChannelRequests.Add(@event.Channel, new ConcurrentDictionary<ulong, TaskCompletionSource<object>>());
+            unconfirmedChannelRequests.Add(@event.Channel.ChannelNumber, new ConcurrentDictionary<ulong, TaskCompletionSource<object>>());
         }
 
         private static void Confirm(TaskCompletionSource<object> tcs, ulong deliveryTag, bool isNack)


### PR DESCRIPTION
- Fix Publisher Confirmation timeout
Issue is that the IModel object reference on the @event in OnMessageConfirmation has changed. So it has the same ChannelNumber but it is a dfferent object