### PR TITLE
Bump Newtonsoft.Json to 12.0.3

### DIFF
--- a/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
+++ b/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="LightInject" Version="5.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="RabbitMQ.Client" Version="[6.0.0,7.0.0)" />
     <PackageReference Include="SimpleInjector" Version="4.6.2" />

--- a/Source/EasyNetQ.Hosepipe.Tests/EasyNetQ.Hosepipe.Tests.csproj
+++ b/Source/EasyNetQ.Hosepipe.Tests/EasyNetQ.Hosepipe.Tests.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="RabbitMQ.Client" Version="[6.0.0,7.0.0)" />
     <PackageReference Include="GitVersionTask" Version="5.0.1">
       <PrivateAssets>all</PrivateAssets>

--- a/Source/EasyNetQ.Hosepipe/EasyNetQ.Hosepipe.csproj
+++ b/Source/EasyNetQ.Hosepipe/EasyNetQ.Hosepipe.csproj
@@ -25,7 +25,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="RabbitMQ.Client" Version="[6.0.0,7.0.0)" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Source/EasyNetQ.Scheduler/EasyNetQ.Scheduler.csproj
+++ b/Source/EasyNetQ.Scheduler/EasyNetQ.Scheduler.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.8" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="RabbitMQ.Client" Version="[6.0.0,7.0.0)" />
     <PackageReference Include="Topshelf" Version="4.2.1" />
     <PackageReference Include="GitVersionTask" Version="5.0.1">

--- a/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
+++ b/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="RabbitMQ.Client" Version="[6.0.0,7.0.0)" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />

--- a/Source/EasyNetQ/EasyNetQ.csproj
+++ b/Source/EasyNetQ/EasyNetQ.csproj
@@ -10,7 +10,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="RabbitMQ.Client" Version="[6.0.0,7.0.0)" />
     <PackageReference Include="LibLog" Version="5.0.8">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Bump [Newtonsoft.Json](https://github.com/JamesNK/Newtonsoft.Json/releases/tag/12.0.3) since a number of errors have been fixed.