### PR TITLE
Exception in consumer not propagating to producer

### DIFF
--- a/Source/EasyNetQ.Tests/DefaultMessageSerializationStrategyTests.cs
+++ b/Source/EasyNetQ.Tests/DefaultMessageSerializationStrategyTests.cs
@@ -84,6 +84,24 @@ namespace EasyNetQ.Tests
             Assert.Equal(((Message<MyMessage>)deserializedMessage).Body.Text, message.Body.Text);
         }
 
+        [Fact]
+        public void When_using_the_default_serialization_strategy_messages_are_correctly_round_tripped_when_null()
+        {
+            var typeNameSerializer = new DefaultTypeNameSerializer();
+            var serializer = new JsonSerializer();
+            const string correlationId = "CorrelationId";
+
+            var serializationStrategy = new DefaultMessageSerializationStrategy(typeNameSerializer, serializer, new StaticCorrelationIdGenerationStrategy(correlationId));
+
+            var message = new Message<MyMessage>();
+            var serializedMessage = serializationStrategy.SerializeMessage(message);
+            var deserializedMessage = serializationStrategy.DeserializeMessage(serializedMessage.Properties, serializedMessage.Body);
+
+            Assert.Equal(deserializedMessage.MessageType, message.MessageType);
+            Assert.Null(((Message<MyMessage>)deserializedMessage).Body);
+        }
+
+
         private void AssertMessageSerializedCorrectly(SerializedMessage message, byte[] expectedBody, string expectedMessageType, string expectedCorrelationId)
         {
             Assert.Equal(message.Body, expectedBody); //, "Serialized message body does not match expected value");

--- a/Source/EasyNetQ/IMessage.cs
+++ b/Source/EasyNetQ/IMessage.cs
@@ -29,7 +29,7 @@ namespace EasyNetQ
 
     public class Message<T> : IMessage<T>
     {
-        public MessageProperties Properties { get; private set; }
+        public MessageProperties Properties { get; }
         public Type MessageType { get; }
         public T Body { get; }
 
@@ -37,12 +37,11 @@ namespace EasyNetQ
 
         public Message(T body)
         {
-            Preconditions.CheckNotNull(body, "body");
             Body = body;
             Properties = new MessageProperties();
-            MessageType = body.GetType();
+            MessageType = body != null ? body.GetType() : typeof(T);
         }
-        
+
         public Message()
         {
             Body = default;
@@ -52,11 +51,9 @@ namespace EasyNetQ
 
         public Message(T body, MessageProperties properties)
         {
-            Preconditions.CheckNotNull(body, "body");
-            Preconditions.CheckNotNull(properties, "properties");
             Body = body;
             Properties = properties;
-            MessageType = body.GetType();
+            MessageType = body != null ? body.GetType() : typeof(T);
         }
     }
 }

--- a/Source/EasyNetQ/MessageFactory.cs
+++ b/Source/EasyNetQ/MessageFactory.cs
@@ -5,7 +5,7 @@ namespace EasyNetQ
 {
     /// <summary>
     /// Creates a generic <see cref="IMessage{T}"/> and returns it casted as <see cref="IMessage"/>
-    /// so it can be used in scenarios where we only have a runtime <see cref="Type"/> available. 
+    /// so it can be used in scenarios where we only have a runtime <see cref="Type"/> available.
     /// </summary>
     public static class MessageFactory
     {
@@ -23,7 +23,6 @@ namespace EasyNetQ
         public static IMessage CreateInstance(Type messageType, object body, MessageProperties properties)
         {
             Preconditions.CheckNotNull(messageType, "messageType");
-            Preconditions.CheckNotNull(body, "body");
             Preconditions.CheckNotNull(properties, "properties");
 
             var genericType = genericMessageTypesMap.GetOrAdd(messageType, t => typeof(Message<>).MakeGenericType(t));


### PR DESCRIPTION
Upon exception the response message's body was always 'null' since the message was created using an empty constructor. Now the constructor with a type argument is used. To it an instance of the type of the response message is passed. This allows the publisher to receive the incurred exception.

Resolves #987

PS It's a replacement of https://github.com/EasyNetQ/EasyNetQ/pull/1002