### PR TITLE
Drop support of infinite timeouts

### DIFF
--- a/Source/EasyNetQ/ConnectionConfiguration.cs
+++ b/Source/EasyNetQ/ConnectionConfiguration.cs
@@ -153,6 +153,11 @@ namespace EasyNetQ
                 }
             }
 
+            if (Timeout == 0)
+            {
+                throw new EasyNetQException("Invalid connection string. 'timeout' value must be positive value");
+            }
+
             SetDefaultClientProperties(ClientProperties);
         }
     }

--- a/Source/EasyNetQ/Preconditions.cs
+++ b/Source/EasyNetQ/Preconditions.cs
@@ -227,11 +227,18 @@ namespace EasyNetQ
             }
         }
 
-        public static void CheckLess(TimeSpan value, TimeSpan maxValue, string name)
+        public static void CheckLess<T>(T value, T maxValue, string name) where T: IComparable<T>
         {
-            if (value < maxValue)
+            if (value.CompareTo(maxValue) < 0)
                 return;
-            throw new ArgumentOutOfRangeException(name, string.Format("Arguments {0} must be less than maxValue", name));
+            throw new ArgumentOutOfRangeException(name, value, string.Format("{0} must be less than {1}", name, maxValue));
+        }
+
+        public static void CheckGreater<T>(T value, T minValue, string name) where T: IComparable<T>
+        {
+            if (value.CompareTo(minValue) > 0)
+                return;
+            throw new ArgumentOutOfRangeException(name, value, string.Format("{0} must be greated than {1}", name, minValue));
         }
 
         public static void CheckNull<T>(T value, string name)

--- a/Source/EasyNetQ/Producer/PersistentChannel.cs
+++ b/Source/EasyNetQ/Producer/PersistentChannel.cs
@@ -42,9 +42,7 @@ namespace EasyNetQ.Producer
         {
             Preconditions.CheckNotNull(channelAction, "channelAction");
 
-            var timeout = configuration.Timeout.Equals(0)
-                ? TimeBudget.Infinite()
-                : TimeBudget.Start(TimeSpan.FromSeconds(configuration.Timeout));
+            var timeout = TimeBudget.Start(TimeSpan.FromSeconds(configuration.Timeout));
 
             var retryTimeoutMs = MinRetryTimeoutMs;
             while (!timeout.IsExpired())

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -229,8 +229,13 @@ namespace EasyNetQ
             if (connectionConfiguration.PublisherConfirms)
             {
                 var timeout = TimeBudget.Start(TimeSpan.FromSeconds(connectionConfiguration.Timeout));
-                while (!timeout.IsExpired())
+                while (true)
                 {
+                    if (timeout.IsExpired())
+                    {
+                        throw new TimeoutException($"Publish timed out after {connectionConfiguration.Timeout} seconds");
+                    }
+
                     var confirmsWaiter = clientCommandDispatcher.Invoke(model =>
                     {
                         var properties = model.CreateBasicProperties();
@@ -339,8 +344,13 @@ namespace EasyNetQ
             if (connectionConfiguration.PublisherConfirms)
             {
                 var timeout = TimeBudget.Start(TimeSpan.FromSeconds(connectionConfiguration.Timeout));
-                while (!timeout.IsExpired())
+                while (true)
                 {
+                    if (timeout.IsExpired())
+                    {
+                        throw new TimeoutException($"Publish timed out after {connectionConfiguration.Timeout} seconds");
+                    }
+
                     var confirmsWaiter = await clientCommandDispatcher.InvokeAsync(model =>
                     {
                         var properties = model.CreateBasicProperties();

--- a/Source/EasyNetQ/TimeBudget.cs
+++ b/Source/EasyNetQ/TimeBudget.cs
@@ -5,9 +5,9 @@ using System.Threading;
 namespace EasyNetQ
 {
     public sealed class TimeBudget
-    {   
+    {
         private static readonly TimeSpan Precision = TimeSpan.FromMilliseconds(1);
-        
+
         private readonly TimeSpan budget;
         private readonly Stopwatch watch;
 
@@ -17,11 +17,6 @@ namespace EasyNetQ
             this.budget = budget;
         }
 
-        public static TimeBudget Infinite()
-        {
-            return new TimeBudget(Stopwatch.StartNew(), Timeout.InfiniteTimeSpan);
-        }
-
         public static TimeBudget Start(TimeSpan budget)
         {
             return new TimeBudget(Stopwatch.StartNew(), budget);
@@ -29,22 +24,12 @@ namespace EasyNetQ
 
         public bool IsExpired()
         {
-            if (budget == Timeout.InfiniteTimeSpan)
-            {
-                return false;
-            }
-
             var remaining = budget - watch.Elapsed;
             return remaining < Precision;
         }
 
         public static implicit operator TimeSpan(TimeBudget source)
         {
-            if (source.budget == Timeout.InfiniteTimeSpan)
-            {
-                return Timeout.InfiniteTimeSpan;
-            }
-
             var remaining = source.budget - source.watch.Elapsed;
             return remaining < Precision ? TimeSpan.Zero : remaining;
         }

--- a/Source/EasyNetQ/TimeoutSecondsAttribute.cs
+++ b/Source/EasyNetQ/TimeoutSecondsAttribute.cs
@@ -9,6 +9,7 @@ namespace EasyNetQ
 
         public TimeoutSecondsAttribute(ushort timeout)
         {
+            Preconditions.CheckGreater(timeout, 0, "timeout");
             Timeout = timeout;
         }
     }


### PR DESCRIPTION
Fixes #1010

1. It's not possible to support correctly the infinite timeout in case of publishing confirms, so we decided to drop its supports completely.
2. Please implement this logic in your code if you need it.
3. `Timeout=0` is not supported anymore.