### PR TITLE
Drop `IConsumerDispatcher.QueueAction(Action)`

### DIFF
--- a/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
@@ -27,8 +27,9 @@ namespace EasyNetQ.Consumer
                         );
                         action();
                     }
-                    catch (OperationCanceledException)
+                    catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
                     {
+                        break;
                     }
                     catch (Exception exception)
                     {

--- a/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
@@ -16,7 +16,6 @@ namespace EasyNetQ.Consumer
         {
             Preconditions.CheckNotNull(configuration, "configuration");
 
-
             var thread = new Thread(_ =>
             {
                 var blockingCollections = new[] {durableActions, transientActions};
@@ -30,7 +29,6 @@ namespace EasyNetQ.Consumer
                     }
                     catch (OperationCanceledException)
                     {
-                        break;
                     }
                     catch (Exception exception)
                     {

--- a/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
@@ -52,12 +52,7 @@ namespace EasyNetQ.Consumer
             thread.Start();
         }
 
-        public void QueueAction(Action action)
-        {
-            QueueAction(action, false);
-        }
-
-        public void QueueAction(Action action, bool surviveDisconnect)
+        public void QueueAction(Action action, bool surviveDisconnect = false)
         {
             Preconditions.CheckNotNull(action, "action");
 

--- a/Source/EasyNetQ/Consumer/IConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/IConsumerDispatcher.cs
@@ -4,8 +4,7 @@ namespace EasyNetQ.Consumer
 {
     public interface IConsumerDispatcher : IDisposable
     {
-        void QueueAction(Action action);
-        void QueueAction(Action action, bool surviveDisconnect);
+        void QueueAction(Action action, bool surviveDisconnect = false);
         void OnDisconnected();
     }
 }


### PR DESCRIPTION
Related to #1043.

So, it seems that #1021 should be released with major version bump, we could remove `QueueAction(Action)` as well.

Also this PR covers a very weird situation when action throws OCE. 