### PR TITLE
Use own JSON serializer instead of a static one

### DIFF
--- a/Source/EasyNetQ/JsonSerializer.cs
+++ b/Source/EasyNetQ/JsonSerializer.cs
@@ -1,37 +1,53 @@
 ﻿using System;
+using System.IO;
 using System.Text;
-using Newtonsoft.Json;
 
 namespace EasyNetQ
 {
     public class JsonSerializer : ISerializer
     {
-        private readonly JsonSerializerSettings serializerSettings;
-
-        public JsonSerializer()
-        {
-            serializerSettings = new JsonSerializerSettings
+        private static readonly Newtonsoft.Json.JsonSerializerSettings DefaultSerializerSettings =
+            new Newtonsoft.Json.JsonSerializerSettings
             {
-                TypeNameHandling = TypeNameHandling.Auto
+                TypeNameHandling = Newtonsoft.Json.TypeNameHandling.Auto
             };
-        }
 
-        public JsonSerializer(JsonSerializerSettings serializerSettings)
+        private const int DefaultBufferSize = 1024;
+
+        private readonly Newtonsoft.Json.JsonSerializer serializer;
+
+        public JsonSerializer() : this(DefaultSerializerSettings)
         {
-            this.serializerSettings = serializerSettings;
         }
 
-        public byte[] MessageToBytes(Type messageType, object message) 
+        public JsonSerializer(Newtonsoft.Json.JsonSerializerSettings serializerSettings)
+        {
+            serializer = Newtonsoft.Json.JsonSerializer.Create(serializerSettings);
+        }
+
+        public byte[] MessageToBytes(Type messageType, object message)
         {
             Preconditions.CheckNotNull(messageType, "messageType");
-            return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message, messageType, serializerSettings));
+
+            using (var memoryStream = new MemoryStream(DefaultBufferSize))
+            {
+                using (var streamWriter = new StreamWriter(memoryStream, Encoding.UTF8, DefaultBufferSize, true))
+                using (var writer = new Newtonsoft.Json.JsonTextWriter(streamWriter))
+                    serializer.Serialize(writer, message, messageType);
+
+                return memoryStream.ToArray();
+            }
         }
 
         public object BytesToMessage(Type messageType, byte[] bytes)
         {
             Preconditions.CheckNotNull(messageType, "messageType");
             Preconditions.CheckNotNull(bytes, "bytes");
-            return JsonConvert.DeserializeObject(Encoding.UTF8.GetString(bytes), messageType, serializerSettings);
+
+            using (var memoryStream = new MemoryStream(bytes, false))
+            using (var streamReader = new StreamReader(memoryStream, Encoding.UTF8, false, DefaultBufferSize, true))
+            using (var reader = new Newtonsoft.Json.JsonTextReader(streamReader))
+                return serializer.Deserialize(reader, messageType);
         }
     }
 }


### PR DESCRIPTION
Fix #974

Most of the code is from Newtonsoft.JSON, but:
1. We need to return bytes, so StreamWriter+MemoryStream is used instead of StringWriter+StringBuilder.
2. UTF8 without BOM is used because it is how serialization worked before(BOM was not emitted).