### PR TITLE
Allow infinite timeout with publish confirms

### DIFF
--- a/Source/EasyNetQ/ConnectionConfigurationExtensions.cs
+++ b/Source/EasyNetQ/ConnectionConfigurationExtensions.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading;
+
+namespace EasyNetQ
+{
+    // TODO Should migrate Timeout from ushort to TimeSpan
+    internal static class ConnectionConfigurationExtensions
+    {
+        public static TimeSpan GetTimeout(this ConnectionConfiguration configuration)
+        {
+            return configuration.Timeout == 0 ? Timeout.InfiniteTimeSpan : TimeSpan.FromSeconds(configuration.Timeout);
+        }
+    }
+}

--- a/Source/EasyNetQ/Producer/PersistentChannel.cs
+++ b/Source/EasyNetQ/Producer/PersistentChannel.cs
@@ -42,9 +42,7 @@ namespace EasyNetQ.Producer
         {
             Preconditions.CheckNotNull(channelAction, "channelAction");
 
-            var timeout = configuration.Timeout.Equals(0)
-                ? TimeBudget.Infinite()
-                : TimeBudget.Start(TimeSpan.FromSeconds(configuration.Timeout));
+            var timeout = TimeBudget.Start(configuration.GetTimeout());
 
             var retryTimeoutMs = MinRetryTimeoutMs;
             while (!timeout.IsExpired())

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -228,9 +228,14 @@ namespace EasyNetQ
             var rawMessage = produceConsumeInterceptor.OnProduce(new RawMessage(messageProperties, body));
             if (connectionConfiguration.PublisherConfirms)
             {
-                var timeout = TimeBudget.Start(TimeSpan.FromSeconds(connectionConfiguration.Timeout));
-                while (!timeout.IsExpired())
+                var timeout = TimeBudget.Start(connectionConfiguration.GetTimeout());
+                while (true)
                 {
+                    if (timeout.IsExpired())
+                    {
+                        throw new TimeoutException($"Publish timed out after {connectionConfiguration.Timeout} seconds");
+                    }
+
                     var confirmsWaiter = clientCommandDispatcher.Invoke(model =>
                     {
                         var properties = model.CreateBasicProperties();
@@ -338,9 +343,14 @@ namespace EasyNetQ
             var rawMessage = produceConsumeInterceptor.OnProduce(new RawMessage(messageProperties, body));
             if (connectionConfiguration.PublisherConfirms)
             {
-                var timeout = TimeBudget.Start(TimeSpan.FromSeconds(connectionConfiguration.Timeout));
-                while (!timeout.IsExpired())
+                var timeout = TimeBudget.Start(connectionConfiguration.GetTimeout());
+                while (true)
                 {
+                    if (timeout.IsExpired())
+                    {
+                        throw new TimeoutException($"Publish timed out after {connectionConfiguration.Timeout} seconds");
+                    }
+
                     var confirmsWaiter = await clientCommandDispatcher.InvokeAsync(model =>
                     {
                         var properties = model.CreateBasicProperties();


### PR DESCRIPTION
Fix #1010

Also, this PR fixes a very rare situation when Publish tells that message is published, but actually, it is not.

PS All versions of sleep(async Thread.Sleep or async Task.Delay) work fine with `InfiniteTimeSpan`. 