### PR TITLE
Bump base image and simplify configuration

### DIFF
--- a/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
+++ b/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
   <ItemGroup>
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\EasyNetQ.DI.Ninject\EasyNetQ.DI.Ninject.csproj" />
     <ProjectReference Include="..\EasyNetQ.Tests.Common\EasyNetQ.Tests.Common.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
     <ProjectReference Include="..\EasyNetQ.DI.Microsoft\EasyNetQ.DI.Microsoft.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/Source/EasyNetQ.Hosepipe.Tests/EasyNetQ.Hosepipe.Tests.csproj
+++ b/Source/EasyNetQ.Hosepipe.Tests/EasyNetQ.Hosepipe.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
   <PropertyGroup>
     <Description>EasyNetQ.Hosepipe.Tests</Description>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -33,7 +33,7 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
     <DefineConstants>$(DefineConstants);NET_STANDARD</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
+++ b/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
   <PropertyGroup>
     <Description>EasyNetQ.Tests</Description>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\EasyNetQ\EasyNetQ.csproj" />
@@ -30,7 +30,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
     <DefineConstants>$(DefineConstants);NET_CORE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/Source/NuGet.Config
+++ b/Source/NuGet.Config
@@ -2,6 +2,6 @@
 <configuration>
 	<packageSources>
 		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-		<add key="EasyNetQ Unstable" value="https://www.myget.org/F/easynetq-unstable/api/v3/index.json" />
+		<add key="appveyor" value="https://ci.appveyor.com/nuget/easynetq-trqma83u327s" />
 	</packageSources>
 </configuration>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image:
-  - Visual Studio 2017
+  - Visual Studio 2019
 
 pull_requests:
   do_not_increment_build_number: true
@@ -15,7 +15,6 @@ branches:
   only:
   - master
   - develop
-  - feature/*
 
 artifacts:
   - path: Package\**\*.nupkg
@@ -38,22 +37,6 @@ deploy:
     skip_symbols: false
     on:
       branch: develop
-  - provider: NuGet
-    artifact: /.*\.s?nupkg/
-    server:
-    api_key:
-      secure: ejD7WLs3aqlXgHLyWq444QK6pnMT6g/QiRxptqIGaOgKvGM7SJ17r/QH6e1jEJ9M
-    skip_symbols: false
-    on:
-      branch: /release\/.+/
-  - provider: NuGet
-    artifact: /.*\.s?nupkg/
-    server: https://www.myget.org/F/easynetq-unstable/api/v2/package
-    api_key:
-       secure: +0aKxcCHqWvvdJxA4dh1ToRqwA6x8yqhfrYDIeOjQu6Skpg/UrwxAPBik8z6be99
-    skip_symbols: false
-    on:
-      branch: /feature\/.+/
 
 skip_commits:
   files:


### PR DESCRIPTION
1. Upgrade from 2017 to 2019 image
2. Bump netcore2 to netcore3
3. Remove feature and release branches specific configurations