### PR TITLE
Add QueueAttribute.Default

### DIFF
--- a/Source/EasyNetQ/Conventions.cs
+++ b/Source/EasyNetQ/Conventions.cs
@@ -81,7 +81,7 @@ namespace EasyNetQ
 
         private QueueAttribute GetQueueAttribute(Type messageType)
         {
-            return messageType.GetAttribute<QueueAttribute>() ?? new QueueAttribute(string.Empty);
+            return messageType.GetAttribute<QueueAttribute>() ?? QueueAttribute.Default;
         }
 
 		public ExchangeNameConvention ExchangeNamingConvention { get; set; }

--- a/Source/EasyNetQ/QueueAttribute.cs
+++ b/Source/EasyNetQ/QueueAttribute.cs
@@ -5,12 +5,15 @@ namespace EasyNetQ
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple=false)]
     public class QueueAttribute : Attribute
     {
+        internal static readonly QueueAttribute Default = new QueueAttribute(null);
+
         public QueueAttribute(string queueName)
         {
             QueueName = queueName ?? string.Empty;
         }
 
         public string QueueName { get; }
+
         public string ExchangeName { get; set; }
     }
 }

--- a/Source/EasyNetQ/ReflectionHelpers.cs
+++ b/Source/EasyNetQ/ReflectionHelpers.cs
@@ -2,9 +2,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
-
 
 namespace EasyNetQ
 {
@@ -14,7 +11,7 @@ namespace EasyNetQ
 
         private static Dictionary<Type, Attribute[]> GetOrAddTypeAttributeDictionary(Type type)
         {
-            return typesAttributes.GetOrAdd(type, t => t.GetTypeInfo().GetCustomAttributes(true)
+            return typesAttributes.GetOrAdd(type, t => t.GetCustomAttributes(true)
                                                     .Cast<Attribute>()
                                                     .GroupBy(attr => attr.GetType())
                                                     .ToDictionary(group => group.Key, group => group.ToArray()));
@@ -36,7 +33,7 @@ namespace EasyNetQ
             {
                 return (TAttribute)attributes[0];
             }
-            return default(TAttribute);
+            return default;
         }
     }
 }


### PR DESCRIPTION
Eliminates memory allocation for empty `QueueAttribute` on each exchange/queue declaration.