### PR TITLE
Add missing ConfirmSelect

### DIFF
--- a/Source/EasyNetQ.Tests/ConsumeTests/DefaultConsumerErrorStrategyTests.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/DefaultConsumerErrorStrategyTests.cs
@@ -22,6 +22,7 @@ namespace EasyNetQ.Tests.ConsumeTests
 
             Assert.Equal(AckStrategies.Ack, ackStrategy);
             modelMock.Received().WaitForConfirms(Arg.Any<TimeSpan>());
+            modelMock.Received().ConfirmSelect();
         }
 
         [Fact]
@@ -38,6 +39,7 @@ namespace EasyNetQ.Tests.ConsumeTests
 
             Assert.Equal(AckStrategies.NackWithRequeue, ackStrategy);
             modelMock.Received().WaitForConfirms(Arg.Any<TimeSpan>());
+            modelMock.Received().ConfirmSelect();
         }
 
         [Fact]

--- a/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
+++ b/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
@@ -76,6 +76,8 @@ namespace EasyNetQ.Consumer
             {
                 using (var model = connection.CreateModel())
                 {
+                    if (configuration.PublisherConfirms) model.ConfirmSelect();
+
                     var errorExchange = DeclareErrorExchangeWithQueue(model, context);
 
                     var messageBody = CreateErrorMessage(context, exception);


### PR DESCRIPTION
This bug was introduced in #997: ConfirmSelect must be called on IModel before waiting for confirms.

FYI @Rotvig