### PR TITLE
Fix consumers reconnection

### DIFF
--- a/Source/EasyNetQ.IntegrationTests/DockerProxy.cs
+++ b/Source/EasyNetQ.IntegrationTests/DockerProxy.cs
@@ -94,6 +94,11 @@ namespace EasyNetQ.IntegrationTests
             await Task.WhenAll(stopTasks);
         }
 
+        public Task StopContainerByIdAsync(string id, CancellationToken token = default)
+        {
+            return client.Containers.StopContainerAsync(id, new ContainerStopParameters(), token);
+        }
+
         public async Task RemoveContainerAsync(string name, CancellationToken token = default)
         {
             var ids = await FindContainerIdsAsync(name).ConfigureAwait(false);
@@ -123,7 +128,7 @@ namespace EasyNetQ.IntegrationTests
             return hostPorts.Select(x => new PortBinding {HostPort = x}).ToList();
         }
 
-        private async Task<IEnumerable<string>> FindContainerIdsAsync(string name)
+        public async Task<IEnumerable<string>> FindContainerIdsAsync(string name)
         {
             var containers = await client.Containers
                 .ListContainersAsync(new ContainersListParameters {All = true, Filters = ListFilters(name)})

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_polymorphic.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_polymorphic.cs
@@ -13,7 +13,7 @@ namespace EasyNetQ.IntegrationTests.PubSub
     {
         public When_publish_and_subscribe_polymorphic(RabbitMQFixture fixture)
         {
-            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1");
+            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1;timeout=5");
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_polymorphic.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_polymorphic.cs
@@ -28,7 +28,7 @@ namespace EasyNetQ.IntegrationTests.PubSub
         [Fact]
         public async Task Test()
         {
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
             var subscriptionId = Guid.NewGuid().ToString();
 
@@ -52,12 +52,12 @@ namespace EasyNetQ.IntegrationTests.PubSub
                 }
             }))
             {
-                await bus.PublishBatchAsync(bunnies.Concat(rabbits), timeoutCts.Token)
+                await bus.PublishBatchAsync(bunnies.Concat(rabbits), cts.Token)
                     .ConfigureAwait(false);
 
                 await Task.WhenAll(
-                    bunniesSink.WaitAllReceivedAsync(timeoutCts.Token),
-                    rabbitsSink.WaitAllReceivedAsync(timeoutCts.Token)
+                    bunniesSink.WaitAllReceivedAsync(cts.Token),
+                    rabbitsSink.WaitAllReceivedAsync(cts.Token)
                 ).ConfigureAwait(false);
 
                 bunniesSink.ReceivedMessages.Should().Equal(bunnies);

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_default_options.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_default_options.cs
@@ -15,7 +15,7 @@ namespace EasyNetQ.IntegrationTests.PubSub
         public When_publish_and_subscribe_with_default_options(RabbitMQFixture rmqFixture)
         {
             this.rmqFixture = rmqFixture;
-            bus = RabbitHutch.CreateBus($"host={rmqFixture.Host};prefetchCount=1");
+            bus = RabbitHutch.CreateBus($"host={rmqFixture.Host};prefetchCount=1;timeout=5");
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_default_options.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_default_options.cs
@@ -92,7 +92,7 @@ namespace EasyNetQ.IntegrationTests.PubSub
         [Fact]
         public async Task Should_survive_restart()
         {
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
             var subscriptionId = Guid.NewGuid().ToString();
             var messagesSink = new MessagesSink(2);

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_exclusive.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_exclusive.cs
@@ -27,7 +27,7 @@ namespace EasyNetQ.IntegrationTests.PubSub
         [Fact]
         public async Task Test()
         {
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
             var firstConsumerMessagesSink = new MessagesSink(MessagesCount);
             var secondConsumerMessagesSink = new MessagesSink(0);
@@ -43,7 +43,7 @@ namespace EasyNetQ.IntegrationTests.PubSub
             )
             {
                 // To ensure that ^ subscriber started successfully
-                await Task.Delay(TimeSpan.FromSeconds(1), timeoutCts.Token).ConfigureAwait(false);
+                await Task.Delay(TimeSpan.FromSeconds(1), cts.Token).ConfigureAwait(false);
 
                 using (
                     bus.Subscribe<Message>(
@@ -53,11 +53,11 @@ namespace EasyNetQ.IntegrationTests.PubSub
                     )
                 )
                 {
-                    await bus.PublishBatchAsync(messages, timeoutCts.Token).ConfigureAwait(false);
+                    await bus.PublishBatchAsync(messages, cts.Token).ConfigureAwait(false);
 
                     await Task.WhenAll(
-                        firstConsumerMessagesSink.WaitAllReceivedAsync(timeoutCts.Token),
-                        secondConsumerMessagesSink.WaitAllReceivedAsync(timeoutCts.Token)
+                        firstConsumerMessagesSink.WaitAllReceivedAsync(cts.Token),
+                        secondConsumerMessagesSink.WaitAllReceivedAsync(cts.Token)
                     ).ConfigureAwait(false);
 
                     firstConsumerMessagesSink.ReceivedMessages.Should().Equal(messages);

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_exclusive.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_exclusive.cs
@@ -12,7 +12,7 @@ namespace EasyNetQ.IntegrationTests.PubSub
     {
         public When_publish_and_subscribe_with_exclusive(RabbitMQFixture fixture)
         {
-            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1");
+            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1;timeout=5");
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_priority.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_priority.cs
@@ -13,7 +13,7 @@ namespace EasyNetQ.IntegrationTests.PubSub
     {
         public When_publish_and_subscribe_with_priority(RabbitMQFixture fixture)
         {
-            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1");
+            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1;timeout=5");
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_priority.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_priority.cs
@@ -30,7 +30,7 @@ namespace EasyNetQ.IntegrationTests.PubSub
         [Fact]
         public async Task Test()
         {
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
             var messagesSink = new MessagesSink(MessagesCount * 2);
             var highPriorityMessages = MessagesFactories.Create(MessagesCount);
@@ -42,15 +42,15 @@ namespace EasyNetQ.IntegrationTests.PubSub
             }
 
             await bus.PublishBatchAsync(
-                lowPriorityMessages, x => x.WithPriority(LowPriority), timeoutCts.Token
+                lowPriorityMessages, x => x.WithPriority(LowPriority), cts.Token
             ).ConfigureAwait(false);
             await bus.PublishBatchAsync(
-                highPriorityMessages, x => x.WithPriority(HighPriority), timeoutCts.Token
+                highPriorityMessages, x => x.WithPriority(HighPriority), cts.Token
             ).ConfigureAwait(false);
 
             using (bus.Subscribe<Message>(subscriptionId, messagesSink.Receive, x => x.WithMaxPriority(2)))
             {
-                await messagesSink.WaitAllReceivedAsync(timeoutCts.Token).ConfigureAwait(false);
+                await messagesSink.WaitAllReceivedAsync(cts.Token).ConfigureAwait(false);
 
                 messagesSink.ReceivedMessages.Should().Equal(highPriorityMessages.Concat(lowPriorityMessages));
             }

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_publish_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_publish_confirms.cs
@@ -12,7 +12,7 @@ namespace EasyNetQ.IntegrationTests.PubSub
     {
         public When_publish_and_subscribe_with_publish_confirms(RabbitMQFixture fixture)
         {
-            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1;publisherConfirms=True");
+            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1;publisherConfirms=True;timeout=5");
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_publish_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_publish_confirms.cs
@@ -27,7 +27,7 @@ namespace EasyNetQ.IntegrationTests.PubSub
         [Fact]
         public async Task Test()
         {
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
             var subscriptionId = Guid.NewGuid().ToString();
 
@@ -36,9 +36,9 @@ namespace EasyNetQ.IntegrationTests.PubSub
 
             using (bus.Subscribe<Message>(subscriptionId, messagesSink.Receive))
             {
-                await bus.PublishBatchAsync(messages, timeoutCts.Token).ConfigureAwait(false);
+                await bus.PublishBatchAsync(messages, cts.Token).ConfigureAwait(false);
 
-                await messagesSink.WaitAllReceivedAsync(timeoutCts.Token).ConfigureAwait(false);
+                await messagesSink.WaitAllReceivedAsync(cts.Token).ConfigureAwait(false);
                 messagesSink.ReceivedMessages.Should().Equal(messages);
             }
         }

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_topic.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_topic.cs
@@ -27,7 +27,7 @@ namespace EasyNetQ.IntegrationTests.PubSub
         [Fact]
         public async Task Test()
         {
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
             var firstTopicMessagesSink = new MessagesSink(MessagesCount);
             var secondTopicMessagesSink = new MessagesSink(MessagesCount);
@@ -51,15 +51,15 @@ namespace EasyNetQ.IntegrationTests.PubSub
             )
             {
                 await bus.PublishBatchAsync(
-                    firstTopicMessages, x => x.WithTopic("first"), timeoutCts.Token
+                    firstTopicMessages, x => x.WithTopic("first"), cts.Token
                 ).ConfigureAwait(false);
                 await bus.PublishBatchAsync(
-                    secondTopicMessages, x => x.WithTopic("second"), timeoutCts.Token
+                    secondTopicMessages, x => x.WithTopic("second"), cts.Token
                 ).ConfigureAwait(false);
 
                 await Task.WhenAll(
-                    firstTopicMessagesSink.WaitAllReceivedAsync(timeoutCts.Token),
-                    secondTopicMessagesSink.WaitAllReceivedAsync(timeoutCts.Token)
+                    firstTopicMessagesSink.WaitAllReceivedAsync(cts.Token),
+                    secondTopicMessagesSink.WaitAllReceivedAsync(cts.Token)
                 ).ConfigureAwait(false);
 
                 firstTopicMessagesSink.ReceivedMessages.Should().Equal(firstTopicMessages);

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_topic.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_topic.cs
@@ -12,7 +12,7 @@ namespace EasyNetQ.IntegrationTests.PubSub
     {
         public When_publish_and_subscribe_with_topic(RabbitMQFixture fixture)
         {
-            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1");
+            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1;timeout=5");
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.IntegrationTests/RabbitMQFixture.cs
+++ b/Source/EasyNetQ.IntegrationTests/RabbitMQFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,23 +31,30 @@ namespace EasyNetQ.IntegrationTests
 
         public async Task InitializeAsync()
         {
-            using (var timeoutCts = new CancellationTokenSource(InitializationTimeout))
-            {
-                dockerEngineOsPlatform =
-                    await dockerProxy.GetDockerEngineOsAsync(timeoutCts.Token).ConfigureAwait(false);
-                dockerNetworkName = dockerEngineOsPlatform == OSPlatform.Windows ? null : "bridgeWhaleNet";
-                await DisposeAsync(timeoutCts.Token).ConfigureAwait(false);
-                await CreateNetworkAsync(timeoutCts.Token).ConfigureAwait(false);
-                var rabbitMQDockerImage = await PullImageAsync(timeoutCts.Token).ConfigureAwait(false);
-                var containerId = await RunContainerAsync(rabbitMQDockerImage, timeoutCts.Token).ConfigureAwait(false);
-                if (dockerEngineOsPlatform == OSPlatform.Windows)
-                    Host = await dockerProxy.GetContainerIpAsync(containerId, timeoutCts.Token).ConfigureAwait(false);
-                ManagementClient = new ManagementClient(
-                    Host, Configuration.RabbitMqUser, Configuration.RabbitMqPassword,
-                    Configuration.RabbitMqManagementPort
-                );
-                await WaitForRabbitMqReadyAsync(timeoutCts.Token);
-            }
+            using var timeoutCts = new CancellationTokenSource(InitializationTimeout);
+            dockerEngineOsPlatform = await dockerProxy.GetDockerEngineOsAsync(timeoutCts.Token).ConfigureAwait(false);
+            dockerNetworkName = dockerEngineOsPlatform == OSPlatform.Windows ? null : "bridgeWhaleNet";
+            await DisposeAsync(timeoutCts.Token).ConfigureAwait(false);
+            await CreateNetworkAsync(timeoutCts.Token).ConfigureAwait(false);
+            var rabbitMQDockerImage = await PullImageAsync(timeoutCts.Token).ConfigureAwait(false);
+            var containerId = await RunNewContainerAsync(rabbitMQDockerImage, timeoutCts.Token).ConfigureAwait(false);
+            if (dockerEngineOsPlatform == OSPlatform.Windows)
+                Host = await dockerProxy.GetContainerIpAsync(containerId, timeoutCts.Token).ConfigureAwait(false);
+            ManagementClient = new ManagementClient(
+                Host, Configuration.RabbitMqUser, Configuration.RabbitMqPassword,
+                Configuration.RabbitMqManagementPort
+            );
+            await WaitForRabbitMqReadyAsync(timeoutCts.Token);
+        }
+
+        public async Task RestartAsync(CancellationToken cancellationToken)
+        {
+            var containersIds = await dockerProxy.FindContainerIdsAsync(Configuration.RabbitMqHostName)
+                .ConfigureAwait(false);
+            var containerId = containersIds.Single();
+            await dockerProxy.StopContainerByIdAsync(containerId, cancellationToken).ConfigureAwait(false);
+            await dockerProxy.StartContainerAsync(containerId, cancellationToken).ConfigureAwait(false);
+            await WaitForRabbitMqReadyAsync(cancellationToken).ConfigureAwait(false);
         }
 
         public async Task DisposeAsync()
@@ -84,7 +92,7 @@ namespace EasyNetQ.IntegrationTests
             return $"{rabbitMQDockerImageName}:{rabbitMQDockerImageTag}";
         }
 
-        private async Task<string> RunContainerAsync(string rabbitMQDockerImage, CancellationToken cancellationToken)
+        private async Task<string> RunNewContainerAsync(string rabbitMQDockerImage, CancellationToken cancellationToken)
         {
             var portMappings = new Dictionary<string, ISet<string>>
             {

--- a/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_polymorphic.cs
+++ b/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_polymorphic.cs
@@ -10,7 +10,7 @@ namespace EasyNetQ.IntegrationTests.Rpc
     {
         public When_request_and_respond_polymorphic(RabbitMQFixture fixture)
         {
-            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1");
+            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1;timeout=5");
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_default_options.cs
+++ b/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_default_options.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using EasyNetQ.IntegrationTests.Utils;
 using FluentAssertions;
 using Xunit;
 
@@ -48,13 +49,13 @@ namespace EasyNetQ.IntegrationTests.Rpc
         [Fact]
         public async Task Should_survive_restart()
         {
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
             using (bus.RespondAsync<Request, Response>(x => Task.FromResult(new Response(x.Id))))
             {
                 await bus.RequestAsync<Request, Response>(new Request(42)).ConfigureAwait(false);
 
-                await rmqFixture.RestartAsync(timeoutCts.Token).ConfigureAwait(false);
+                await rmqFixture.ManagementClient.KillAllConnectionsAsync(cts.Token);
 
                 try
                 {

--- a/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_default_options.cs
+++ b/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_default_options.cs
@@ -48,6 +48,8 @@ namespace EasyNetQ.IntegrationTests.Rpc
         [Fact]
         public async Task Should_survive_restart()
         {
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
             using (bus.RespondAsync<Request, Response>(x => Task.FromResult(new Response(x.Id))))
             {
                 await bus.RequestAsync<Request, Response>(new Request(42)).ConfigureAwait(false);

--- a/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_legacy_options.cs
+++ b/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_legacy_options.cs
@@ -10,7 +10,7 @@ namespace EasyNetQ.IntegrationTests.Rpc
     {
         public When_request_and_respond_with_legacy_options(RabbitMQFixture fixture)
         {
-            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1", c => c.EnableLegacyConventions());
+            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1;timeout=5", c => c.EnableLegacyConventions());
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_publish_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_publish_confirms.cs
@@ -10,7 +10,7 @@ namespace EasyNetQ.IntegrationTests.Rpc
     {
         public When_request_and_respond_with_publish_confirms(RabbitMQFixture fixture)
         {
-            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1;publisherConfirms=True");
+            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1;publisherConfirms=True;timeout=5");
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_dead_letter_exchange.cs
+++ b/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_dead_letter_exchange.cs
@@ -30,7 +30,7 @@ namespace EasyNetQ.IntegrationTests.Scheduler
         [Fact]
         public async Task Test()
         {
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
             var subscriptionId = Guid.NewGuid().ToString();
             var messagesSink = new MessagesSink(MessagesCount);
@@ -38,10 +38,10 @@ namespace EasyNetQ.IntegrationTests.Scheduler
 
             using (bus.Subscribe<Message>(subscriptionId, messagesSink.Receive))
             {
-                await bus.FuturePublishBatchAsync(messages, TimeSpan.FromSeconds(5), timeoutCts.Token)
+                await bus.FuturePublishBatchAsync(messages, TimeSpan.FromSeconds(5), cts.Token)
                     .ConfigureAwait(false);
 
-                await messagesSink.WaitAllReceivedAsync(timeoutCts.Token).ConfigureAwait(false);
+                await messagesSink.WaitAllReceivedAsync(cts.Token).ConfigureAwait(false);
                 messagesSink.ReceivedMessages.Should().Equal(messages);
             }
         }

--- a/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_dead_letter_exchange.cs
+++ b/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_dead_letter_exchange.cs
@@ -14,7 +14,7 @@ namespace EasyNetQ.IntegrationTests.Scheduler
         public When_publish_and_subscribe_with_delay_using_dead_letter_exchange(RabbitMQFixture fixture)
         {
             bus = RabbitHutch.CreateBus(
-                $"host={fixture.Host};prefetchCount=1", c => c.EnableDeadLetterExchangeAndMessageTtlScheduler()
+                $"host={fixture.Host};prefetchCount=1;timeout=5", c => c.EnableDeadLetterExchangeAndMessageTtlScheduler()
             );
         }
 

--- a/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_dead_letter_exchange_with_publish_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_dead_letter_exchange_with_publish_confirms.cs
@@ -31,7 +31,7 @@ namespace EasyNetQ.IntegrationTests.Scheduler
         [Fact]
         public async Task Test()
         {
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
             var subscriptionId = Guid.NewGuid().ToString();
             var messagesSink = new MessagesSink(MessagesCount);
@@ -39,10 +39,10 @@ namespace EasyNetQ.IntegrationTests.Scheduler
 
             using (bus.Subscribe<Message>(subscriptionId, messagesSink.Receive))
             {
-                await bus.FuturePublishBatchAsync(messages, TimeSpan.FromSeconds(5), timeoutCts.Token)
+                await bus.FuturePublishBatchAsync(messages, TimeSpan.FromSeconds(5), cts.Token)
                     .ConfigureAwait(false);
 
-                await messagesSink.WaitAllReceivedAsync(timeoutCts.Token).ConfigureAwait(false);
+                await messagesSink.WaitAllReceivedAsync(cts.Token).ConfigureAwait(false);
                 messagesSink.ReceivedMessages.Should().Equal(messages);
             }
         }

--- a/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_dead_letter_exchange_with_publish_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_dead_letter_exchange_with_publish_confirms.cs
@@ -14,7 +14,7 @@ namespace EasyNetQ.IntegrationTests.Scheduler
         public When_publish_and_subscribe_using_delay_using_dead_letter_exchange_with_publish_confirms(RabbitMQFixture fixture)
         {
             bus = RabbitHutch.CreateBus(
-                $"host={fixture.Host};prefetchCount=1;publisherConfirms=True",
+                $"host={fixture.Host};prefetchCount=1;publisherConfirms=True;timeout=5",
                 c => c.EnableDeadLetterExchangeAndMessageTtlScheduler()
             );
         }

--- a/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_delayed_exchange.cs
+++ b/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_delayed_exchange.cs
@@ -14,7 +14,7 @@ namespace EasyNetQ.IntegrationTests.Scheduler
         public When_publish_and_subscribe_with_delay_using_delay_exchange(RabbitMQFixture fixture)
         {
             bus = RabbitHutch.CreateBus(
-                $"host={fixture.Host};prefetchCount=1", c => c.EnableDelayedExchangeScheduler()
+                $"host={fixture.Host};prefetchCount=1;timeout=5", c => c.EnableDelayedExchangeScheduler()
             );
         }
 

--- a/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_delayed_exchange.cs
+++ b/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_delayed_exchange.cs
@@ -30,7 +30,7 @@ namespace EasyNetQ.IntegrationTests.Scheduler
         [Fact]
         public async Task Test()
         {
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
             var subscriptionId = Guid.NewGuid().ToString();
             var messagesSink = new MessagesSink(MessagesCount);
@@ -38,10 +38,10 @@ namespace EasyNetQ.IntegrationTests.Scheduler
 
             using (bus.Subscribe<Message>(subscriptionId, messagesSink.Receive))
             {
-                await bus.FuturePublishBatchAsync(messages, TimeSpan.FromSeconds(5), timeoutCts.Token)
+                await bus.FuturePublishBatchAsync(messages, TimeSpan.FromSeconds(5), cts.Token)
                     .ConfigureAwait(false);
 
-                await messagesSink.WaitAllReceivedAsync(timeoutCts.Token).ConfigureAwait(false);
+                await messagesSink.WaitAllReceivedAsync(cts.Token).ConfigureAwait(false);
                 messagesSink.ReceivedMessages.Should().Equal(messages);
             }
         }

--- a/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_delayed_exchange_with_publish_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_delayed_exchange_with_publish_confirms.cs
@@ -31,7 +31,7 @@ namespace EasyNetQ.IntegrationTests.Scheduler
         [Fact]
         public async Task Test()
         {
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
             var subscriptionId = Guid.NewGuid().ToString();
             var messagesSink = new MessagesSink(MessagesCount);
@@ -39,10 +39,10 @@ namespace EasyNetQ.IntegrationTests.Scheduler
 
             using (bus.Subscribe<Message>(subscriptionId, messagesSink.Receive))
             {
-                await bus.FuturePublishBatchAsync(messages, TimeSpan.FromSeconds(5), timeoutCts.Token)
+                await bus.FuturePublishBatchAsync(messages, TimeSpan.FromSeconds(5), cts.Token)
                     .ConfigureAwait(false);
 
-                await messagesSink.WaitAllReceivedAsync(timeoutCts.Token).ConfigureAwait(false);
+                await messagesSink.WaitAllReceivedAsync(cts.Token).ConfigureAwait(false);
                 messagesSink.ReceivedMessages.Should().Equal(messages);
             }
         }

--- a/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_delayed_exchange_with_publish_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_delayed_exchange_with_publish_confirms.cs
@@ -14,7 +14,7 @@ namespace EasyNetQ.IntegrationTests.Scheduler
         public When_publish_and_subscribe_with_delay_using_delay_exchange_with_publish_confirms(RabbitMQFixture fixture)
         {
             bus = RabbitHutch.CreateBus(
-                $"host={fixture.Host};prefetchCount=1;publisherConfirms=True",
+                $"host={fixture.Host};prefetchCount=1;publisherConfirms=True;timeout=5",
                 c => c.EnableDelayedExchangeScheduler()
             );
         }

--- a/Source/EasyNetQ.IntegrationTests/SendReceive/When_send_receive_with_default_options.cs
+++ b/Source/EasyNetQ.IntegrationTests/SendReceive/When_send_receive_with_default_options.cs
@@ -18,7 +18,7 @@ namespace EasyNetQ.IntegrationTests.SendReceive
         public When_send_receive_with_default_options(RabbitMQFixture rmqFixture)
         {
             this.rmqFixture = rmqFixture;
-            bus = RabbitHutch.CreateBus($"host={rmqFixture.Host};prefetchCount=1");
+            bus = RabbitHutch.CreateBus($"host={rmqFixture.Host};prefetchCount=1;timeout=5");
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.IntegrationTests/SendReceive/When_send_receive_with_default_options.cs
+++ b/Source/EasyNetQ.IntegrationTests/SendReceive/When_send_receive_with_default_options.cs
@@ -27,7 +27,7 @@ namespace EasyNetQ.IntegrationTests.SendReceive
         }
 
         [Fact]
-        public async Task Test()
+        public async Task Should_work_with_default_options()
         {
             using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
@@ -46,7 +46,7 @@ namespace EasyNetQ.IntegrationTests.SendReceive
         [Fact]
         public async Task Should_survive_restart()
         {
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
             var queue = Guid.NewGuid().ToString();
             var messagesSink = new MessagesSink(2);

--- a/Source/EasyNetQ.IntegrationTests/SendReceive/When_send_receive_with_multiple_message_types.cs
+++ b/Source/EasyNetQ.IntegrationTests/SendReceive/When_send_receive_with_multiple_message_types.cs
@@ -16,7 +16,7 @@ namespace EasyNetQ.IntegrationTests.SendReceive
 
         public When_send_receive_multiple_message_types(RabbitMQFixture fixture)
         {
-            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1");
+            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1;timeout=5");
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.IntegrationTests/SendReceive/When_send_receive_with_multiple_message_types.cs
+++ b/Source/EasyNetQ.IntegrationTests/SendReceive/When_send_receive_with_multiple_message_types.cs
@@ -27,7 +27,7 @@ namespace EasyNetQ.IntegrationTests.SendReceive
         [Fact]
         public async Task Test()
         {
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
             var queue = Guid.NewGuid().ToString();
             var bunniesSink = new MessagesSink(MessagesCount);
@@ -41,12 +41,12 @@ namespace EasyNetQ.IntegrationTests.SendReceive
                 )
             )
             {
-                await bus.SendBatchAsync(queue, bunnies, timeoutCts.Token).ConfigureAwait(false);
-                await bus.SendBatchAsync(queue, rabbits, timeoutCts.Token).ConfigureAwait(false);
+                await bus.SendBatchAsync(queue, bunnies, cts.Token).ConfigureAwait(false);
+                await bus.SendBatchAsync(queue, rabbits, cts.Token).ConfigureAwait(false);
 
                 await Task.WhenAll(
-                    bunniesSink.WaitAllReceivedAsync(timeoutCts.Token),
-                    rabbitsSink.WaitAllReceivedAsync(timeoutCts.Token)
+                    bunniesSink.WaitAllReceivedAsync(cts.Token),
+                    rabbitsSink.WaitAllReceivedAsync(cts.Token)
                 ).ConfigureAwait(false);
 
                 bunniesSink.ReceivedMessages.Should().Equal(bunnies);

--- a/Source/EasyNetQ.IntegrationTests/SendReceive/When_send_receive_with_publish_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/SendReceive/When_send_receive_with_publish_confirms.cs
@@ -27,16 +27,16 @@ namespace EasyNetQ.IntegrationTests.SendReceive
         [Fact]
         public async Task Test()
         {
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
             var queue = Guid.NewGuid().ToString();
             var messagesSink = new MessagesSink(MessagesCount);
             var messages = MessagesFactories.Create(MessagesCount);
             using (bus.Receive(queue, x => x.Add<Message>(messagesSink.Receive)))
             {
-                await bus.SendBatchAsync(queue, messages, timeoutCts.Token).ConfigureAwait(false);
+                await bus.SendBatchAsync(queue, messages, cts.Token).ConfigureAwait(false);
 
-                await messagesSink.WaitAllReceivedAsync(timeoutCts.Token).ConfigureAwait(false);
+                await messagesSink.WaitAllReceivedAsync(cts.Token).ConfigureAwait(false);
                 messagesSink.ReceivedMessages.Should().Equal(messages);
             }
         }

--- a/Source/EasyNetQ.IntegrationTests/SendReceive/When_send_receive_with_publish_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/SendReceive/When_send_receive_with_publish_confirms.cs
@@ -16,7 +16,7 @@ namespace EasyNetQ.IntegrationTests.SendReceive
 
         public When_send_receive_with_publish_confirms(RabbitMQFixture fixture)
         {
-            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1;publisherConfirms=True");
+            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1;publisherConfirms=True;timeout=5");
         }
 
         public void Dispose()

--- a/Source/EasyNetQ.IntegrationTests/Utils/ManagementClientExtensions.cs
+++ b/Source/EasyNetQ.IntegrationTests/Utils/ManagementClientExtensions.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+using EasyNetQ.Management.Client;
+
+namespace EasyNetQ.IntegrationTests.Utils
+{
+    public static class ManagementClientExtensions
+    {
+        public static async Task KillAllConnectionsAsync(
+            this IManagementClient client, CancellationToken cancellationToken
+        )
+        {
+            var connections = await client.GetConnectionsAsync(cancellationToken).ConfigureAwait(false);
+            foreach (var connection in connections)
+                await client.CloseConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/Source/EasyNetQ.IntegrationTests/settings.json
+++ b/Source/EasyNetQ.IntegrationTests/settings.json
@@ -1,6 +1,6 @@
 {
     "dockerHttpApiUri": "http://127.0.0.1:2375",
-    "rabbitMQHostName": "rmq",
+    "rabbitMQHostName": "easynetq-rmq",
     "rabbitMQClientPort": 5672,
     "rabbitMQManagementPort": 15672,
     "rabbitMQVirtualHost": "/",

--- a/Source/EasyNetQ.IntegrationTests/settings.json
+++ b/Source/EasyNetQ.IntegrationTests/settings.json
@@ -1,6 +1,6 @@
 {
     "dockerHttpApiUri": "http://127.0.0.1:2375",
-    "rabbitMQHostName": "easynetq-rmq",
+    "rabbitMQHostName": "rmq",
     "rabbitMQClientPort": 5672,
     "rabbitMQManagementPort": 15672,
     "rabbitMQVirtualHost": "/",

--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -127,7 +127,6 @@ namespace EasyNetQ.Consumer
 
         public void HandleModelShutdown(object model, ShutdownEventArgs reason)
         {
-            Cancel();
             logger.InfoFormat(
                 "Consumer with consumerTag {consumerTag} on queue {queue} has shutdown with reason {reason}",
                 ConsumerTag,

--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -127,6 +127,7 @@ namespace EasyNetQ.Consumer
 
         public void HandleModelShutdown(object model, ShutdownEventArgs reason)
         {
+            Cancel();
             logger.InfoFormat(
                 "Consumer with consumerTag {consumerTag} on queue {queue} has shutdown with reason {reason}",
                 ConsumerTag,


### PR DESCRIPTION
https://github.com/EasyNetQ/EasyNetQ/issues/330#issuecomment-632904466

We have an issue with consumers reconnections which was caused by https://github.com/EasyNetQ/EasyNetQ/pull/1021.

If a connection is closed for any reason(it could be closed in management API or even by broker restart) all models will be closed with ModelShutdown as well.

Thanks to @EduardoPires for reporting.

FYI @Rotvig @sungam3r 