### PR TITLE
Fix client name and clean up configuration

### DIFF
--- a/Source/EasyNetQ.Tests/ConnectionConfigurationTests.cs
+++ b/Source/EasyNetQ.Tests/ConnectionConfigurationTests.cs
@@ -14,8 +14,7 @@ namespace EasyNetQ.Tests
         public void The_validate_method_should_apply_AMQPconnection_idempotently()
         {
             var connectionConfiguration = new ConnectionStringParser().Parse("amqp://amqphost:1234/");
-            connectionConfiguration.Validate(); // Simulates additional call to .Validate(); made by some RabbitHutch.CreateBus(...) overloads, in addition to call within ConnectionStringParser.Parse().
-
+            connectionConfiguration.SetDefaultProperties();
             connectionConfiguration.Hosts.Count().Should().Be(1);
             connectionConfiguration.Hosts.Single().Host.Should().Be("amqphost");
             connectionConfiguration.Hosts.Single().Port.Should().Be(1234);
@@ -25,7 +24,7 @@ namespace EasyNetQ.Tests
         public void The_validate_method_should_apply_Default_AmqpsPort_Correctly()
         {
             var connectionConfiguration = new ConnectionStringParser().Parse("amqps://user:pass@host/vhost");
-            connectionConfiguration.Validate();
+            connectionConfiguration.SetDefaultProperties();
 
             connectionConfiguration.Port.Should().Be(5671);
         }
@@ -34,7 +33,7 @@ namespace EasyNetQ.Tests
         public void The_validate_method_should_apply_Default_AmqpPort_Correctly()
         {
             var connectionConfiguration = new ConnectionStringParser().Parse("amqp://user:pass@host/vhost");
-            connectionConfiguration.Validate();
+            connectionConfiguration.SetDefaultProperties();
 
             connectionConfiguration.Port.Should().Be(5672);
         }
@@ -43,7 +42,7 @@ namespace EasyNetQ.Tests
         public void The_validate_method_should_apply_NonDefault_VirtualHost_Correctly()
         {
             var connectionConfiguration = new ConnectionStringParser().Parse("amqp://user:pass@host/vhost");
-            connectionConfiguration.Validate();
+            connectionConfiguration.SetDefaultProperties();
 
             connectionConfiguration.VirtualHost.Should().Be("vhost");
         }
@@ -52,7 +51,7 @@ namespace EasyNetQ.Tests
         public void The_validate_method_should_apply_Default_VirtualHost_Correctly()
         {
             var connectionConfiguration = new ConnectionStringParser().Parse("amqp://user:pass@host/");
-            connectionConfiguration.Validate();
+            connectionConfiguration.SetDefaultProperties();
 
             connectionConfiguration.VirtualHost.Should().Be("/");
         }

--- a/Source/EasyNetQ.Tests/Integration/DefaultConsumerErrorStrategyTests.cs
+++ b/Source/EasyNetQ.Tests/Integration/DefaultConsumerErrorStrategyTests.cs
@@ -29,7 +29,7 @@ namespace EasyNetQ.Tests.Integration
                 Password = "guest"
             };
 
-            configuration.Validate();
+            configuration.SetDefaultProperties();
 
             var typeNameSerializer = new DefaultTypeNameSerializer();
             var errorMessageSerializer = new DefaultErrorMessageSerializer();

--- a/Source/EasyNetQ/ConnectionConfiguration.cs
+++ b/Source/EasyNetQ/ConnectionConfiguration.cs
@@ -7,7 +7,7 @@ namespace EasyNetQ
     /// <summary>
     ///     Contains various settings of a connection and more
     /// </summary>
-    public sealed class ConnectionConfiguration
+    public class ConnectionConfiguration
     {
         /// <summary>
         ///     Default AMQP port
@@ -140,7 +140,7 @@ namespace EasyNetQ
     /// <summary>
     ///     Represents a host configuration
     /// </summary>
-    public sealed class HostConfiguration
+    public class HostConfiguration
     {
         /// <summary>
         ///     Address of the host
@@ -151,7 +151,6 @@ namespace EasyNetQ
         ///     Port of the host
         /// </summary>
         public ushort Port { get; set; }
-
 
         /// <summary>
         ///     TSL configuration of the host

--- a/Source/EasyNetQ/ConnectionConfiguration.cs
+++ b/Source/EasyNetQ/ConnectionConfiguration.cs
@@ -1,20 +1,28 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
 using RabbitMQ.Client;
 
 namespace EasyNetQ
 {
-    public class ConnectionConfiguration
+    /// <summary>
+    ///     Contains various settings of a connection and more
+    /// </summary>
+    public sealed class ConnectionConfiguration
     {
-        private const int DefaultPort = 5672;
-        private const int DefaultAmqpsPort = 5671;
+        /// <summary>
+        ///     Default AMQP port
+        /// </summary>
+        public const int DefaultPort = 5672;
 
+        /// <summary>
+        ///     Default secured AMQP port
+        /// </summary>
+        public const int DefaultAmqpsPort = 5671;
+
+        /// <summary>
+        /// </summary>
         public ConnectionConfiguration()
         {
-            // set default values
             Port = DefaultPort;
             VirtualHost = "/";
             UserName = "guest";
@@ -30,7 +38,7 @@ namespace EasyNetQ
             // set to 50 based on this blog post:
             // http://www.rabbitmq.com/blog/2012/04/25/rabbitmq-performance-measurements-part-2/
             PrefetchCount = 50;
-            AuthMechanisms = new IAuthMechanismFactory[] { new PlainMechanismFactory() };
+            AuthMechanisms = new List<IAuthMechanismFactory> {new PlainMechanismFactory()};
 
             Hosts = new List<HostConfiguration>();
 
@@ -38,131 +46,116 @@ namespace EasyNetQ
             ClientProperties = new Dictionary<string, object>();
         }
 
+        /// <summary>
+        ///     Port used to connect to the broker
+        /// </summary>
         public ushort Port { get; set; }
+
+        /// <summary>
+        ///     Virtual host to connect to
+        /// </summary>
         public string VirtualHost { get; set; }
+
+        /// <summary>
+        ///     UserName used to connect to the broker
+        /// </summary>
         public string UserName { get; set; }
+
+        /// <summary>
+        ///     Password used to connect to the broker
+        /// </summary>
         public string Password { get; set; }
 
         /// <summary>
-        ///     Heartbeat interval. (default is 10)
+        ///     Heartbeat interval (default is 10)
         /// </summary>
         public TimeSpan RequestedHeartbeat { get; set; }
 
+        /// <summary>
+        ///     Prefetch count (default is 50)
+        /// </summary>
         public ushort PrefetchCount { get; set; }
+
+        /// <summary>
+        ///     The connection string used for the connection.
+        /// </summary>
         public Uri AmqpConnectionString { get; set; }
+
+        /// <summary>
+        ///     Client properties to be sent to the broker
+        /// </summary>
         public IDictionary<string, object> ClientProperties { get; }
 
-        public IEnumerable<HostConfiguration> Hosts { get; set; }
+        /// <summary>
+        ///     List of hosts to use for the connection
+        /// </summary>
+        public IList<HostConfiguration> Hosts { get; set; }
+
+        /// <summary>
+        ///     TLS options for the connection.
+        /// </summary>
         public SslOption Ssl { get; }
 
         /// <summary>
-        ///     Operations timeout. (default is 10)
+        ///     Operations timeout (default is 10s)
         /// </summary>
         public TimeSpan Timeout { get; set; }
 
+        /// <summary>
+        ///     Enables publisher confirms (default is false)
+        /// </summary>
         public bool PublisherConfirms { get; set; }
+
+        /// <summary>
+        ///     Enables persistent messages. (default is true)
+        /// </summary>
         public bool PersistentMessages { get; set; }
+
+        /// <summary>
+        ///     Allows to override default product value
+        /// </summary>
         public string Product { get; set; }
+
+        /// <summary>
+        ///     Allows to override default platform value
+        /// </summary>
         public string Platform { get; set; }
+
+        /// <summary>
+        ///     Name to be used for connection
+        /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        ///     Auth mechanisms to use
+        /// </summary>
         public IList<IAuthMechanismFactory> AuthMechanisms { get; set; }
+
+        /// <summary>
+        ///     Interval between reconnection attempts. (default is 5s)
+        /// </summary>
         public TimeSpan ConnectIntervalAttempt { get; set; }
-
-        private void SetDefaultClientProperties(IDictionary<string, object> clientProperties)
-        {
-            string applicationNameAndPath = null;
-#if !NETFX
-            var version = GetType().GetTypeInfo().Assembly.GetName().Version.ToString();
-#else
-            var version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-#endif
-            applicationNameAndPath = Environment.GetCommandLineArgs()[0];
-
-            var applicationName = "unknown";
-            var applicationPath = "unknown";
-            if (!string.IsNullOrWhiteSpace(applicationNameAndPath))
-                try
-                {
-                    // Will only throw an exception if the applicationName contains invalid characters, is empty, or too long
-                    // Silently catch the exception, as we will just leave the application name and path to "unknown"
-                    applicationName = Path.GetFileName(applicationNameAndPath);
-                    applicationPath = Path.GetDirectoryName(applicationNameAndPath);
-                }
-                catch (ArgumentException)
-                {
-                }
-                catch (PathTooLongException)
-                {
-                }
-
-            var hostname = Environment.MachineName;
-
-            var netVersion = Environment.Version.ToString();
-            var product = Product ?? applicationName;
-            var platform = Platform ?? hostname;
-            var name = Name ?? applicationName;
-
-            AddValueIfNotExists(clientProperties, "client_api", "EasyNetQ");
-            AddValueIfNotExists(clientProperties, "product", product);
-            AddValueIfNotExists(clientProperties, "platform", platform);
-            AddValueIfNotExists(clientProperties, "net_version", netVersion);
-            AddValueIfNotExists(clientProperties, "version", version);
-            AddValueIfNotExists(clientProperties, "connection_name", name);
-            AddValueIfNotExists(clientProperties, "easynetq_version", version);
-            AddValueIfNotExists(clientProperties, "application", applicationName);
-            AddValueIfNotExists(clientProperties, "application_location", applicationPath);
-            AddValueIfNotExists(clientProperties, "machine_name", hostname);
-            AddValueIfNotExists(clientProperties, "user", UserName);
-            AddValueIfNotExists(clientProperties, "connected", DateTime.UtcNow.ToString("u")); // UniversalSortableDateTimePattern: yyyy'-'MM'-'dd HH':'mm':'ss'Z'
-            AddValueIfNotExists(clientProperties, "requested_heartbeat", RequestedHeartbeat.ToString());
-            AddValueIfNotExists(clientProperties, "timeout", Timeout.ToString());
-            AddValueIfNotExists(clientProperties, "publisher_confirms", PublisherConfirms.ToString());
-            AddValueIfNotExists(clientProperties, "persistent_messages", PersistentMessages.ToString());
-        }
-
-        private static void AddValueIfNotExists(IDictionary<string, object> clientProperties, string name, string value)
-        {
-            if (!clientProperties.ContainsKey(name))
-                clientProperties.Add(name, value);
-        }
-
-        public void Validate()
-        {
-            if (AmqpConnectionString != null && Hosts.All(h => h.Host != AmqpConnectionString.Host))
-            {
-                if (Port == DefaultPort)
-                {
-                    if (AmqpConnectionString.Port > 0)
-                        Port = (ushort)AmqpConnectionString.Port;
-                    else if (AmqpConnectionString.Scheme.Equals("amqps", StringComparison.OrdinalIgnoreCase))
-                        Port = DefaultAmqpsPort;
-                }
-
-                if (AmqpConnectionString.Segments.Length > 1) VirtualHost = AmqpConnectionString.Segments.Last();
-
-                Hosts = Hosts.Concat(new[] { new HostConfiguration { Host = AmqpConnectionString.Host } });
-            }
-
-            if (!Hosts.Any())
-                throw new EasyNetQException("Invalid connection string. 'host' value must be supplied. e.g: \"host=myserver\"");
-
-            foreach (var hostConfiguration in Hosts)
-                if (hostConfiguration.Port == 0)
-                    hostConfiguration.Port = Port;
-
-            SetDefaultClientProperties(ClientProperties);
-        }
     }
 
-    public class HostConfiguration
+    /// <summary>
+    ///     Represents a host configuration
+    /// </summary>
+    public sealed class HostConfiguration
     {
-        public HostConfiguration()
-        {
-            Ssl = new SslOption();
-        }
-
+        /// <summary>
+        ///     Address of the host
+        /// </summary>
         public string Host { get; set; }
+
+        /// <summary>
+        ///     Port of the host
+        /// </summary>
         public ushort Port { get; set; }
-        public SslOption Ssl { get; }
+
+
+        /// <summary>
+        ///     TSL configuration of the host
+        /// </summary>
+        public SslOption Ssl { get; } = new SslOption();
     }
 }

--- a/Source/EasyNetQ/ConnectionConfiguration.cs
+++ b/Source/EasyNetQ/ConnectionConfiguration.cs
@@ -67,7 +67,7 @@ namespace EasyNetQ
         public string Password { get; set; }
 
         /// <summary>
-        ///     Heartbeat interval (default is 10)
+        ///     Heartbeat interval (default is 10 seconds)
         /// </summary>
         public TimeSpan RequestedHeartbeat { get; set; }
 

--- a/Source/EasyNetQ/ConnectionConfigurationExtensions.cs
+++ b/Source/EasyNetQ/ConnectionConfigurationExtensions.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace EasyNetQ
+{
+    internal static class ConnectionConfigurationExtensions
+    {
+        public static void SetDefaultProperties(this ConnectionConfiguration configuration)
+        {
+            Preconditions.CheckNotNull(configuration, "configuration");
+
+            if (
+                configuration.AmqpConnectionString != null &&
+                configuration.Hosts.All(h => h.Host != configuration.AmqpConnectionString.Host)
+            )
+            {
+                if (configuration.Port == ConnectionConfiguration.DefaultPort)
+                {
+                    if (configuration.AmqpConnectionString.Port > 0)
+                        configuration.Port = (ushort) configuration.AmqpConnectionString.Port;
+                    else if (
+                        configuration.AmqpConnectionString.Scheme.Equals("amqps", StringComparison.OrdinalIgnoreCase)
+                    )
+                        configuration.Port = ConnectionConfiguration.DefaultAmqpsPort;
+                }
+
+                if (configuration.AmqpConnectionString.Segments.Length > 1)
+                    configuration.VirtualHost = configuration.AmqpConnectionString.Segments.Last();
+
+                configuration.Hosts.Add(new HostConfiguration {Host = configuration.AmqpConnectionString.Host});
+            }
+
+            if (configuration.Hosts.Count == 0)
+                throw new EasyNetQException(
+                    "Invalid connection string. 'host' value must be supplied. e.g: \"host=myserver\"");
+
+            foreach (var hostConfiguration in configuration.Hosts)
+                if (hostConfiguration.Port == 0)
+                    hostConfiguration.Port = configuration.Port;
+
+#if !NETFX
+            var version = typeof(ConnectionConfigurationExtensions).GetTypeInfo().Assembly.GetName().Version.ToString();
+#else
+            var version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+#endif
+            var applicationNameAndPath = Environment.GetCommandLineArgs()[0];
+
+            var applicationName = "unknown";
+            var applicationPath = "unknown";
+            if (!string.IsNullOrWhiteSpace(applicationNameAndPath))
+                try
+                {
+                    // Will only throw an exception if the applicationName contains invalid characters, is empty, or too long
+                    // Silently catch the exception, as we will just leave the application name and path to "unknown"
+                    applicationName = Path.GetFileName(applicationNameAndPath);
+                    applicationPath = Path.GetDirectoryName(applicationNameAndPath);
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (PathTooLongException)
+                {
+                }
+
+            var hostname = Environment.MachineName;
+
+            var netVersion = Environment.Version.ToString();
+            configuration.Product ??= applicationName;
+            configuration.Platform ??= hostname;
+            configuration.Name ??= applicationName;
+
+            AddValueIfNotExists(configuration.ClientProperties, "client_api", "EasyNetQ");
+            AddValueIfNotExists(configuration.ClientProperties, "product", configuration.Product);
+            AddValueIfNotExists(configuration.ClientProperties, "platform", configuration.Platform);
+            AddValueIfNotExists(configuration.ClientProperties, "net_version", netVersion);
+            AddValueIfNotExists(configuration.ClientProperties, "version", version);
+            AddValueIfNotExists(configuration.ClientProperties, "easynetq_version", version);
+            AddValueIfNotExists(configuration.ClientProperties, "application", applicationName);
+            AddValueIfNotExists(configuration.ClientProperties, "application_location", applicationPath);
+            AddValueIfNotExists(configuration.ClientProperties, "machine_name", hostname);
+            AddValueIfNotExists(configuration.ClientProperties, "timeout", configuration.Timeout.ToString());
+            AddValueIfNotExists(
+                configuration.ClientProperties, "publisher_confirms", configuration.PublisherConfirms.ToString()
+            );
+            AddValueIfNotExists(
+                configuration.ClientProperties, "persistent_messages", configuration.PersistentMessages.ToString()
+            );
+        }
+
+        private static void AddValueIfNotExists(IDictionary<string, object> clientProperties, string name, string value)
+        {
+            if (!clientProperties.ContainsKey(name))
+                clientProperties.Add(name, value);
+        }
+    }
+}

--- a/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
+++ b/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
@@ -28,7 +28,7 @@ namespace EasyNetQ.ConnectionString
             from port in Parse.Char(':').Then(_ => UShortNumber).Or(Parse.Return((ushort)0))
             select new HostConfiguration { Host = host, Port = port };
 
-        internal static readonly Parser<IEnumerable<HostConfiguration>> Hosts = Host.ListDelimitedBy(',');
+        internal static readonly Parser<IList<HostConfiguration>> Hosts = Host.ListDelimitedBy(',').Select(hosts => hosts.ToList());
 
         internal static readonly Parser<Uri> Amqp = Parse.CharExcept(';').Many().Text().Where(x => Uri.TryCreate(x, UriKind.Absolute, out _)).Select(_ => new Uri(_));
 

--- a/Source/EasyNetQ/ConnectionString/IConnectionStringParser.cs
+++ b/Source/EasyNetQ/ConnectionString/IConnectionStringParser.cs
@@ -3,21 +3,32 @@ using EasyNetQ.Sprache;
 
 namespace EasyNetQ.ConnectionString
 {
+    /// <summary>
+    ///     Allows to create ConnectionConfiguration from string
+    /// </summary>
     public interface IConnectionStringParser
     {
+        /// <summary>
+        ///     Parses a connection string to a ConnectionConfiguration
+        /// </summary>
+        /// <param name="connectionString">The connection string</param>
+        /// <returns>Parsed ConnectionConfiguration</returns>
         ConnectionConfiguration Parse(string connectionString);
     }
 
+    /// <inheritdoc />
     public class ConnectionStringParser : IConnectionStringParser
     {
+        /// <inheritdoc />
         public ConnectionConfiguration Parse(string connectionString)
         {
             try
             {
                 var updater = ConnectionStringGrammar.ParseConnectionString(connectionString);
-                var connectionConfiguration = updater.Aggregate(new ConnectionConfiguration(), (current, updateFunction) => updateFunction(current));
-                connectionConfiguration.Validate();
-                return connectionConfiguration;
+                var configuration = updater.Aggregate(new ConnectionConfiguration(),
+                    (current, updateFunction) => updateFunction(current));
+                configuration.SetDefaultProperties();
+                return configuration;
             }
             catch (ParseException parseException)
             {

--- a/Source/EasyNetQ/DI/ConnectionFactoryFactory.cs
+++ b/Source/EasyNetQ/DI/ConnectionFactoryFactory.cs
@@ -2,36 +2,29 @@
 
 namespace EasyNetQ.DI
 {
-    public static class ConnectionFactoryFactory
+    internal static class ConnectionFactoryFactory
     {
-        public static IConnectionFactory CreateConnectionFactory(ConnectionConfiguration connectionConfiguration)
+        public static IConnectionFactory CreateConnectionFactory(ConnectionConfiguration configuration)
         {
-            Preconditions.CheckNotNull(connectionConfiguration, "connectionConfiguration");
+            Preconditions.CheckNotNull(configuration, "configuration");
 
             var connectionFactory = new ConnectionFactory
             {
                 AutomaticRecoveryEnabled = true,
-                TopologyRecoveryEnabled = false
+                TopologyRecoveryEnabled = false,
+                VirtualHost = configuration.VirtualHost,
+                UserName = configuration.UserName,
+                Password = configuration.Password,
+                Port = configuration.Port,
+                RequestedHeartbeat = configuration.RequestedHeartbeat,
+                ClientProperties = configuration.ClientProperties,
+                AuthMechanisms = configuration.AuthMechanisms,
+                ClientProvidedName = configuration.Name,
+                NetworkRecoveryInterval = configuration.ConnectIntervalAttempt
             };
 
-            if (connectionConfiguration.AmqpConnectionString != null)
-                connectionFactory.Uri = connectionConfiguration.AmqpConnectionString;
-
-            if (connectionFactory.VirtualHost == "/")
-                connectionFactory.VirtualHost = connectionConfiguration.VirtualHost;
-
-            if (connectionFactory.UserName == "guest")
-                connectionFactory.UserName = connectionConfiguration.UserName;
-
-            if (connectionFactory.Password == "guest")
-                connectionFactory.Password = connectionConfiguration.Password;
-
-            if (connectionFactory.Port == -1)
-                connectionFactory.Port = connectionConfiguration.Port;
-
-            connectionFactory.RequestedHeartbeat = connectionConfiguration.RequestedHeartbeat;
-            connectionFactory.ClientProperties = connectionConfiguration.ClientProperties;
-            connectionFactory.AuthMechanisms = connectionConfiguration.AuthMechanisms;
+            if (configuration.AmqpConnectionString != null)
+                connectionFactory.Uri = configuration.AmqpConnectionString;
 
             return connectionFactory;
         }

--- a/Source/EasyNetQ/DI/ConnectionFactoryFactory.cs
+++ b/Source/EasyNetQ/DI/ConnectionFactoryFactory.cs
@@ -20,7 +20,8 @@ namespace EasyNetQ.DI
                 ClientProperties = configuration.ClientProperties,
                 AuthMechanisms = configuration.AuthMechanisms,
                 ClientProvidedName = configuration.Name,
-                NetworkRecoveryInterval = configuration.ConnectIntervalAttempt
+                NetworkRecoveryInterval = configuration.ConnectIntervalAttempt,
+                ContinuationTimeout = configuration.Timeout
             };
 
             if (configuration.AmqpConnectionString != null)

--- a/Source/EasyNetQ/RabbitHutch.cs
+++ b/Source/EasyNetQ/RabbitHutch.cs
@@ -212,9 +212,9 @@ namespace EasyNetQ
 
             serviceRegister.Register(c =>
             {
-                var connectionConfiguration = connectionConfigurationFactory.Invoke(c);
-                connectionConfiguration.Validate();
-                return connectionConfiguration;
+                var configuration = connectionConfigurationFactory.Invoke(c);
+                configuration.SetDefaultProperties();
+                return configuration;
             });
 
             serviceRegister.RegisterDefaultServices();

--- a/Source/EasyNetQ/RabbitHutch.cs
+++ b/Source/EasyNetQ/RabbitHutch.cs
@@ -212,7 +212,7 @@ namespace EasyNetQ
 
             serviceRegister.Register(c =>
             {
-                var configuration = connectionConfigurationFactory.Invoke(c);
+                var configuration = connectionConfigurationFactory(c);
                 configuration.SetDefaultProperties();
                 return configuration;
             });

--- a/Source/EasyNetQ/ServiceRegisterExtensions.cs
+++ b/Source/EasyNetQ/ServiceRegisterExtensions.cs
@@ -52,8 +52,9 @@ namespace EasyNetQ
                 .Register<IClientCommandDispatcher, SingleChannelClientCommandDispatcher>()
                 .Register<IPersistentConnection>(c =>
                 {
-                    var connection = new PersistentConnection(c.Resolve<ConnectionConfiguration>(),
-                        c.Resolve<IConnectionFactory>(), c.Resolve<IEventBus>());
+                    var connection = new PersistentConnection(
+                        c.Resolve<ConnectionConfiguration>(), c.Resolve<IConnectionFactory>(), c.Resolve<IEventBus>()
+                    );
                     connection.Initialize();
                     return connection;
                 })


### PR DESCRIPTION
Fixes #986

It seems that:
1. ContinuationTimeout should be set to Timeout
1. NetworkRecoveryInterval should be set to ConnectIntervalAttempt

Also, PR removes properties which are shown by default in management plugin UI:
1. version
1. connected
1. user
1. requested_hearbeat

In addition, XML docs are added.