### PR TITLE
Issue 1068: Move logging from HandlerRunner to DefaultConsumerErrorStrategy

### DIFF
--- a/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
+++ b/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
@@ -71,6 +71,14 @@ namespace EasyNetQ.Consumer
 
                 return AckStrategies.NackWithRequeue;
             }
+
+            logger.Error(
+                exception,
+                "Exception thrown by subscription callback, receivedInfo={receivedInfo}, properties={properties}, message={message}",
+                context.Info,
+                context.Properties,
+                Convert.ToBase64String(context.Body)
+            );
 
             try
             {

--- a/Source/EasyNetQ/Consumer/HandlerRunner.cs
+++ b/Source/EasyNetQ/Consumer/HandlerRunner.cs
@@ -1,4 +1,4 @@
-﻿using EasyNetQ.Events;
+using EasyNetQ.Events;
 using EasyNetQ.Logging;
 using RabbitMQ.Client.Exceptions;
 using System;
@@ -85,13 +85,6 @@ namespace EasyNetQ.Consumer
                 }
                 catch (Exception exception)
                 {
-                    logger.Error(
-                        exception,
-                        "Exception thrown by subscription callback, receivedInfo={receivedInfo}, properties={properties}, message={message}",
-                        context.Info,
-                        context.Properties,
-                        Convert.ToBase64String(context.Body)
-                    );
                     return consumerErrorStrategy.HandleConsumerError(context, exception);
                 }
             }


### PR DESCRIPTION
As discussed [here](https://github.com/EasyNetQ/EasyNetQ/issues/1068). I haven't found any tests covering logging so didn't change anything.