### PR TITLE
Extract IPubSub, IRpc, ISendReceive, IScheduler to root namespace

### DIFF
--- a/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_dead_letter_exchange.cs
+++ b/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_dead_letter_exchange.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.IntegrationTests.Utils;
-using EasyNetQ.Scheduling;
 using FluentAssertions;
 using Xunit;
 

--- a/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_dead_letter_exchange_with_publish_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_dead_letter_exchange_with_publish_confirms.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.IntegrationTests.Utils;
-using EasyNetQ.Scheduling;
 using FluentAssertions;
 using Xunit;
 

--- a/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_delayed_exchange.cs
+++ b/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_delayed_exchange.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.IntegrationTests.Utils;
-using EasyNetQ.Scheduling;
 using FluentAssertions;
 using Xunit;
 

--- a/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_delayed_exchange_with_publish_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_delayed_exchange_with_publish_confirms.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.IntegrationTests.Utils;
-using EasyNetQ.Scheduling;
 using FluentAssertions;
 using Xunit;
 

--- a/Source/EasyNetQ.IntegrationTests/Utils/BusExtensions.cs
+++ b/Source/EasyNetQ.IntegrationTests/Utils/BusExtensions.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using EasyNetQ.Scheduling;
 
 namespace EasyNetQ.IntegrationTests.Utils
 {

--- a/Source/EasyNetQ.IntegrationTests/Utils/BusExtensions.cs
+++ b/Source/EasyNetQ.IntegrationTests/Utils/BusExtensions.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using EasyNetQ.FluentConfiguration;
-using EasyNetQ.Producer;
 using EasyNetQ.Scheduling;
 
 namespace EasyNetQ.IntegrationTests.Utils

--- a/Source/EasyNetQ.Tests.Tasks/Tasks/TestScheduledMessages.cs
+++ b/Source/EasyNetQ.Tests.Tasks/Tasks/TestScheduledMessages.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using EasyNetQ.Producer;
-using EasyNetQ.Scheduling;
 using Net.CommandLine;
 using Serilog;
 

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async_with_subscription_configuration.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async_with_subscription_configuration.cs
@@ -1,8 +1,6 @@
 ﻿// ReSharper disable InconsistentNaming
 using EasyNetQ.AutoSubscribe;
-using EasyNetQ.FluentConfiguration;
 using EasyNetQ.Internals;
-using EasyNetQ.Producer;
 using FluentAssertions;
 using NSubstitute;
 using System;

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async_with_subscription_configuration_action.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async_with_subscription_configuration_action.cs
@@ -1,8 +1,6 @@
 ﻿// ReSharper disable InconsistentNaming
 using EasyNetQ.AutoSubscribe;
-using EasyNetQ.FluentConfiguration;
 using EasyNetQ.Internals;
-using EasyNetQ.Producer;
 using FluentAssertions;
 using NSubstitute;
 using System;

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async_with_subscription_configuration_action_and_attribute.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async_with_subscription_configuration_action_and_attribute.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.AutoSubscribe;
-using EasyNetQ.FluentConfiguration;
 using EasyNetQ.Internals;
-using EasyNetQ.Producer;
 using FluentAssertions;
 using NSubstitute;
 using Xunit;

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_subscription_configuration.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_subscription_configuration.cs
@@ -1,8 +1,6 @@
 ﻿// ReSharper disable InconsistentNaming
 using EasyNetQ.AutoSubscribe;
-using EasyNetQ.FluentConfiguration;
 using EasyNetQ.Internals;
-using EasyNetQ.Producer;
 using FluentAssertions;
 using NSubstitute;
 using System;

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_subscription_configuration_action.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_subscription_configuration_action.cs
@@ -1,8 +1,6 @@
 ﻿// ReSharper disable InconsistentNaming
 using EasyNetQ.AutoSubscribe;
-using EasyNetQ.FluentConfiguration;
 using EasyNetQ.Internals;
-using EasyNetQ.Producer;
 using FluentAssertions;
 using NSubstitute;
 using System;

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_subscription_configuration_action_and_attribute.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_subscription_configuration_action_and_attribute.cs
@@ -1,8 +1,6 @@
 ﻿// ReSharper disable InconsistentNaming
 using EasyNetQ.AutoSubscribe;
-using EasyNetQ.FluentConfiguration;
 using EasyNetQ.Internals;
-using EasyNetQ.Producer;
 using FluentAssertions;
 using NSubstitute;
 using System;

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_subscription_configuration_attribute_no_expires.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_subscription_configuration_attribute_no_expires.cs
@@ -1,7 +1,5 @@
 using EasyNetQ.AutoSubscribe;
-using EasyNetQ.FluentConfiguration;
 using EasyNetQ.Internals;
-using EasyNetQ.Producer;
 using FluentAssertions;
 using NSubstitute;
 using System;

--- a/Source/EasyNetQ.Tests/FluentConfiguration/PublishConfigurationTests.cs
+++ b/Source/EasyNetQ.Tests/FluentConfiguration/PublishConfigurationTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using EasyNetQ.FluentConfiguration;
 using Xunit;
 
 namespace EasyNetQ.Tests.FluentConfiguration

--- a/Source/EasyNetQ.Tests/FluentConfiguration/SubscriptionConfigurationTests.cs
+++ b/Source/EasyNetQ.Tests/FluentConfiguration/SubscriptionConfigurationTests.cs
@@ -1,5 +1,4 @@
-﻿using EasyNetQ.FluentConfiguration;
-using Xunit;
+﻿using Xunit;
 
 namespace EasyNetQ.Tests.FluentConfiguration
 {

--- a/Source/EasyNetQ.Tests/Mocking/MockBuilder.cs
+++ b/Source/EasyNetQ.Tests/Mocking/MockBuilder.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using EasyNetQ.DI;
 using EasyNetQ.Producer;
-using EasyNetQ.Scheduling;
 using FluentAssertions;
 using NSubstitute;
 using RabbitMQ.Client;

--- a/Source/EasyNetQ.Tests/Scheduling/SchedulingExtensionsTests.cs
+++ b/Source/EasyNetQ.Tests/Scheduling/SchedulingExtensionsTests.cs
@@ -1,7 +1,6 @@
 // ReSharper disable InconsistentNaming
 
 using EasyNetQ.DI;
-using EasyNetQ.Scheduling;
 using NSubstitute;
 using Xunit;
 

--- a/Source/EasyNetQ/AutoSubscribe/AutoSubscriber.cs
+++ b/Source/EasyNetQ/AutoSubscribe/AutoSubscriber.cs
@@ -1,5 +1,4 @@
-﻿using EasyNetQ.FluentConfiguration;
-using EasyNetQ.Internals;
+﻿using EasyNetQ.Internals;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
+++ b/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
@@ -10,7 +10,7 @@ namespace EasyNetQ.ConnectionString
 {
     using UpdateConfiguration = Func<ConnectionConfiguration, ConnectionConfiguration>;
 
-    public static class ConnectionStringGrammar
+    internal static class ConnectionStringGrammar
     {
         internal static readonly Parser<string> Text = Parse.CharExcept(';').Many().Text();
         internal static readonly Parser<ushort> UShortNumber = Parse.Number.Select(ushort.Parse);

--- a/Source/EasyNetQ/DeadLetterExchangeAndMessageTtlScheduler.cs
+++ b/Source/EasyNetQ/DeadLetterExchangeAndMessageTtlScheduler.cs
@@ -5,8 +5,11 @@ using EasyNetQ.Internals;
 using EasyNetQ.Producer;
 using EasyNetQ.Topology;
 
-namespace EasyNetQ.Scheduling
+namespace EasyNetQ
 {
+    /// <summary>
+    ///     Scheduler based on DLE and Message TTL
+    /// </summary>
     public class DeadLetterExchangeAndMessageTtlScheduler : IScheduler
     {
         private readonly ConnectionConfiguration configuration;
@@ -15,6 +18,14 @@ namespace EasyNetQ.Scheduling
         private readonly IExchangeDeclareStrategy exchangeDeclareStrategy;
         private readonly IMessageDeliveryModeStrategy messageDeliveryModeStrategy;
 
+        /// <summary>
+        ///     Creates DeadLetterExchangeAndMessageTtlScheduler
+        /// </summary>
+        /// <param name="configuration">The configuration</param>
+        /// <param name="advancedBus">The advanced bus</param>
+        /// <param name="conventions">The conventions</param>
+        /// <param name="messageDeliveryModeStrategy">The message delivery mode strategy</param>
+        /// <param name="exchangeDeclareStrategy">The exchange declare strategy</param>
         public DeadLetterExchangeAndMessageTtlScheduler(
             ConnectionConfiguration configuration,
             IAdvancedBus advancedBus,

--- a/Source/EasyNetQ/DefaultPubSub.cs
+++ b/Source/EasyNetQ/DefaultPubSub.cs
@@ -2,12 +2,13 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using EasyNetQ.FluentConfiguration;
 using EasyNetQ.Internals;
+using EasyNetQ.Producer;
 using EasyNetQ.Topology;
 
-namespace EasyNetQ.Producer
+namespace EasyNetQ
 {
+    /// <inheritdoc />
     public class DefaultPubSub : IPubSub
     {
         private readonly IAdvancedBus advancedBus;
@@ -16,6 +17,14 @@ namespace EasyNetQ.Producer
         private readonly IMessageDeliveryModeStrategy messageDeliveryModeStrategy;
         private readonly IExchangeDeclareStrategy exchangeDeclareStrategy;
 
+        /// <summary>
+        ///     Creates DefaultPubSub
+        /// </summary>
+        /// <param name="configuration">The configuration</param>
+        /// <param name="conventions">The conventions</param>
+        /// <param name="exchangeDeclareStrategy">The exchange declare strategy</param>
+        /// <param name="messageDeliveryModeStrategy">The message delivery mode strategy</param>
+        /// <param name="advancedBus">The advanced bus</param>
         public DefaultPubSub(
             ConnectionConfiguration configuration,
             IConventions conventions,

--- a/Source/EasyNetQ/DefaultRpc.cs
+++ b/Source/EasyNetQ/DefaultRpc.cs
@@ -5,11 +5,11 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.Events;
-using EasyNetQ.FluentConfiguration;
 using EasyNetQ.Internals;
+using EasyNetQ.Producer;
 using EasyNetQ.Topology;
 
-namespace EasyNetQ.Producer
+namespace EasyNetQ
 {
     /// <summary>
     ///     Default implementation of EasyNetQ's request-response pattern

--- a/Source/EasyNetQ/DefaultSendReceive.cs
+++ b/Source/EasyNetQ/DefaultSendReceive.cs
@@ -6,7 +6,7 @@ using EasyNetQ.Consumer;
 using EasyNetQ.Internals;
 using EasyNetQ.Topology;
 
-namespace EasyNetQ.Producer
+namespace EasyNetQ
 {
     /// <summary>
     ///     Default implementation of EasyNetQ's send-receive pattern
@@ -20,6 +20,12 @@ namespace EasyNetQ.Producer
         private readonly IAdvancedBus advancedBus;
         private readonly IMessageDeliveryModeStrategy messageDeliveryModeStrategy;
 
+        /// <summary>
+        ///     Creates DefaultSendReceive
+        /// </summary>
+        /// <param name="configuration">The configuration</param>
+        /// <param name="advancedBus">The advanced bus</param>
+        /// <param name="messageDeliveryModeStrategy">The message delivery mode strategy</param>
         public DefaultSendReceive(
             ConnectionConfiguration configuration,
             IAdvancedBus advancedBus,

--- a/Source/EasyNetQ/DelayedExchangeExtensions.cs
+++ b/Source/EasyNetQ/DelayedExchangeExtensions.cs
@@ -3,14 +3,31 @@ using EasyNetQ.Topology;
 
 namespace EasyNetQ
 {
+    /// <summary>
+    ///     Extensions related to using delayed exchange
+    /// </summary>
     public static class DelayedExchangeExtensions
     {
-        public static IExchangeDeclareConfiguration AsDelayedExchange(this IExchangeDeclareConfiguration configuration, string exchangeType = ExchangeType.Fanout)
+        /// <summary>
+        ///     Marks an exchange as delayed
+        /// </summary>
+        /// <param name="configuration">The configuration</param>
+        /// <param name="exchangeType">The exchange type</param>
+        public static IExchangeDeclareConfiguration AsDelayedExchange(
+            this IExchangeDeclareConfiguration configuration, string exchangeType = ExchangeType.Fanout
+        )
         {
+            Preconditions.CheckNotNull(configuration, "configuration");
+
             return configuration.WithType("x-delayed-message")
                 .WithArgument("x-delayed-type", exchangeType);
         }
 
+        /// <summary>
+        ///     Add the delay to the message to be used by delayed exchange
+        /// </summary>
+        /// <param name="message">The message</param>
+        /// <param name="delay">The delay</param>
         public static IMessage<T> WithDelay<T>(this IMessage<T> message, TimeSpan delay)
         {
             Preconditions.CheckNotNull(message, "message");

--- a/Source/EasyNetQ/DelayedExchangeScheduler.cs
+++ b/Source/EasyNetQ/DelayedExchangeScheduler.cs
@@ -4,8 +4,11 @@ using System.Threading.Tasks;
 using EasyNetQ.Internals;
 using EasyNetQ.Topology;
 
-namespace EasyNetQ.Scheduling
+namespace EasyNetQ
 {
+    /// <summary>
+    ///     Scheduler based on delayed exchange
+    /// </summary>
     public class DelayedExchangeScheduler : IScheduler
     {
         private readonly ConnectionConfiguration configuration;
@@ -13,6 +16,13 @@ namespace EasyNetQ.Scheduling
         private readonly IConventions conventions;
         private readonly IMessageDeliveryModeStrategy messageDeliveryModeStrategy;
 
+        /// <summary>
+        ///     Creates DelayedExchangeScheduler
+        /// </summary>
+        /// <param name="configuration">The configuration</param>
+        /// <param name="advancedBus">The advanced bus</param>
+        /// <param name="conventions">The conventions</param>
+        /// <param name="messageDeliveryModeStrategy">The message delivery mode strategy</param>
         public DelayedExchangeScheduler(
             ConnectionConfiguration configuration,
             IAdvancedBus advancedBus,

--- a/Source/EasyNetQ/ExchangeDeclareConfiguration.cs
+++ b/Source/EasyNetQ/ExchangeDeclareConfiguration.cs
@@ -2,6 +2,12 @@ using System.Collections.Generic;
 
 namespace EasyNetQ
 {
+    /// <summary>
+    /// Allows exchange configuration to be fluently extended without adding overloads
+    ///
+    /// e.g.
+    /// x => x.AsDurable(true)
+    /// </summary>
     public interface IExchangeDeclareConfiguration
     {
         /// <summary>
@@ -34,7 +40,7 @@ namespace EasyNetQ
         IExchangeDeclareConfiguration WithArgument(string name, object value);
     }
 
-    public sealed class ExchangeDeclareConfiguration : IExchangeDeclareConfiguration
+    internal class ExchangeDeclareConfiguration : IExchangeDeclareConfiguration
     {
         public bool IsDurable { get; private set; } = true;
 

--- a/Source/EasyNetQ/ExchangeDeclareConfigurationExtensions.cs
+++ b/Source/EasyNetQ/ExchangeDeclareConfigurationExtensions.cs
@@ -2,6 +2,9 @@ using EasyNetQ.Topology;
 
 namespace EasyNetQ
 {
+    /// <summary>
+    ///     Various extensions for IExchangeDeclareConfiguration
+    /// </summary>
     public static class ExchangeDeclareConfigurationExtensions
     {
         /// <summary>

--- a/Source/EasyNetQ/ExternalScheduler.cs
+++ b/Source/EasyNetQ/ExternalScheduler.cs
@@ -6,8 +6,11 @@ using EasyNetQ.Producer;
 using EasyNetQ.SystemMessages;
 using EasyNetQ.Topology;
 
-namespace EasyNetQ.Scheduling
+namespace EasyNetQ
 {
+    /// <summary>
+    ///     Scheduler based on external scheduler service
+    /// </summary>
     public class ExternalScheduler : IScheduler
     {
         private readonly ConnectionConfiguration configuration;
@@ -17,6 +20,15 @@ namespace EasyNetQ.Scheduling
         private readonly IExchangeDeclareStrategy exchangeDeclareStrategy;
         private readonly IMessageSerializationStrategy messageSerializationStrategy;
 
+        /// <summary>
+        ///     Creates ExternalScheduler
+        /// </summary>
+        /// <param name="configuration">The configuration</param>
+        /// <param name="advancedBus">The advanced bus</param>
+        /// <param name="conventions">The conventions</param>
+        /// <param name="exchangeDeclareStrategy">The exchange declare strategy</param>
+        /// <param name="messageDeliveryModeStrategy">The message delivery mode strategy</param>
+        /// <param name="messageSerializationStrategy">The message serialization strategy</param>
         public ExternalScheduler(
             ConnectionConfiguration configuration,
             IAdvancedBus advancedBus,
@@ -41,7 +53,7 @@ namespace EasyNetQ.Scheduling
             this.messageSerializationStrategy = messageSerializationStrategy;
         }
 
-        /// <inheritdoc />s
+        /// <inheritdoc />
         public async Task FuturePublishAsync<T>(T message, TimeSpan delay, string topic, CancellationToken cancellationToken = default)
         {
             Preconditions.CheckNotNull(message, "message");

--- a/Source/EasyNetQ/FluentConfiguration/IRequestConfiguration.cs
+++ b/Source/EasyNetQ/FluentConfiguration/IRequestConfiguration.cs
@@ -3,7 +3,7 @@
 namespace EasyNetQ.FluentConfiguration
 {
     /// <summary>
-    /// Allows request configuration to be fluently extended without adding overloads to IBus
+    /// Allows request configuration to be fluently extended without adding overloads
     ///
     /// e.g.
     /// x => x.WithQueueName("MyQueue")

--- a/Source/EasyNetQ/IBus.cs
+++ b/Source/EasyNetQ/IBus.cs
@@ -1,5 +1,4 @@
 using System;
-using EasyNetQ.Producer;
 using EasyNetQ.Scheduling;
 
 namespace EasyNetQ

--- a/Source/EasyNetQ/IBus.cs
+++ b/Source/EasyNetQ/IBus.cs
@@ -1,5 +1,4 @@
 using System;
-using EasyNetQ.Scheduling;
 
 namespace EasyNetQ
 {

--- a/Source/EasyNetQ/ICorrelationIdGenerationStrategy.cs
+++ b/Source/EasyNetQ/ICorrelationIdGenerationStrategy.cs
@@ -1,7 +1,7 @@
 ﻿namespace EasyNetQ
 {
     /// <summary>
-    ///     A strategy of generation of correlation identifier
+    ///     A strategy of generation a correlation identifier
     /// </summary>
     public interface ICorrelationIdGenerationStrategy
     {

--- a/Source/EasyNetQ/IPubSub.cs
+++ b/Source/EasyNetQ/IPubSub.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using EasyNetQ.FluentConfiguration;
 using EasyNetQ.Internals;
 
-namespace EasyNetQ.Producer
+namespace EasyNetQ
 {
-    //TODO Need support of non-generic overloads
+    /// <summary>
+    ///     An abstraction for pub-sub pattern
+    /// </summary>
     public interface IPubSub
     {
         /// <summary>

--- a/Source/EasyNetQ/IReceiveRegistration.cs
+++ b/Source/EasyNetQ/IReceiveRegistration.cs
@@ -2,8 +2,11 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace EasyNetQ.Producer
+namespace EasyNetQ
 {
+    /// <summary>
+    ///     Allow to add multiple asynchronous message handlers
+    /// </summary>
     public interface IReceiveRegistration
     {
         /// <summary>

--- a/Source/EasyNetQ/IRpc.cs
+++ b/Source/EasyNetQ/IRpc.cs
@@ -1,15 +1,13 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using EasyNetQ.FluentConfiguration;
 using EasyNetQ.Internals;
 
-namespace EasyNetQ.Producer
+namespace EasyNetQ
 {
     /// <summary>
     ///     An RPC style request-response pattern
     /// </summary>
-    //TODO Need support of non-generic overloads
     public interface IRpc : IDisposable
     {
         /// <summary>

--- a/Source/EasyNetQ/IScheduler.cs
+++ b/Source/EasyNetQ/IScheduler.cs
@@ -2,12 +2,11 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace EasyNetQ.Scheduling
+namespace EasyNetQ
 {
     /// <summary>
     /// Provides a simple Publish API to schedule a message to be published at some time in the future.
     /// </summary>
-    //TODO Need support of non-generic overloads
     public interface IScheduler
     {
         /// <summary>

--- a/Source/EasyNetQ/ISendReceive.cs
+++ b/Source/EasyNetQ/ISendReceive.cs
@@ -4,12 +4,11 @@ using System.Threading.Tasks;
 using EasyNetQ.Consumer;
 using EasyNetQ.Internals;
 
-namespace EasyNetQ.Producer
+namespace EasyNetQ
 {
     /// <summary>
     ///     An abstraction for send-receive pattern
     /// </summary>
-    //TODO Need support of non-generic overloads
     public interface ISendReceive
     {
         /// <summary>

--- a/Source/EasyNetQ/PubSubExtensions.cs
+++ b/Source/EasyNetQ/PubSubExtensions.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using EasyNetQ.FluentConfiguration;
 using EasyNetQ.Internals;
-using EasyNetQ.Producer;
 
 namespace EasyNetQ
 {
+    /// <summary>
+    ///     Various extensions for IPubSub
+    /// </summary>
     public static class PubSubExtensions
     {
         /// <summary>

--- a/Source/EasyNetQ/PublishConfiguration.cs
+++ b/Source/EasyNetQ/PublishConfiguration.cs
@@ -1,7 +1,7 @@
-﻿namespace EasyNetQ.FluentConfiguration
+﻿namespace EasyNetQ
 {
     /// <summary>
-    /// Allows publish configuration to be fluently extended without adding overloads to IBus
+    /// Allows publish configuration to be fluently extended without adding overloads
     ///
     /// e.g.
     /// x => x.WithTopic("*.brighton").WithPriority(2)
@@ -30,7 +30,7 @@
         IPublishConfiguration WithExpires(int expires);
     }
 
-    public class PublishConfiguration : IPublishConfiguration
+    internal class PublishConfiguration : IPublishConfiguration
     {
         public PublishConfiguration(string defaultTopic)
         {

--- a/Source/EasyNetQ/QueueDeclareConfiguration.cs
+++ b/Source/EasyNetQ/QueueDeclareConfiguration.cs
@@ -40,7 +40,7 @@ namespace EasyNetQ
         IQueueDeclareConfiguration WithArgument(string name, object value);
     }
 
-    public sealed class QueueDeclareConfiguration : IQueueDeclareConfiguration
+    internal class QueueDeclareConfiguration : IQueueDeclareConfiguration
     {
         public bool IsDurable { get; private set; } = true;
         public bool IsExclusive { get; private set; }

--- a/Source/EasyNetQ/QueueDeclareConfigurationExtensions.cs
+++ b/Source/EasyNetQ/QueueDeclareConfigurationExtensions.cs
@@ -3,6 +3,9 @@ using EasyNetQ.Topology;
 
 namespace EasyNetQ
 {
+    /// <summary>
+    ///     Various extensions for IQueueDeclareConfiguration
+    /// </summary>
     public static class QueueDeclareConfigurationExtensions
     {
         /// <summary>

--- a/Source/EasyNetQ/RabbitBus.cs
+++ b/Source/EasyNetQ/RabbitBus.cs
@@ -1,4 +1,3 @@
-using EasyNetQ.Producer;
 using EasyNetQ.Scheduling;
 
 namespace EasyNetQ

--- a/Source/EasyNetQ/RabbitBus.cs
+++ b/Source/EasyNetQ/RabbitBus.cs
@@ -1,5 +1,3 @@
-using EasyNetQ.Scheduling;
-
 namespace EasyNetQ
 {
     public class RabbitBus : IBus

--- a/Source/EasyNetQ/ReceiveRegistrationExtensions.cs
+++ b/Source/EasyNetQ/ReceiveRegistrationExtensions.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Threading.Tasks;
 using EasyNetQ.Internals;
-using EasyNetQ.Producer;
 
 namespace EasyNetQ
 {
+    /// <summary>
+    ///     Various extensions for IReceiveRegistration
+    /// </summary>
     public static class ReceiveRegistrationExtensions
     {
         /// <summary>

--- a/Source/EasyNetQ/RequestConfiguration.cs
+++ b/Source/EasyNetQ/RequestConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace EasyNetQ.FluentConfiguration
+namespace EasyNetQ
 {
     /// <summary>
     /// Allows request configuration to be fluently extended without adding overloads
@@ -25,8 +25,7 @@ namespace EasyNetQ.FluentConfiguration
         IRequestConfiguration WithQueueName(string queueName);
     }
 
-    /// <inheritdoc />
-    public class RequestConfiguration : IRequestConfiguration
+    internal class RequestConfiguration : IRequestConfiguration
     {
         public RequestConfiguration(string queueName, TimeSpan expiration)
         {
@@ -37,14 +36,12 @@ namespace EasyNetQ.FluentConfiguration
         public string QueueName { get; private set; }
         public TimeSpan Expiration { get; private set; }
 
-        /// <inheritdoc />
         public IRequestConfiguration WithExpiration(TimeSpan expiration)
         {
             Expiration = expiration;
             return this;
         }
 
-        /// <inheritdoc />
         public IRequestConfiguration WithQueueName(string queueName)
         {
             QueueName = queueName;

--- a/Source/EasyNetQ/ResponderConfiguration.cs
+++ b/Source/EasyNetQ/ResponderConfiguration.cs
@@ -1,7 +1,7 @@
-﻿namespace EasyNetQ.Producer
+﻿namespace EasyNetQ
 {
     /// <summary>
-    /// Allows configuration to be fluently extended without adding overloads to IBus
+    /// Allows configuration to be fluently extended without adding overloads
     ///
     /// e.g.
     /// x => x.WithPrefetchCount(50)
@@ -42,7 +42,7 @@
         IResponderConfiguration WithExpires(int expires);
     }
 
-    public class ResponderConfiguration : IResponderConfiguration
+    internal class ResponderConfiguration : IResponderConfiguration
     {
         public ResponderConfiguration(ushort defaultPrefetchCount)
         {
@@ -50,17 +50,8 @@
         }
 
         public ushort PrefetchCount { get; private set; }
-
         public string QueueName { get; private set; }
-
-        /// <summary>
-        /// Durable queues remain active when a server restarts.
-        /// </summary>
         public bool Durable { get; private set; } = true;
-
-        /// <summary>
-        /// Determines how long (in milliseconds) a queue can remain unused before it is automatically deleted by the server.
-        /// </summary>
         public int? Expires { get; private set; }
 
         public IResponderConfiguration WithPrefetchCount(ushort prefetchCount)

--- a/Source/EasyNetQ/RpcExtensions.cs
+++ b/Source/EasyNetQ/RpcExtensions.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using EasyNetQ.FluentConfiguration;
 using EasyNetQ.Internals;
-using EasyNetQ.Producer;
 
 namespace EasyNetQ
 {
+    /// <summary>
+    ///     Various extensions for IRpc
+    /// </summary>
     public static class RpcExtensions
     {
         /// <summary>

--- a/Source/EasyNetQ/SchedulerExtensions.cs
+++ b/Source/EasyNetQ/SchedulerExtensions.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using EasyNetQ.Scheduling;
 
 namespace EasyNetQ
 {
+    /// <summary>
+    ///     Various extensions for IScheduler
+    /// </summary>
     public static class SchedulerExtensions
     {
         /// <summary>

--- a/Source/EasyNetQ/SendReceiveExtensions.cs
+++ b/Source/EasyNetQ/SendReceiveExtensions.cs
@@ -3,10 +3,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.Consumer;
 using EasyNetQ.Internals;
-using EasyNetQ.Producer;
 
 namespace EasyNetQ
 {
+    /// <summary>
+    ///     Various extensions for ISendReceive
+    /// </summary>
     public static class SendReceiveExtensions
     {
         /// <summary>

--- a/Source/EasyNetQ/ServiceRegisterExtensions.cs
+++ b/Source/EasyNetQ/ServiceRegisterExtensions.cs
@@ -6,7 +6,6 @@ using EasyNetQ.Interception;
 using EasyNetQ.MessageVersioning;
 using EasyNetQ.MultipleExchange;
 using EasyNetQ.Producer;
-using EasyNetQ.Scheduling;
 using RabbitMQ.Client;
 
 namespace EasyNetQ

--- a/Source/EasyNetQ/SubscriptionConfiguration.cs
+++ b/Source/EasyNetQ/SubscriptionConfiguration.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 
-namespace EasyNetQ.FluentConfiguration
+namespace EasyNetQ
 {
     /// <summary>
-    /// Allows configuration to be fluently extended without adding overloads to IBus
+    /// Allows subscription configuration to be fluently extended without adding overloads
     ///
     /// e.g.
     /// x => x.WithTopic("*.brighton")
@@ -103,14 +103,13 @@ namespace EasyNetQ.FluentConfiguration
         ISubscriptionConfiguration WithQueueMode(string queueMode = QueueMode.Default);
     }
 
-    public class SubscriptionConfiguration : ISubscriptionConfiguration
+    internal class SubscriptionConfiguration : ISubscriptionConfiguration
     {
         public IList<string> Topics { get; }
         public bool AutoDelete { get; private set; }
         public int Priority { get; private set; }
         public ushort PrefetchCount { get; private set; }
         public int? Expires { get; private set; }
-
         public bool IsExclusive { get; private set; }
         public byte? MaxPriority { get; private set; }
         public bool Durable { get; private set; }
@@ -152,6 +151,7 @@ namespace EasyNetQ.FluentConfiguration
             Priority = priority;
             return this;
         }
+
 
         public ISubscriptionConfiguration WithPrefetchCount(ushort prefetchCount)
         {


### PR DESCRIPTION
It looks strange a bit that IPubSub, IRpc, ISendReceive live in Producer namespace. Also a log time ago we decided to leave extensions to them in the root namespace.
Merely the same situation with IScheduler.

So, this PR does the following:
1. Moves IPubSub, IRpc, ISendReceive, IScheduler and all related stuff to the root namespace
2. Adds a lot of docs
3. Internalises various *Configuration classes
4. Internalises ConnectionStringGrammar