### PR TITLE
Improve mandatory flag support in case of enabled publisher confirms

### DIFF
--- a/Source/EasyNetQ.IntegrationTests/Advanced/When_published_with_mandatory_and_with_publisher_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/Advanced/When_published_with_mandatory_and_with_publisher_confirms.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EasyNetQ.Producer;
+using EasyNetQ.Topology;
+using Xunit;
+
+namespace EasyNetQ.IntegrationTests.Advanced
+{
+    [Collection("RabbitMQ")]
+    public class When_published_with_mandatory_and_with_publisher_confirms : IDisposable
+    {
+        private readonly IBus bus;
+
+        public When_published_with_mandatory_and_with_publisher_confirms(RabbitMQFixture rmqFixture)
+        {
+            bus = RabbitHutch.CreateBus($"host={rmqFixture.Host};prefetchCount=1;timeout=-1;publisherConfirms=True");
+        }
+
+        public void Dispose() => bus.Dispose();
+
+        [Fact]
+        public async Task Should_throw_message_returned_exception()
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+            var exchange = await bus.Advanced.ExchangeDeclareAsync(
+                Guid.NewGuid().ToString("N"), ExchangeType.Direct, cancellationToken: cts.Token
+            ).ConfigureAwait(false);
+
+            await Assert.ThrowsAsync<MessageReturnedException>(
+                () => bus.Advanced.PublishAsync(
+                    exchange, "#", true, new MessageProperties(), Array.Empty<byte>(), cts.Token
+                )
+            ).ConfigureAwait(false);
+        }
+    }
+}

--- a/Source/EasyNetQ.IntegrationTests/Advanced/When_published_with_mandatory_and_with_publisher_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/Advanced/When_published_with_mandatory_and_with_publisher_confirms.cs
@@ -28,7 +28,7 @@ namespace EasyNetQ.IntegrationTests.Advanced
                 Guid.NewGuid().ToString("N"), ExchangeType.Direct, cancellationToken: cts.Token
             ).ConfigureAwait(false);
 
-            await Assert.ThrowsAsync<MessageReturnedException>(
+            await Assert.ThrowsAsync<PublishReturnedException>(
                 () => bus.Advanced.PublishAsync(
                     exchange, "#", true, new MessageProperties(), Array.Empty<byte>(), cts.Token
                 )

--- a/Source/EasyNetQ.Tests/AdvancedBusEventHandlersTests.cs
+++ b/Source/EasyNetQ.Tests/AdvancedBusEventHandlersTests.cs
@@ -119,7 +119,7 @@ namespace EasyNetQ.Tests
         public void AdvancedBusEventHandlers_MessageReturned_handler_is_called()
         {
             var @event = new ReturnedMessageEvent(
-                new byte[0], new MessageProperties(), new MessageReturnedInfo("my.exchange", "routing.key", "reason")
+                null, new byte[0], new MessageProperties(), new MessageReturnedInfo("my.exchange", "routing.key", "reason")
             );
 
             eventBus.Publish(@event);

--- a/Source/EasyNetQ.Tests/ProducerTests/PublishConfirmationListenerTest.cs
+++ b/Source/EasyNetQ.Tests/ProducerTests/PublishConfirmationListenerTest.cs
@@ -116,7 +116,7 @@ namespace EasyNetQ.Tests.ProducerTests
                     new MessageReturnedInfo("exchange", "routingKey", "returnReason")
                 )
             );
-            await Assert.ThrowsAsync<MessageReturnedException>(
+            await Assert.ThrowsAsync<PublishReturnedException>(
                 () => confirmation1.WaitAsync()
             ).ConfigureAwait(false);
         }

--- a/Source/EasyNetQ.Tests/ProducerTests/PublishConfirmationListenerTest.cs
+++ b/Source/EasyNetQ.Tests/ProducerTests/PublishConfirmationListenerTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.Events;
@@ -93,6 +94,31 @@ namespace EasyNetQ.Tests.ProducerTests
             var confirmation2 = publishConfirmationListener.CreatePendingConfirmation(model);
             eventBus.Publish(MessageConfirmationEvent.Ack(model, DeliveryTag, false));
             await confirmation2.WaitAsync().ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task Should_fail_with_returned_message_event()
+        {
+            model.NextPublishSeqNo.Returns(DeliveryTag);
+            var confirmation1 = publishConfirmationListener.CreatePendingConfirmation(model);
+            var properties = new MessageProperties
+            {
+                Headers =
+                {
+                    [MessagePropertiesExtensions.ConfirmationIdHeader] = Encoding.UTF8.GetBytes(confirmation1.Id.ToString())
+                }
+            };
+            eventBus.Publish(
+                new ReturnedMessageEvent(
+                    model,
+                    Array.Empty<byte>(),
+                    properties,
+                    new MessageReturnedInfo("exchange", "routingKey", "returnReason")
+                )
+            );
+            await Assert.ThrowsAsync<MessageReturnedException>(
+                () => confirmation1.WaitAsync()
+            ).ConfigureAwait(false);
         }
     }
 }

--- a/Source/EasyNetQ/Events/MessageConfirmationEvent.cs
+++ b/Source/EasyNetQ/Events/MessageConfirmationEvent.cs
@@ -2,13 +2,38 @@ using RabbitMQ.Client;
 
 namespace EasyNetQ.Events
 {
+    /// <summary>
+    ///     This event is raised after a message is acked or nacked
+    /// </summary>
     public class MessageConfirmationEvent
     {
+        /// <summary>
+        ///     The channel
+        /// </summary>
         public IModel Channel { get; private set; }
+
+        /// <summary>
+        ///     Delivery tag of the message
+        /// </summary>
         public ulong DeliveryTag { get; private set; }
+
+        /// <summary>
+        ///     True if a confirmation affects all previous messages
+        /// </summary>
         public bool Multiple { get; private set; }
+
+        /// <summary>
+        ///     True if a message is rejected
+        /// </summary>
         public bool IsNack { get; private set; }
 
+        /// <summary>
+        ///     Creates ack event
+        /// </summary>
+        /// <param name="channel">The channel</param>
+        /// <param name="deliveryTag">The delivery tag</param>
+        /// <param name="multiple">The multiple option</param>
+        /// <returns></returns>
         public static MessageConfirmationEvent Ack(IModel channel, ulong deliveryTag, bool multiple)
         {
             return new MessageConfirmationEvent
@@ -20,6 +45,13 @@ namespace EasyNetQ.Events
             };
         }
 
+        /// <summary>
+        ///     Creates nack event
+        /// </summary>
+        /// <param name="channel">The channel</param>
+        /// <param name="deliveryTag">The delivery tag</param>
+        /// <param name="multiple">The multiple option</param>
+        /// <returns></returns>
         public static MessageConfirmationEvent Nack(IModel channel, ulong deliveryTag, bool multiple)
         {
             return new MessageConfirmationEvent

--- a/Source/EasyNetQ/Events/PublishedMessageEvent.cs
+++ b/Source/EasyNetQ/Events/PublishedMessageEvent.cs
@@ -1,12 +1,17 @@
 ﻿namespace EasyNetQ.Events
 {
+    /// <summary>
+    ///     This event is raised after a message is published
+    /// </summary>
     public class PublishedMessageEvent
     {
-        public string ExchangeName { get; }
-        public string RoutingKey { get; }
-        public MessageProperties Properties { get; }
-        public byte[] Body { get; }
-
+        /// <summary>
+        ///     Creates PublishedMessageEvent
+        /// </summary>
+        /// <param name="exchangeName">The exchange name</param>
+        /// <param name="routingKey">The routing key</param>
+        /// <param name="properties">The properties</param>
+        /// <param name="body">The body</param>
         public PublishedMessageEvent(string exchangeName, string routingKey, MessageProperties properties, byte[] body)
         {
             ExchangeName = exchangeName;
@@ -14,5 +19,25 @@
             Properties = properties;
             Body = body;
         }
+
+        /// <summary>
+        ///     The exchange name
+        /// </summary>
+        public string ExchangeName { get; }
+
+        /// <summary>
+        ///     The routing key
+        /// </summary>
+        public string RoutingKey { get; }
+
+        /// <summary>
+        ///     The message properties
+        /// </summary>
+        public MessageProperties Properties { get; }
+
+        /// <summary>
+        ///     The message body
+        /// </summary>
+        public byte[] Body { get; }
     }
 }

--- a/Source/EasyNetQ/Events/ReturnedMessageEvent.cs
+++ b/Source/EasyNetQ/Events/ReturnedMessageEvent.cs
@@ -2,13 +2,18 @@
 
 namespace EasyNetQ.Events
 {
+    /// <summary>
+    ///     This event is raised after a message is returned because it couldn't be routed
+    /// </summary>
     public class ReturnedMessageEvent
     {
-        public IModel Channel { get; }
-        public byte[] Body { get; }
-        public MessageProperties Properties { get; }
-        public MessageReturnedInfo Info { get; }
-
+        /// <summary>
+        ///     Creates ReturnedMessageEvent
+        /// </summary>
+        /// <param name="channel">The channel</param>
+        /// <param name="body">The message body</param>
+        /// <param name="properties">The message properties</param>
+        /// <param name="info">The returned message info</param>
         public ReturnedMessageEvent(IModel channel, byte[] body, MessageProperties properties, MessageReturnedInfo info)
         {
             Channel = channel;
@@ -16,5 +21,25 @@ namespace EasyNetQ.Events
             Properties = properties;
             Info = info;
         }
+
+        /// <summary>
+        ///     The channel
+        /// </summary>
+        public IModel Channel { get; }
+
+        /// <summary>
+        ///     Message body
+        /// </summary>
+        public byte[] Body { get; }
+
+        /// <summary>
+        ///     Message properties
+        /// </summary>
+        public MessageProperties Properties { get; }
+
+        /// <summary>
+        ///     Message returned info
+        /// </summary>
+        public MessageReturnedInfo Info { get; }
     }
 }

--- a/Source/EasyNetQ/Events/ReturnedMessageEvent.cs
+++ b/Source/EasyNetQ/Events/ReturnedMessageEvent.cs
@@ -1,13 +1,17 @@
-﻿namespace EasyNetQ.Events
+﻿using RabbitMQ.Client;
+
+namespace EasyNetQ.Events
 {
     public class ReturnedMessageEvent
     {
+        public IModel Channel { get; }
         public byte[] Body { get; }
         public MessageProperties Properties { get; }
         public MessageReturnedInfo Info { get; }
 
-        public ReturnedMessageEvent(byte[] body, MessageProperties properties, MessageReturnedInfo info)
+        public ReturnedMessageEvent(IModel channel, byte[] body, MessageProperties properties, MessageReturnedInfo info)
         {
+            Channel = channel;
             Body = body;
             Properties = properties;
             Info = info;

--- a/Source/EasyNetQ/Producer/IPublishPendingConfirmation.cs
+++ b/Source/EasyNetQ/Producer/IPublishPendingConfirmation.cs
@@ -9,6 +9,11 @@ namespace EasyNetQ.Producer
     public interface IPublishPendingConfirmation
     {
         /// <summary>
+        ///     Identifier of the confirmation
+        /// </summary>
+        ulong Id { get; }
+
+        /// <summary>
         ///     Wait confirmation for ack, nack and etc.
         /// </summary>
         /// <param name="cancellationToken">The cancellation token</param>

--- a/Source/EasyNetQ/Producer/MessagePropertiesExtensions.cs
+++ b/Source/EasyNetQ/Producer/MessagePropertiesExtensions.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Text;
+
+namespace EasyNetQ.Producer
+{
+    internal static class MessagePropertiesExtensions
+    {
+        private const string ConfirmationIdHeader = "EasyNetQ.Confirmation.Id";
+
+        public static void SetConfirmationId(this MessageProperties properties, ulong confirmationId)
+        {
+            properties.Headers[ConfirmationIdHeader] = confirmationId.ToString();
+        }
+
+        public static bool TryGetConfirmationId(this MessageProperties properties, out ulong confirmationId)
+        {
+            confirmationId = 0;
+            return properties.Headers.TryGetValue(ConfirmationIdHeader, out var value) &&
+                   ulong.TryParse(Encoding.UTF8.GetString(value as byte[] ?? Array.Empty<byte>()), out confirmationId);
+        }
+    }
+}

--- a/Source/EasyNetQ/Producer/MessagePropertiesExtensions.cs
+++ b/Source/EasyNetQ/Producer/MessagePropertiesExtensions.cs
@@ -5,11 +5,12 @@ namespace EasyNetQ.Producer
 {
     internal static class MessagePropertiesExtensions
     {
-        private const string ConfirmationIdHeader = "EasyNetQ.Confirmation.Id";
+        public const string ConfirmationIdHeader = "EasyNetQ.Confirmation.Id";
 
-        public static void SetConfirmationId(this MessageProperties properties, ulong confirmationId)
+        public static MessageProperties SetConfirmationId(this MessageProperties properties, ulong confirmationId)
         {
             properties.Headers[ConfirmationIdHeader] = confirmationId.ToString();
+            return properties;
         }
 
         public static bool TryGetConfirmationId(this MessageProperties properties, out ulong confirmationId)

--- a/Source/EasyNetQ/Producer/MessageReturnedException.cs
+++ b/Source/EasyNetQ/Producer/MessageReturnedException.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace EasyNetQ.Producer
+{
+    /// <summary>
+    ///     This exception indicates that a message was returned
+    /// </summary>
+    [Serializable]
+    public class MessageReturnedException : Exception
+    {
+        //
+        // For guidelines regarding the creation of new exception types, see
+        //    http://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpgenref/html/cpconerrorraisinghandlingguidelines.asp
+        // and
+        //    http://msdn.microsoft.com/library/default.asp?url=/library/en-us/dncscol/html/csharp07192001.asp
+        //
+
+        /// <summary>
+        ///     Creates MessageReturnedException
+        /// </summary>
+        public MessageReturnedException()
+        {
+        }
+
+        /// <summary>
+        ///     Creates MessageReturnedException
+        /// </summary>
+        /// <param name="message">The message</param>
+        public MessageReturnedException(string message) : base(message)
+        {
+        }
+
+        public MessageReturnedException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+        protected MessageReturnedException(
+            SerializationInfo info,
+            StreamingContext context
+        ) : base(info, context)
+        {
+        }
+    }
+}

--- a/Source/EasyNetQ/Producer/PersistentChannel.cs
+++ b/Source/EasyNetQ/Producer/PersistentChannel.cs
@@ -151,6 +151,7 @@ namespace EasyNetQ.Producer
         private void OnReturn(object sender, BasicReturnEventArgs args)
         {
             var returnedMessageEvent = new ReturnedMessageEvent(
+                (IModel) sender,
                 args.Body.ToArray(),
                 new MessageProperties(args.BasicProperties),
                 new MessageReturnedInfo(args.Exchange, args.RoutingKey, args.ReplyText)

--- a/Source/EasyNetQ/Producer/PublishConfirmationListener.cs
+++ b/Source/EasyNetQ/Producer/PublishConfirmationListener.cs
@@ -67,7 +67,7 @@ namespace EasyNetQ.Producer
 
             var deliveryTag = @event.DeliveryTag;
             var multiple = @event.Multiple;
-            var type = @event.IsNack ? ConfirmationType.Nacked : ConfirmationType.Acked;
+            var type = @event.IsNack ? ConfirmationType.Nack : ConfirmationType.Ack;
             if (multiple)
             {
                 foreach (var sequenceNumber in requests.Select(x => x.Key))
@@ -109,7 +109,7 @@ namespace EasyNetQ.Producer
             if (!requests.TryRemove(confirmationId, out var confirmationTcs))
                 return;
 
-            Confirm(confirmationTcs, confirmationId, ConfirmationType.Returned);
+            Confirm(confirmationTcs, confirmationId, ConfirmationType.Return);
         }
 
 
@@ -148,17 +148,17 @@ namespace EasyNetQ.Producer
         {
             switch (type)
             {
-                case ConfirmationType.Returned:
+                case ConfirmationType.Return:
                     confirmationTcs.TrySetException(
                         new MessageReturnedException("Broker has signalled that message is returned")
                     );
                     break;
-                case ConfirmationType.Nacked:
+                case ConfirmationType.Nack:
                     confirmationTcs.TrySetException(
                         new PublishNackedException($"Broker has signalled that publish {sequenceNumber} was unsuccessful")
                     );
                     break;
-                case ConfirmationType.Acked:
+                case ConfirmationType.Ack:
                     confirmationTcs.TrySetResult(null);;
                     break;
                 default:
@@ -168,9 +168,9 @@ namespace EasyNetQ.Producer
 
         private enum ConfirmationType
         {
-            Acked,
-            Nacked,
-            Returned,
+            Ack,
+            Nack,
+            Return
         }
 
         private sealed class PublishPendingConfirmation : IPublishPendingConfirmation

--- a/Source/EasyNetQ/Producer/PublishConfirmationListener.cs
+++ b/Source/EasyNetQ/Producer/PublishConfirmationListener.cs
@@ -29,7 +29,8 @@ namespace EasyNetQ.Producer
             {
                 eventBus.Subscribe<MessageConfirmationEvent>(OnMessageConfirmation),
                 eventBus.Subscribe<ChannelRecoveredEvent>(OnChannelRecovered),
-                eventBus.Subscribe<ChannelShutdownEvent>(OnChannelShutdown)
+                eventBus.Subscribe<ChannelShutdownEvent>(OnChannelShutdown),
+                eventBus.Subscribe<ReturnedMessageEvent>(OnReturnedMessage)
             };
         }
 
@@ -46,7 +47,9 @@ namespace EasyNetQ.Producer
             if (!requests.TryAdd(sequenceNumber, confirmationTcs))
                 throw new InvalidOperationException($"Confirmation {sequenceNumber} already exists");
 
-            return new PublishPendingConfirmation(confirmationTcs, () => requests.Remove(sequenceNumber));
+            return new PublishPendingConfirmation(
+                sequenceNumber, confirmationTcs, () => requests.Remove(sequenceNumber)
+            );
         }
 
         /// <inheritdoc />
@@ -64,15 +67,15 @@ namespace EasyNetQ.Producer
 
             var deliveryTag = @event.DeliveryTag;
             var multiple = @event.Multiple;
-            var isNack = @event.IsNack;
+            var type = @event.IsNack ? ConfirmationType.Nack : ConfirmationType.Ack;
             if (multiple)
             {
                 foreach (var sequenceNumber in requests.Select(x => x.Key))
                     if (sequenceNumber <= deliveryTag && requests.TryRemove(sequenceNumber, out var confirmationTcs))
-                        Confirm(confirmationTcs, sequenceNumber, isNack);
+                        Confirm(confirmationTcs, sequenceNumber, type);
             }
             else if (requests.TryRemove(deliveryTag, out var confirmation))
-                Confirm(confirmation, deliveryTag, isNack);
+                Confirm(confirmation, deliveryTag, type);
         }
 
         private void OnChannelRecovered(ChannelRecoveredEvent @event)
@@ -89,6 +92,24 @@ namespace EasyNetQ.Producer
                 return;
 
             InterruptUnconfirmedRequests(@event.Channel.ChannelNumber);
+        }
+
+
+        private void OnReturnedMessage(ReturnedMessageEvent @event)
+        {
+            if (@event.Channel.NextPublishSeqNo == 0)
+                return;
+
+            if (!@event.Properties.TryGetConfirmationId(out var confirmationId))
+                return;
+
+            if (!unconfirmedChannelRequests.TryGetValue(@event.Channel.ChannelNumber, out var requests))
+                return;
+
+            if (!requests.TryRemove(confirmationId, out var confirmationTcs))
+                return;
+
+            Confirm(confirmationTcs, confirmationId, ConfirmationType.Returned);
         }
 
 
@@ -121,26 +142,51 @@ namespace EasyNetQ.Producer
             } while (!unconfirmedChannelRequests.IsEmpty);
         }
 
-        private static void Confirm(TaskCompletionSource<object> confirmationTcs, ulong sequenceNumber, bool isNack)
+        private static void Confirm(
+            TaskCompletionSource<object> confirmationTcs, ulong sequenceNumber, ConfirmationType type
+        )
         {
-            if (isNack)
-                confirmationTcs.TrySetException(
-                    new PublishNackedException($"Broker has signalled that publish {sequenceNumber} was unsuccessful")
-                );
-            else
-                confirmationTcs.TrySetResult(null);
+            switch (type)
+            {
+                case ConfirmationType.Returned:
+                    confirmationTcs.TrySetException(
+                        new MessageReturnedException("Broker has signalled that message is returned")
+                    );
+                    break;
+                case ConfirmationType.Nack:
+                    confirmationTcs.TrySetException(
+                        new PublishNackedException($"Broker has signalled that publish {sequenceNumber} was unsuccessful")
+                    );
+                    break;
+                case ConfirmationType.Ack:
+                    confirmationTcs.TrySetResult(null);;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type), type, null);
+            }
+        }
+
+        private enum ConfirmationType
+        {
+            Ack,
+            Nack,
+            Returned,
         }
 
         private sealed class PublishPendingConfirmation : IPublishPendingConfirmation
         {
+            private readonly ulong id;
             private readonly TaskCompletionSource<object> confirmationTcs;
             private readonly Action cleanup;
 
-            public PublishPendingConfirmation(TaskCompletionSource<object> confirmationTcs, Action cleanup)
+            public PublishPendingConfirmation(ulong id, TaskCompletionSource<object> confirmationTcs, Action cleanup)
             {
+                this.id = id;
                 this.confirmationTcs = confirmationTcs;
                 this.cleanup = cleanup;
             }
+
+            public ulong Id => id;
 
             public async Task WaitAsync(CancellationToken cancellationToken)
             {

--- a/Source/EasyNetQ/Producer/PublishConfirmationListener.cs
+++ b/Source/EasyNetQ/Producer/PublishConfirmationListener.cs
@@ -67,7 +67,7 @@ namespace EasyNetQ.Producer
 
             var deliveryTag = @event.DeliveryTag;
             var multiple = @event.Multiple;
-            var type = @event.IsNack ? ConfirmationType.Nack : ConfirmationType.Ack;
+            var type = @event.IsNack ? ConfirmationType.Nacked : ConfirmationType.Acked;
             if (multiple)
             {
                 foreach (var sequenceNumber in requests.Select(x => x.Key))
@@ -153,12 +153,12 @@ namespace EasyNetQ.Producer
                         new MessageReturnedException("Broker has signalled that message is returned")
                     );
                     break;
-                case ConfirmationType.Nack:
+                case ConfirmationType.Nacked:
                     confirmationTcs.TrySetException(
                         new PublishNackedException($"Broker has signalled that publish {sequenceNumber} was unsuccessful")
                     );
                     break;
-                case ConfirmationType.Ack:
+                case ConfirmationType.Acked:
                     confirmationTcs.TrySetResult(null);;
                     break;
                 default:
@@ -168,8 +168,8 @@ namespace EasyNetQ.Producer
 
         private enum ConfirmationType
         {
-            Ack,
-            Nack,
+            Acked,
+            Nacked,
             Returned,
         }
 

--- a/Source/EasyNetQ/Producer/PublishConfirmationListener.cs
+++ b/Source/EasyNetQ/Producer/PublishConfirmationListener.cs
@@ -150,7 +150,7 @@ namespace EasyNetQ.Producer
             {
                 case ConfirmationType.Return:
                     confirmationTcs.TrySetException(
-                        new MessageReturnedException("Broker has signalled that message is returned")
+                        new PublishReturnedException("Broker has signalled that message is returned")
                     );
                     break;
                 case ConfirmationType.Nack:

--- a/Source/EasyNetQ/Producer/PublishInterruptedException.cs
+++ b/Source/EasyNetQ/Producer/PublishInterruptedException.cs
@@ -1,7 +1,12 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace EasyNetQ.Producer
 {
+    /// <summary>
+    ///     This exception indicates that a publish was interrupted(for instance, because of a reconnection)
+    /// </summary>
+    [Serializable]
     public class PublishInterruptedException : Exception
     {
         //
@@ -11,17 +16,25 @@ namespace EasyNetQ.Producer
         //    http://msdn.microsoft.com/library/default.asp?url=/library/en-us/dncscol/html/csharp07192001.asp
         //
 
+        /// <inheritdoc />
         public PublishInterruptedException()
         {
         }
 
+        /// <inheritdoc />
         public PublishInterruptedException(string message)
             : base(message)
         {
         }
 
+        /// <inheritdoc />
         public PublishInterruptedException(string message, Exception inner)
             : base(message, inner)
+        {
+        }
+
+        /// <inheritdoc />
+        protected PublishInterruptedException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/Source/EasyNetQ/Producer/PublishNackedException.cs
+++ b/Source/EasyNetQ/Producer/PublishNackedException.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace EasyNetQ.Producer
 {
+    [Serializable]
     public class PublishNackedException : Exception
     {
         //
@@ -20,6 +22,13 @@ namespace EasyNetQ.Producer
         }
 
         public PublishNackedException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+        protected PublishNackedException(
+            SerializationInfo info,
+            StreamingContext context
+        ) : base(info, context)
         {
         }
     }

--- a/Source/EasyNetQ/Producer/PublishNackedException.cs
+++ b/Source/EasyNetQ/Producer/PublishNackedException.cs
@@ -3,6 +3,9 @@ using System.Runtime.Serialization;
 
 namespace EasyNetQ.Producer
 {
+    /// <summary>
+    ///     This exception indicates that a message was nacked
+    /// </summary>
     [Serializable]
     public class PublishNackedException : Exception
     {
@@ -13,22 +16,23 @@ namespace EasyNetQ.Producer
         //    http://msdn.microsoft.com/library/default.asp?url=/library/en-us/dncscol/html/csharp07192001.asp
         //
 
+        /// <inheritdoc />
         public PublishNackedException()
         {
         }
 
+        /// <inheritdoc />
         public PublishNackedException(string message) : base(message)
         {
         }
 
+        /// <inheritdoc />
         public PublishNackedException(string message, Exception inner) : base(message, inner)
         {
         }
 
-        protected PublishNackedException(
-            SerializationInfo info,
-            StreamingContext context
-        ) : base(info, context)
+        /// <inheritdoc />
+        protected PublishNackedException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/Source/EasyNetQ/Producer/PublishReturnedException.cs
+++ b/Source/EasyNetQ/Producer/PublishReturnedException.cs
@@ -7,7 +7,7 @@ namespace EasyNetQ.Producer
     ///     This exception indicates that a message was returned
     /// </summary>
     [Serializable]
-    public class MessageReturnedException : Exception
+    public class PublishReturnedException : Exception
     {
         //
         // For guidelines regarding the creation of new exception types, see
@@ -16,29 +16,23 @@ namespace EasyNetQ.Producer
         //    http://msdn.microsoft.com/library/default.asp?url=/library/en-us/dncscol/html/csharp07192001.asp
         //
 
-        /// <summary>
-        ///     Creates MessageReturnedException
-        /// </summary>
-        public MessageReturnedException()
+        /// <inheritdoc />
+        public PublishReturnedException()
         {
         }
 
-        /// <summary>
-        ///     Creates MessageReturnedException
-        /// </summary>
-        /// <param name="message">The message</param>
-        public MessageReturnedException(string message) : base(message)
+        /// <inheritdoc />
+        public PublishReturnedException(string message) : base(message)
         {
         }
 
-        public MessageReturnedException(string message, Exception inner) : base(message, inner)
+        /// <inheritdoc />
+        public PublishReturnedException(string message, Exception inner) : base(message, inner)
         {
         }
 
-        protected MessageReturnedException(
-            SerializationInfo info,
-            StreamingContext context
-        ) : base(info, context)
+        /// <inheritdoc />
+        protected PublishReturnedException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -251,9 +251,10 @@ namespace EasyNetQ
                 {
                     var pendingConfirmation = await clientCommandDispatcher.InvokeAsync(model =>
                     {
+                        var confirmation = confirmationListener.CreatePendingConfirmation(model);
+                        rawMessage.Properties.SetConfirmationId(confirmation.Id);
                         var properties = model.CreateBasicProperties();
                         rawMessage.Properties.CopyTo(properties);
-                        var confirmation = confirmationListener.CreatePendingConfirmation(model);
                         try
                         {
                             model.BasicPublish(exchange.Name, routingKey, mandatory, properties, rawMessage.Body);


### PR DESCRIPTION
Fixes #537

In case of enabled publisher confirms, we could observe a message was neither acknowledged nor rejected because it was returned. 

PR helps to not receive a timeout in case of a returned message(as mentioned in #537) but to receive a proper exception that indicates that a message was returned. Unfortunately, it's impossible to match a published message with a returned message by delivery tag, because there is no delivery tag in returned message info, but we could attach it manually to headers.
