### PR TITLE
Remove ConfigureAwait(false) from tests

### DIFF
--- a/Source/EasyNetQ.IntegrationTests/Advanced/When_connected_event_raised.cs
+++ b/Source/EasyNetQ.IntegrationTests/Advanced/When_connected_event_raised.cs
@@ -28,7 +28,7 @@ namespace EasyNetQ.IntegrationTests.Advanced
 
             await bus.Advanced.ExchangeDeclareAsync(
                 Guid.NewGuid().ToString("N"), c => c.WithType(ExchangeType.Topic), cts.Token
-            ).ConfigureAwait(false);
+            );
 
             mre.Wait(cts.Token);
         }

--- a/Source/EasyNetQ.IntegrationTests/Advanced/When_declare_an_exchange_with_different_properties.cs
+++ b/Source/EasyNetQ.IntegrationTests/Advanced/When_declare_an_exchange_with_different_properties.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client.Exceptions;
@@ -24,11 +24,11 @@ namespace EasyNetQ.IntegrationTests.Advanced
         {
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
-            await bus.Advanced.ExchangeDeclareAsync("a", ExchangeType.Topic, cancellationToken: cts.Token).ConfigureAwait(false);
+            await bus.Advanced.ExchangeDeclareAsync("a", ExchangeType.Topic, cancellationToken: cts.Token);
             await Assert.ThrowsAsync<OperationInterruptedException>(
                 () => bus.Advanced.ExchangeDeclareAsync("a", ExchangeType.Direct, cancellationToken: cts.Token)
-            ).ConfigureAwait(false);
-            await bus.Advanced.ExchangeDeclareAsync("a", ExchangeType.Topic, cancellationToken: cts.Token).ConfigureAwait(false);
+            );
+            await bus.Advanced.ExchangeDeclareAsync("a", ExchangeType.Topic, cancellationToken: cts.Token);
         }
     }
 }

--- a/Source/EasyNetQ.IntegrationTests/Advanced/When_publish_to_non_existent_exchange.cs
+++ b/Source/EasyNetQ.IntegrationTests/Advanced/When_publish_to_non_existent_exchange.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.Topology;
@@ -25,15 +25,15 @@ namespace EasyNetQ.IntegrationTests.Advanced
         {
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
-            await bus.Advanced.ExchangeDeclareAsync("existent", ExchangeType.Topic, cancellationToken: cts.Token).ConfigureAwait(false);
+            await bus.Advanced.ExchangeDeclareAsync("existent", ExchangeType.Topic, cancellationToken: cts.Token);
             await Assert.ThrowsAsync<AlreadyClosedException>(() =>
                 bus.Advanced.PublishAsync(
                     new Exchange("non-existent"), "#", false, new MessageProperties(), Array.Empty<byte>(), cts.Token
                 )
-            ).ConfigureAwait(false);
+            );
             await bus.Advanced.PublishAsync(
                 new Exchange("existent"), "#", false, new MessageProperties(), Array.Empty<byte>(), cts.Token
-            ).ConfigureAwait(false);
+            );
         }
     }
 }

--- a/Source/EasyNetQ.IntegrationTests/Advanced/When_published_with_mandatory_and_with_publisher_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/Advanced/When_published_with_mandatory_and_with_publisher_confirms.cs
@@ -26,13 +26,13 @@ namespace EasyNetQ.IntegrationTests.Advanced
 
             var exchange = await bus.Advanced.ExchangeDeclareAsync(
                 Guid.NewGuid().ToString("N"), ExchangeType.Direct, cancellationToken: cts.Token
-            ).ConfigureAwait(false);
+            );
 
             await Assert.ThrowsAsync<PublishReturnedException>(
                 () => bus.Advanced.PublishAsync(
                     exchange, "#", true, new MessageProperties(), Array.Empty<byte>(), cts.Token
                 )
-            ).ConfigureAwait(false);
+            );
         }
     }
 }

--- a/Source/EasyNetQ.IntegrationTests/Advanced/When_pull_messages.cs
+++ b/Source/EasyNetQ.IntegrationTests/Advanced/When_pull_messages.cs
@@ -29,23 +29,23 @@ namespace EasyNetQ.IntegrationTests.Advanced
 
             var queue = await bus.Advanced.QueueDeclareAsync(
                 Guid.NewGuid().ToString("N"), cts.Token
-            ).ConfigureAwait(false);
+            );
             await bus.Advanced.PublishAsync(
                 Exchange.GetDefault(), queue.Name, false, new MessageProperties(), Array.Empty<byte>(), cts.Token
-            ).ConfigureAwait(false);
+            );
 
             var consumer = bus.Advanced.CreatePullingConsumer(queue, false);
 
             {
-                var pullResult = await consumer.PullAsync(cts.Token).ConfigureAwait(false);
+                var pullResult = await consumer.PullAsync(cts.Token);
                 pullResult.IsAvailable.Should().BeTrue();
                 await consumer.AckAsync(
                     pullResult.ReceivedInfo.DeliveryTag, cts.Token
-                ).ConfigureAwait(false);
+                );
             }
 
             {
-                var pullResult = await consumer.PullAsync(cts.Token).ConfigureAwait(false);
+                var pullResult = await consumer.PullAsync(cts.Token);
                 pullResult.IsAvailable.Should().BeFalse();
             }
         }
@@ -57,23 +57,23 @@ namespace EasyNetQ.IntegrationTests.Advanced
 
             var queue = await bus.Advanced.QueueDeclareAsync(
                 Guid.NewGuid().ToString("N"), cts.Token
-            ).ConfigureAwait(false);
+            );
             await bus.Advanced.PublishAsync(
                 Exchange.GetDefault(), queue.Name, false, new MessageProperties(), Array.Empty<byte>(), cts.Token
-            ).ConfigureAwait(false);
+            );
 
             var consumer = bus.Advanced.CreatePullingConsumer(queue, false);
 
             {
-                var pullResult = await consumer.PullAsync(cts.Token).ConfigureAwait(false);
+                var pullResult = await consumer.PullAsync(cts.Token);
                 pullResult.IsAvailable.Should().BeTrue();
                 await consumer.RejectAsync(
                     pullResult.ReceivedInfo.DeliveryTag, false, cts.Token
-                ).ConfigureAwait(false);
+                );
             }
 
             {
-                var pullResult = await consumer.PullAsync(cts.Token).ConfigureAwait(false);
+                var pullResult = await consumer.PullAsync(cts.Token);
                 pullResult.IsAvailable.Should().BeFalse();
             }
         }
@@ -85,23 +85,23 @@ namespace EasyNetQ.IntegrationTests.Advanced
 
             var queue = await bus.Advanced.QueueDeclareAsync(
                 Guid.NewGuid().ToString("N"), cts.Token
-            ).ConfigureAwait(false);
+            );
             await bus.Advanced.PublishAsync(
                 Exchange.GetDefault(), queue.Name, false, new MessageProperties(), Array.Empty<byte>(), cts.Token
-            ).ConfigureAwait(false);
+            );
 
             var consumer = bus.Advanced.CreatePullingConsumer(queue, false);
 
             {
-                var pullResult = await consumer.PullAsync(cts.Token).ConfigureAwait(false);
+                var pullResult = await consumer.PullAsync(cts.Token);
                 pullResult.IsAvailable.Should().BeTrue();
                 await consumer.RejectAsync(
                     pullResult.ReceivedInfo.DeliveryTag, true, cts.Token
-                ).ConfigureAwait(false);
+                );
             }
 
             {
-                var pullResult = await consumer.PullAsync(cts.Token).ConfigureAwait(false);
+                var pullResult = await consumer.PullAsync(cts.Token);
                 pullResult.IsAvailable.Should().BeTrue();
             }
         }
@@ -113,20 +113,20 @@ namespace EasyNetQ.IntegrationTests.Advanced
 
             var queue = await bus.Advanced.QueueDeclareAsync(
                 Guid.NewGuid().ToString("N"), cts.Token
-            ).ConfigureAwait(false);
+            );
             await bus.Advanced.PublishAsync(
                 Exchange.GetDefault(), queue.Name, false, new MessageProperties(), Array.Empty<byte>(), cts.Token
-            ).ConfigureAwait(false);
+            );
 
             var consumer = bus.Advanced.CreatePullingConsumer(queue);
 
             {
-                var pullResult = await consumer.PullAsync(cts.Token).ConfigureAwait(false);
+                var pullResult = await consumer.PullAsync(cts.Token);
                 pullResult.IsAvailable.Should().BeTrue();
             }
 
             {
-                var pullResult = await consumer.PullAsync(cts.Token).ConfigureAwait(false);
+                var pullResult = await consumer.PullAsync(cts.Token);
                 pullResult.IsAvailable.Should().BeFalse();
             }
         }

--- a/Source/EasyNetQ.IntegrationTests/Advanced/When_pull_messages_batch.cs
+++ b/Source/EasyNetQ.IntegrationTests/Advanced/When_pull_messages_batch.cs
@@ -29,26 +29,26 @@ namespace EasyNetQ.IntegrationTests.Advanced
 
             var queue = await bus.Advanced.QueueDeclareAsync(
                 Guid.NewGuid().ToString("N"), cts.Token
-            ).ConfigureAwait(false);
+            );
             await bus.Advanced.PublishAsync(
                 Exchange.GetDefault(), queue.Name, false, new MessageProperties(), Array.Empty<byte>(), cts.Token
-            ).ConfigureAwait(false);
+            );
             await bus.Advanced.PublishAsync(
                 Exchange.GetDefault(), queue.Name, false, new MessageProperties(), Array.Empty<byte>(), cts.Token
-            ).ConfigureAwait(false);
+            );
 
             var consumer = bus.Advanced.CreatePullingConsumer(queue, false);
 
             {
-                var pullResult = await consumer.PullBatchAsync(2, cts.Token).ConfigureAwait(false);
+                var pullResult = await consumer.PullBatchAsync(2, cts.Token);
                 pullResult.Messages.Should().HaveCount(2);
                 await consumer.AckBatchAsync(
                     pullResult.DeliveryTag, cts.Token
-                ).ConfigureAwait(false);
+                );
             }
 
             {
-                var pullResult = await consumer.PullBatchAsync(2, cts.Token).ConfigureAwait(false);
+                var pullResult = await consumer.PullBatchAsync(2, cts.Token);
                 pullResult.Messages.Should().HaveCount(0);
             }
         }
@@ -60,26 +60,26 @@ namespace EasyNetQ.IntegrationTests.Advanced
 
             var queue = await bus.Advanced.QueueDeclareAsync(
                 Guid.NewGuid().ToString("N"), cts.Token
-            ).ConfigureAwait(false);
+            );
             await bus.Advanced.PublishAsync(
                 Exchange.GetDefault(), queue.Name, false, new MessageProperties(), Array.Empty<byte>(), cts.Token
-            ).ConfigureAwait(false);
+            );
             await bus.Advanced.PublishAsync(
                 Exchange.GetDefault(), queue.Name, false, new MessageProperties(), Array.Empty<byte>(), cts.Token
-            ).ConfigureAwait(false);
+            );
 
             var consumer = bus.Advanced.CreatePullingConsumer(queue, false);
 
             {
-                var pullResult = await consumer.PullBatchAsync(2, cts.Token).ConfigureAwait(false);
+                var pullResult = await consumer.PullBatchAsync(2, cts.Token);
                 pullResult.Messages.Should().HaveCount(2);
                 await consumer.RejectBatchAsync(
                     pullResult.DeliveryTag, false, cts.Token
-                ).ConfigureAwait(false);
+                );
             }
 
             {
-                var pullResult = await consumer.PullBatchAsync(2, cts.Token).ConfigureAwait(false);
+                var pullResult = await consumer.PullBatchAsync(2, cts.Token);
                 pullResult.Messages.Should().HaveCount(0);
             }
         }
@@ -91,26 +91,26 @@ namespace EasyNetQ.IntegrationTests.Advanced
 
             var queue = await bus.Advanced.QueueDeclareAsync(
                 Guid.NewGuid().ToString("N"), cts.Token
-            ).ConfigureAwait(false);
+            );
             await bus.Advanced.PublishAsync(
                 Exchange.GetDefault(), queue.Name, false, new MessageProperties(), Array.Empty<byte>(), cts.Token
-            ).ConfigureAwait(false);
+            );
             await bus.Advanced.PublishAsync(
                 Exchange.GetDefault(), queue.Name, false, new MessageProperties(), Array.Empty<byte>(), cts.Token
-            ).ConfigureAwait(false);
+            );
 
             var consumer = bus.Advanced.CreatePullingConsumer(queue, false);
 
             {
-                var pullResult = await consumer.PullBatchAsync(2, cts.Token).ConfigureAwait(false);
+                var pullResult = await consumer.PullBatchAsync(2, cts.Token);
                 pullResult.Messages.Should().HaveCount(2);
                 await consumer.RejectBatchAsync(
                     pullResult.DeliveryTag, true, cts.Token
-                ).ConfigureAwait(false);
+                );
             }
 
             {
-                var pullResult = await consumer.PullBatchAsync(2, cts.Token).ConfigureAwait(false);
+                var pullResult = await consumer.PullBatchAsync(2, cts.Token);
                 pullResult.Messages.Should().HaveCount(2);
             }
         }
@@ -122,23 +122,23 @@ namespace EasyNetQ.IntegrationTests.Advanced
 
             var queue = await bus.Advanced.QueueDeclareAsync(
                 Guid.NewGuid().ToString("N"), cts.Token
-            ).ConfigureAwait(false);
+            );
             await bus.Advanced.PublishAsync(
                 Exchange.GetDefault(), queue.Name, false, new MessageProperties(), Array.Empty<byte>(), cts.Token
-            ).ConfigureAwait(false);
+            );
             await bus.Advanced.PublishAsync(
                 Exchange.GetDefault(), queue.Name, false, new MessageProperties(), Array.Empty<byte>(), cts.Token
-            ).ConfigureAwait(false);
+            );
 
             var consumer = bus.Advanced.CreatePullingConsumer(queue);
 
             {
-                var pullResult = await consumer.PullBatchAsync(2, cts.Token).ConfigureAwait(false);
+                var pullResult = await consumer.PullBatchAsync(2, cts.Token);
                 pullResult.Messages.Should().HaveCount(2);
             }
 
             {
-                var pullResult = await consumer.PullBatchAsync(0, cts.Token).ConfigureAwait(false);
+                var pullResult = await consumer.PullBatchAsync(0, cts.Token);
                 pullResult.Messages.Should().HaveCount(0);
             }
         }

--- a/Source/EasyNetQ.IntegrationTests/DockerProxy.cs
+++ b/Source/EasyNetQ.IntegrationTests/DockerProxy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -28,7 +28,7 @@ namespace EasyNetQ.IntegrationTests
 
         public async Task<OSPlatform> GetDockerEngineOsAsync(CancellationToken token = default)
         {
-            var response = await client.System.GetSystemInfoAsync(token).ConfigureAwait(false);
+            var response = await client.System.GetSystemInfoAsync(token);
             return OSPlatform.Create(response.OSType.ToUpper());
         }
 
@@ -38,7 +38,7 @@ namespace EasyNetQ.IntegrationTests
             {
                 Name = name
             };
-            await client.Networks.CreateNetworkAsync(networksCreateParameters, token).ConfigureAwait(false);
+            await client.Networks.CreateNetworkAsync(networksCreateParameters, token);
         }
 
         public async Task PullImageAsync(string image, string tag, CancellationToken token = default)
@@ -49,7 +49,7 @@ namespace EasyNetQ.IntegrationTests
                 Tag = tag
             };
             var progress = new Progress<JSONMessage>(jsonMessage => { });
-            await client.Images.CreateImageAsync(createParameters, null, progress, token).ConfigureAwait(false);
+            await client.Images.CreateImageAsync(createParameters, null, progress, token);
         }
 
         public async Task<string> CreateContainerAsync(string image, string name,
@@ -69,26 +69,26 @@ namespace EasyNetQ.IntegrationTests
                 },
                 ExposedPorts = portMappings.ToDictionary(x => x.Key, x => new EmptyStruct())
             };
-            var response = await client.Containers.CreateContainerAsync(createParameters, token).ConfigureAwait(false);
+            var response = await client.Containers.CreateContainerAsync(createParameters, token);
             return response.ID;
         }
 
         public async Task StartContainerAsync(string id, CancellationToken token = default)
         {
             await client.Containers.StartContainerAsync(id, new ContainerStartParameters(), token)
-                .ConfigureAwait(false);
+                ;
         }
 
         public async Task<string> GetContainerIpAsync(string id, CancellationToken token = default)
         {
-            var response = await client.Containers.InspectContainerAsync(id, token).ConfigureAwait(false);
+            var response = await client.Containers.InspectContainerAsync(id, token);
             var networks = response.NetworkSettings.Networks;
             return networks.Select(x => x.Value.IPAddress).First(x => !string.IsNullOrEmpty(x));
         }
 
         public async Task StopContainerAsync(string name, CancellationToken token = default)
         {
-            var ids = await FindContainerIdsAsync(name).ConfigureAwait(false);
+            var ids = await FindContainerIdsAsync(name);
             var stopTasks = ids.Select(x =>
                 client.Containers.StopContainerAsync(x, new ContainerStopParameters(), token));
             await Task.WhenAll(stopTasks);
@@ -101,7 +101,7 @@ namespace EasyNetQ.IntegrationTests
 
         public async Task RemoveContainerAsync(string name, CancellationToken token = default)
         {
-            var ids = await FindContainerIdsAsync(name).ConfigureAwait(false);
+            var ids = await FindContainerIdsAsync(name);
             var containerRemoveParameters = new ContainerRemoveParameters {Force = true, RemoveVolumes = true};
             var removeTasks =
                 ids.Select(x => client.Containers.RemoveContainerAsync(x, containerRemoveParameters, token));
@@ -110,7 +110,7 @@ namespace EasyNetQ.IntegrationTests
 
         public async Task DeleteNetworkAsync(string name, CancellationToken token = default)
         {
-            var ids = await FindNetworkIdsAsync(name).ConfigureAwait(false);
+            var ids = await FindNetworkIdsAsync(name);
             var deleteTasks = ids.Select(x => client.Networks.DeleteNetworkAsync(x, token));
             await Task.WhenAll(deleteTasks);
         }
@@ -132,14 +132,14 @@ namespace EasyNetQ.IntegrationTests
         {
             var containers = await client.Containers
                 .ListContainersAsync(new ContainersListParameters {All = true, Filters = ListFilters(name)})
-                .ConfigureAwait(false);
+                ;
             return containers.Select(x => x.ID);
         }
 
         private async Task<IEnumerable<string>> FindNetworkIdsAsync(string name)
         {
             var networks = await client.Networks
-                .ListNetworksAsync(new NetworksListParameters {Filters = ListFilters(name)}).ConfigureAwait(false);
+                .ListNetworksAsync(new NetworksListParameters {Filters = ListFilters(name)});
             return networks.Select(x => x.ID);
         }
 

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_polymorphic.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_polymorphic.cs
@@ -53,12 +53,12 @@ namespace EasyNetQ.IntegrationTests.PubSub
             }, cts.Token))
             {
                 await bus.PubSub.PublishBatchAsync(bunnies.Concat(rabbits), cts.Token)
-                    .ConfigureAwait(false);
+                    ;
 
                 await Task.WhenAll(
                     bunniesSink.WaitAllReceivedAsync(cts.Token),
                     rabbitsSink.WaitAllReceivedAsync(cts.Token)
-                ).ConfigureAwait(false);
+                );
 
                 bunniesSink.ReceivedMessages.Should().Equal(bunnies);
                 rabbitsSink.ReceivedMessages.Should().Equal(rabbits);

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_default_options.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_default_options.cs
@@ -38,9 +38,9 @@ namespace EasyNetQ.IntegrationTests.PubSub
 
             using (await bus.PubSub.SubscribeAsync<Message>(subscriptionId, messagesSink.Receive))
             {
-                await bus.PubSub.PublishBatchAsync(messages, cts.Token).ConfigureAwait(false);
+                await bus.PubSub.PublishBatchAsync(messages, cts.Token);
 
-                await messagesSink.WaitAllReceivedAsync(cts.Token).ConfigureAwait(false);
+                await messagesSink.WaitAllReceivedAsync(cts.Token);
                 messagesSink.ReceivedMessages.Should().Equal(messages);
             }
         }
@@ -65,12 +65,12 @@ namespace EasyNetQ.IntegrationTests.PubSub
                 )
             )
             {
-                await bus.PubSub.PublishBatchAsync(messages, cts.Token).ConfigureAwait(false);
+                await bus.PubSub.PublishBatchAsync(messages, cts.Token);
 
                 await Task.WhenAll(
                     firstConsumerMessagesSink.WaitAllReceivedAsync(cts.Token),
                     secondConsumerMessagesSink.WaitAllReceivedAsync(cts.Token)
-                ).ConfigureAwait(false);
+                );
 
                 firstConsumerMessagesSink.ReceivedMessages.Should().BeEquivalentTo(messages);
                 secondConsumerMessagesSink.ReceivedMessages.Should().BeEquivalentTo(messages);
@@ -90,9 +90,9 @@ namespace EasyNetQ.IntegrationTests.PubSub
             using (await bus.PubSub.SubscribeAsync<Message>(subscriptionId, messagesSink.Receive, cts.Token))
             using (await bus.PubSub.SubscribeAsync<Message>(subscriptionId, messagesSink.Receive, cts.Token))
             {
-                await bus.PubSub.PublishBatchAsync(messages, cts.Token).ConfigureAwait(false);
+                await bus.PubSub.PublishBatchAsync(messages, cts.Token);
 
-                await messagesSink.WaitAllReceivedAsync(cts.Token).ConfigureAwait(false);
+                await messagesSink.WaitAllReceivedAsync(cts.Token);
                 messagesSink.ReceivedMessages.Should().BeEquivalentTo(messages);
             }
         }
@@ -107,10 +107,10 @@ namespace EasyNetQ.IntegrationTests.PubSub
             using (await bus.PubSub.SubscribeAsync<Message>(subscriptionId, messagesSink.Receive, cts.Token))
             {
                 var message = new Message(0);
-                await bus.PubSub.PublishAsync(message, cts.Token).ConfigureAwait(false);
-                await rmqFixture.ManagementClient.KillAllConnectionsAsync(cts.Token).ConfigureAwait(false);
-                await bus.PubSub.PublishAsync(message, cts.Token).ConfigureAwait(false);
-                await messagesSink.WaitAllReceivedAsync(cts.Token).ConfigureAwait(false);
+                await bus.PubSub.PublishAsync(message, cts.Token);
+                await rmqFixture.ManagementClient.KillAllConnectionsAsync(cts.Token);
+                await bus.PubSub.PublishAsync(message, cts.Token);
+                await messagesSink.WaitAllReceivedAsync(cts.Token);
             }
         }
     }

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_exclusive.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_exclusive.cs
@@ -44,7 +44,7 @@ namespace EasyNetQ.IntegrationTests.PubSub
             )
             {
                 // To ensure that ^ subscriber started successfully
-                await Task.Delay(TimeSpan.FromSeconds(1), cts.Token).ConfigureAwait(false);
+                await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
 
                 using (
                     await bus.PubSub.SubscribeAsync<Message>(
@@ -55,12 +55,12 @@ namespace EasyNetQ.IntegrationTests.PubSub
                     )
                 )
                 {
-                    await bus.PubSub.PublishBatchAsync(messages, cts.Token).ConfigureAwait(false);
+                    await bus.PubSub.PublishBatchAsync(messages, cts.Token);
 
                     await Task.WhenAll(
                         firstConsumerMessagesSink.WaitAllReceivedAsync(cts.Token),
                         secondConsumerMessagesSink.WaitAllReceivedAsync(cts.Token)
-                    ).ConfigureAwait(false);
+                    );
 
                     firstConsumerMessagesSink.ReceivedMessages.Should().Equal(messages);
                     secondConsumerMessagesSink.ReceivedMessages.Should().Equal();

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_priority.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_priority.cs
@@ -47,10 +47,10 @@ namespace EasyNetQ.IntegrationTests.PubSub
 
             await bus.PubSub.PublishBatchAsync(
                 lowPriorityMessages, x => x.WithPriority(LowPriority), cts.Token
-            ).ConfigureAwait(false);
+            );
             await bus.PubSub.PublishBatchAsync(
                 highPriorityMessages, x => x.WithPriority(HighPriority), cts.Token
-            ).ConfigureAwait(false);
+            );
 
             using (
                 await bus.PubSub.SubscribeAsync<Message>(
@@ -58,7 +58,7 @@ namespace EasyNetQ.IntegrationTests.PubSub
                 )
             )
             {
-                await messagesSink.WaitAllReceivedAsync(cts.Token).ConfigureAwait(false);
+                await messagesSink.WaitAllReceivedAsync(cts.Token);
 
                 messagesSink.ReceivedMessages.Should().Equal(highPriorityMessages.Concat(lowPriorityMessages));
             }

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_publish_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_publish_confirms.cs
@@ -36,9 +36,9 @@ namespace EasyNetQ.IntegrationTests.PubSub
 
             using (await bus.PubSub.SubscribeAsync<Message>(subscriptionId, messagesSink.Receive, cts.Token))
             {
-                await bus.PubSub.PublishBatchAsync(messages, cts.Token).ConfigureAwait(false);
+                await bus.PubSub.PublishBatchAsync(messages, cts.Token);
 
-                await messagesSink.WaitAllReceivedAsync(cts.Token).ConfigureAwait(false);
+                await messagesSink.WaitAllReceivedAsync(cts.Token);
                 messagesSink.ReceivedMessages.Should().Equal(messages);
             }
         }

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_publish_confirms_and_multi_channel_dispatcher.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_publish_confirms_and_multi_channel_dispatcher.cs
@@ -39,9 +39,9 @@ namespace EasyNetQ.IntegrationTests.PubSub
 
             using (await bus.PubSub.SubscribeAsync<Message>(subscriptionId, messagesSink.Receive, timeoutCts.Token))
             {
-                await bus.PubSub.PublishBatchInParallelAsync(messages, timeoutCts.Token).ConfigureAwait(false);
+                await bus.PubSub.PublishBatchInParallelAsync(messages, timeoutCts.Token);
 
-                await messagesSink.WaitAllReceivedAsync(timeoutCts.Token).ConfigureAwait(false);
+                await messagesSink.WaitAllReceivedAsync(timeoutCts.Token);
                 messagesSink.ReceivedMessages.Should().BeEquivalentTo(messages);
             }
         }

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_topic.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_topic.cs
@@ -54,15 +54,15 @@ namespace EasyNetQ.IntegrationTests.PubSub
             {
                 await bus.PubSub.PublishBatchAsync(
                     firstTopicMessages, x => x.WithTopic("first"), cts.Token
-                ).ConfigureAwait(false);
+                );
                 await bus.PubSub.PublishBatchAsync(
                     secondTopicMessages, x => x.WithTopic("second"), cts.Token
-                ).ConfigureAwait(false);
+                );
 
                 await Task.WhenAll(
                     firstTopicMessagesSink.WaitAllReceivedAsync(cts.Token),
                     secondTopicMessagesSink.WaitAllReceivedAsync(cts.Token)
-                ).ConfigureAwait(false);
+                );
 
                 firstTopicMessagesSink.ReceivedMessages.Should().Equal(firstTopicMessages);
                 secondTopicMessagesSink.ReceivedMessages.Should().Equal(secondTopicMessages);

--- a/Source/EasyNetQ.IntegrationTests/RabbitMQFixture.cs
+++ b/Source/EasyNetQ.IntegrationTests/RabbitMQFixture.cs
@@ -54,10 +54,8 @@ namespace EasyNetQ.IntegrationTests
 
         private async Task DisposeAsync(CancellationToken cancellationToken)
         {
-            await dockerProxy.StopContainerAsync(Configuration.RabbitMqHostName, cancellationToken)
-                ;
-            await dockerProxy.RemoveContainerAsync(Configuration.RabbitMqHostName, cancellationToken)
-                ;
+            await dockerProxy.StopContainerAsync(Configuration.RabbitMqHostName, cancellationToken);
+            await dockerProxy.RemoveContainerAsync(Configuration.RabbitMqHostName, cancellationToken);
             if (dockerEngineOsPlatform == OSPlatform.Linux || dockerEngineOsPlatform == OSPlatform.OSX)
                 await dockerProxy.DeleteNetworkAsync(dockerNetworkName, cancellationToken);
         }
@@ -72,8 +70,7 @@ namespace EasyNetQ.IntegrationTests
         {
             var rabbitMQDockerImageName = Configuration.RabbitMQDockerImageName(dockerEngineOsPlatform);
             var rabbitMQDockerImageTag = Configuration.RabbitMQDockerImageTag(dockerEngineOsPlatform);
-            await dockerProxy.PullImageAsync(rabbitMQDockerImageName, rabbitMQDockerImageTag, cancellationToken)
-                ;
+            await dockerProxy.PullImageAsync(rabbitMQDockerImageName, rabbitMQDockerImageTag, cancellationToken);
             return $"{rabbitMQDockerImageName}:{rabbitMQDockerImageTag}";
         }
 
@@ -91,10 +88,8 @@ namespace EasyNetQ.IntegrationTests
             var envVars = new List<string> {$"RABBITMQ_DEFAULT_VHOST={Configuration.RabbitMqVirtualHostName}"};
             var containerId = await dockerProxy
                 .CreateContainerAsync(
-                    rabbitMQDockerImage, Configuration.RabbitMqHostName, portMappings, dockerNetworkName, envVars,
-                    cancellationToken
-                )
-                ;
+                    rabbitMQDockerImage, Configuration.RabbitMqHostName, portMappings, dockerNetworkName, envVars, cancellationToken
+                );
             await dockerProxy.StartContainerAsync(containerId, cancellationToken);
             return containerId;
         }
@@ -114,8 +109,7 @@ namespace EasyNetQ.IntegrationTests
         {
             try
             {
-                return await ManagementClient.IsAliveAsync(Configuration.RabbitMqVirtualHost, cancellationToken)
-                    ;
+                return await ManagementClient.IsAliveAsync(Configuration.RabbitMqVirtualHost, cancellationToken);
             }
             catch (OperationCanceledException)
             {

--- a/Source/EasyNetQ.IntegrationTests/RabbitMQFixture.cs
+++ b/Source/EasyNetQ.IntegrationTests/RabbitMQFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -30,21 +30,21 @@ namespace EasyNetQ.IntegrationTests
         public async Task InitializeAsync()
         {
             using var cts = new CancellationTokenSource(InitializationTimeout);
-            dockerEngineOsPlatform = await dockerProxy.GetDockerEngineOsAsync(cts.Token).ConfigureAwait(false);
+            dockerEngineOsPlatform = await dockerProxy.GetDockerEngineOsAsync(cts.Token);
             dockerNetworkName = dockerEngineOsPlatform == OSPlatform.Windows ? null : "bridgeWhaleNet";
-            await DisposeAsync(cts.Token).ConfigureAwait(false);
-            await CreateNetworkAsync(cts.Token).ConfigureAwait(false);
-            var rabbitMQDockerImage = await PullImageAsync(cts.Token).ConfigureAwait(false);
-            var containerId = await RunNewContainerAsync(rabbitMQDockerImage, cts.Token).ConfigureAwait(false);
+            await DisposeAsync(cts.Token);
+            await CreateNetworkAsync(cts.Token);
+            var rabbitMQDockerImage = await PullImageAsync(cts.Token);
+            var containerId = await RunNewContainerAsync(rabbitMQDockerImage, cts.Token);
             if (dockerEngineOsPlatform == OSPlatform.Windows)
-                Host = await dockerProxy.GetContainerIpAsync(containerId, cts.Token).ConfigureAwait(false);
+                Host = await dockerProxy.GetContainerIpAsync(containerId, cts.Token);
             ManagementClient = new ManagementClient(Host, Configuration.RabbitMqUser, Configuration.RabbitMqPassword);
             await WaitForRabbitMqReadyAsync(cts.Token);
         }
 
         public async Task DisposeAsync()
         {
-            await DisposeAsync(default).ConfigureAwait(false);
+            await DisposeAsync(default);
         }
 
         public void Dispose()
@@ -55,17 +55,17 @@ namespace EasyNetQ.IntegrationTests
         private async Task DisposeAsync(CancellationToken cancellationToken)
         {
             await dockerProxy.StopContainerAsync(Configuration.RabbitMqHostName, cancellationToken)
-                .ConfigureAwait(false);
+                ;
             await dockerProxy.RemoveContainerAsync(Configuration.RabbitMqHostName, cancellationToken)
-                .ConfigureAwait(false);
+                ;
             if (dockerEngineOsPlatform == OSPlatform.Linux || dockerEngineOsPlatform == OSPlatform.OSX)
-                await dockerProxy.DeleteNetworkAsync(dockerNetworkName, cancellationToken).ConfigureAwait(false);
+                await dockerProxy.DeleteNetworkAsync(dockerNetworkName, cancellationToken);
         }
 
         private async Task CreateNetworkAsync(CancellationToken cancellationToken)
         {
             if (dockerEngineOsPlatform == OSPlatform.Linux || dockerEngineOsPlatform == OSPlatform.OSX)
-                await dockerProxy.CreateNetworkAsync(dockerNetworkName, cancellationToken).ConfigureAwait(false);
+                await dockerProxy.CreateNetworkAsync(dockerNetworkName, cancellationToken);
         }
 
         private async Task<string> PullImageAsync(CancellationToken cancellationToken)
@@ -73,7 +73,7 @@ namespace EasyNetQ.IntegrationTests
             var rabbitMQDockerImageName = Configuration.RabbitMQDockerImageName(dockerEngineOsPlatform);
             var rabbitMQDockerImageTag = Configuration.RabbitMQDockerImageTag(dockerEngineOsPlatform);
             await dockerProxy.PullImageAsync(rabbitMQDockerImageName, rabbitMQDockerImageTag, cancellationToken)
-                .ConfigureAwait(false);
+                ;
             return $"{rabbitMQDockerImageName}:{rabbitMQDockerImageTag}";
         }
 
@@ -94,8 +94,8 @@ namespace EasyNetQ.IntegrationTests
                     rabbitMQDockerImage, Configuration.RabbitMqHostName, portMappings, dockerNetworkName, envVars,
                     cancellationToken
                 )
-                .ConfigureAwait(false);
-            await dockerProxy.StartContainerAsync(containerId, cancellationToken).ConfigureAwait(false);
+                ;
+            await dockerProxy.StartContainerAsync(containerId, cancellationToken);
             return containerId;
         }
 
@@ -104,9 +104,9 @@ namespace EasyNetQ.IntegrationTests
             while (true)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                if (await IsRabbitMqReadyAsync(cancellationToken).ConfigureAwait(false))
+                if (await IsRabbitMqReadyAsync(cancellationToken))
                     return;
-                await Task.Delay(500, cancellationToken).ConfigureAwait(false);
+                await Task.Delay(500, cancellationToken);
             }
         }
 
@@ -115,7 +115,7 @@ namespace EasyNetQ.IntegrationTests
             try
             {
                 return await ManagementClient.IsAliveAsync(Configuration.RabbitMqVirtualHost, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
             }
             catch (OperationCanceledException)
             {

--- a/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_polymorphic.cs
+++ b/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_polymorphic.cs
@@ -38,12 +38,12 @@ namespace EasyNetQ.IntegrationTests.Rpc
             {
                 var bunnyResponse = await bus.Rpc.RequestAsync<Request, Response>(
                     new BunnyRequest(42), cts.Token
-                ).ConfigureAwait(false);
+                );
                 bunnyResponse.Should().Be(new BunnyResponse(42));
 
                 var rabbitResponse = await bus.Rpc.RequestAsync<Request, Response>(
                     new RabbitRequest(42), cts.Token
-                ).ConfigureAwait(false);
+                );
                 rabbitResponse.Should().Be(new RabbitResponse(42));
             }
         }

--- a/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_default_options.cs
+++ b/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_default_options.cs
@@ -38,7 +38,7 @@ namespace EasyNetQ.IntegrationTests.Rpc
             {
                 await Assert.ThrowsAsync<EasyNetQResponderException>(
                     () => bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token)
-                ).ConfigureAwait(false);
+                );
             }
         }
 
@@ -50,7 +50,7 @@ namespace EasyNetQ.IntegrationTests.Rpc
             using (await bus.Rpc.RespondAsync<Request, Response>(x => new Response(x.Id), cts.Token))
             {
                 var response = await bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token)
-                    .ConfigureAwait(false);
+                    ;
                 response.Should().Be(new Response(42));
             }
         }
@@ -62,20 +62,20 @@ namespace EasyNetQ.IntegrationTests.Rpc
 
             using (await bus.Rpc.RespondAsync<Request, Response>(x => Task.FromResult(new Response(x.Id)), cts.Token))
             {
-                await bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token).ConfigureAwait(false);
+                await bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token);
 
-                await rmqFixture.ManagementClient.KillAllConnectionsAsync(cts.Token).ConfigureAwait(false);
+                await rmqFixture.ManagementClient.KillAllConnectionsAsync(cts.Token);
 
                 try
                 {
-                    await bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token).ConfigureAwait(false);
+                    await bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token);
                 }
                 catch (Exception)
                 {
                     // The crunch to deal with the race when Rpc has not handled reconnection yet
                 }
 
-                await bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token).ConfigureAwait(false);
+                await bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token);
             }
         }
     }

--- a/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_legacy_options.cs
+++ b/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_legacy_options.cs
@@ -37,7 +37,7 @@ namespace EasyNetQ.IntegrationTests.Rpc
             {
                 var exception = await Assert.ThrowsAsync<EasyNetQResponderException>(
                     () => bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token)
-                ).ConfigureAwait(false);
+                );
                 exception.Message.Should().Be("Oops");
             }
         }
@@ -50,7 +50,7 @@ namespace EasyNetQ.IntegrationTests.Rpc
             using (await bus.Rpc.RespondAsync<Request, Response>(x => new Response(x.Id), cts.Token))
             {
                 var response = await bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token)
-                    .ConfigureAwait(false);
+                    ;
                 response.Should().Be(new Response(42));
             }
         }

--- a/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_publish_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_publish_confirms.cs
@@ -34,7 +34,7 @@ namespace EasyNetQ.IntegrationTests.Rpc
             {
                 await Assert.ThrowsAsync<EasyNetQResponderException>(
                     () => bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token)
-                ).ConfigureAwait(false);
+                );
             }
         }
 
@@ -46,7 +46,7 @@ namespace EasyNetQ.IntegrationTests.Rpc
             using (await bus.Rpc.RespondAsync<Request, Response>(x => new Response(x.Id), cts.Token))
             {
                 var response = await bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token)
-                    .ConfigureAwait(false);
+                    ;
                 response.Should().Be(new Response(42));
             }
         }

--- a/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_dead_letter_exchange.cs
+++ b/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_dead_letter_exchange.cs
@@ -37,10 +37,9 @@ namespace EasyNetQ.IntegrationTests.Scheduler
 
             using (await bus.PubSub.SubscribeAsync<Message>(subscriptionId, messagesSink.Receive, cts.Token))
             {
-                await bus.Scheduler.FuturePublishBatchAsync(messages, TimeSpan.FromSeconds(5), "#", cts.Token)
-                    .ConfigureAwait(false);
+                await bus.Scheduler.FuturePublishBatchAsync(messages, TimeSpan.FromSeconds(5), "#", cts.Token);
 
-                await messagesSink.WaitAllReceivedAsync(cts.Token).ConfigureAwait(false);
+                await messagesSink.WaitAllReceivedAsync(cts.Token);
                 messagesSink.ReceivedMessages.Should().Equal(messages);
             }
         }

--- a/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_dead_letter_exchange_with_publish_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_dead_letter_exchange_with_publish_confirms.cs
@@ -39,10 +39,9 @@ namespace EasyNetQ.IntegrationTests.Scheduler
 
             using (await bus.PubSub.SubscribeAsync<Message>(subscriptionId, messagesSink.Receive, cts.Token))
             {
-                await bus.Scheduler.FuturePublishBatchAsync(messages, TimeSpan.FromSeconds(5), "#", cts.Token)
-                    .ConfigureAwait(false);
+                await bus.Scheduler.FuturePublishBatchAsync(messages, TimeSpan.FromSeconds(5), "#", cts.Token);
 
-                await messagesSink.WaitAllReceivedAsync(cts.Token).ConfigureAwait(false);
+                await messagesSink.WaitAllReceivedAsync(cts.Token);
                 messagesSink.ReceivedMessages.Should().Equal(messages);
             }
         }

--- a/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_dead_letter_exchange_with_topic.cs
+++ b/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_dead_letter_exchange_with_topic.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EasyNetQ.IntegrationTests.Utils;
@@ -41,12 +41,12 @@ namespace EasyNetQ.IntegrationTests.Scheduler
                 await Task.WhenAll(
                     bus.Scheduler.FuturePublishBatchAsync(firstTopicMessages, TimeSpan.FromSeconds(5), "first", cts.Token),
                     bus.Scheduler.FuturePublishBatchAsync(secondTopicMessages, TimeSpan.FromSeconds(5), "second", cts.Token)
-                ).ConfigureAwait(false);
+                );
 
                 await Task.WhenAll(
                     firstTopicMessagesSink.WaitAllReceivedAsync(cts.Token),
                     secondTopicMessagesSink.WaitAllReceivedAsync(cts.Token)
-                ).ConfigureAwait(false);
+                );
 
                 firstTopicMessagesSink.ReceivedMessages.Should().Equal(firstTopicMessages);
                 secondTopicMessagesSink.ReceivedMessages.Should().Equal(secondTopicMessages);

--- a/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_delayed_exchange.cs
+++ b/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_delayed_exchange.cs
@@ -37,10 +37,9 @@ namespace EasyNetQ.IntegrationTests.Scheduler
 
             using (await bus.PubSub.SubscribeAsync<Message>(subscriptionId, messagesSink.Receive, cts.Token))
             {
-                await bus.Scheduler.FuturePublishBatchAsync(messages, TimeSpan.FromSeconds(5), "#", cts.Token)
-                    .ConfigureAwait(false);
+                await bus.Scheduler.FuturePublishBatchAsync(messages, TimeSpan.FromSeconds(5), "#", cts.Token);
 
-                await messagesSink.WaitAllReceivedAsync(cts.Token).ConfigureAwait(false);
+                await messagesSink.WaitAllReceivedAsync(cts.Token);
                 messagesSink.ReceivedMessages.Should().Equal(messages);
             }
         }

--- a/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_delayed_exchange_with_publish_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/Scheduler/When_future_publish_using_delayed_exchange_with_publish_confirms.cs
@@ -38,10 +38,9 @@ namespace EasyNetQ.IntegrationTests.Scheduler
 
             using (await bus.PubSub.SubscribeAsync<Message>(subscriptionId, messagesSink.Receive, cts.Token))
             {
-                await bus.Scheduler.FuturePublishBatchAsync(messages, TimeSpan.FromSeconds(5), "#", cts.Token)
-                    .ConfigureAwait(false);
+                await bus.Scheduler.FuturePublishBatchAsync(messages, TimeSpan.FromSeconds(5), "#", cts.Token);
 
-                await messagesSink.WaitAllReceivedAsync(cts.Token).ConfigureAwait(false);
+                await messagesSink.WaitAllReceivedAsync(cts.Token);
                 messagesSink.ReceivedMessages.Should().Equal(messages);
             }
         }

--- a/Source/EasyNetQ.IntegrationTests/SendReceive/When_send_receive_with_default_options.cs
+++ b/Source/EasyNetQ.IntegrationTests/SendReceive/When_send_receive_with_default_options.cs
@@ -38,9 +38,9 @@ namespace EasyNetQ.IntegrationTests.SendReceive
                 await bus.SendReceive.ReceiveAsync(queue, x => x.Add<Message>(messagesSink.Receive), cts.Token)
             )
             {
-                await bus.SendReceive.SendBatchAsync(queue, messages, cts.Token).ConfigureAwait(false);
+                await bus.SendReceive.SendBatchAsync(queue, messages, cts.Token);
 
-                await messagesSink.WaitAllReceivedAsync(cts.Token).ConfigureAwait(false);
+                await messagesSink.WaitAllReceivedAsync(cts.Token);
                 messagesSink.ReceivedMessages.Should().Equal(messages);
             }
         }
@@ -55,10 +55,10 @@ namespace EasyNetQ.IntegrationTests.SendReceive
             using (await bus.SendReceive.ReceiveAsync(queue, x => x.Add<Message>(messagesSink.Receive), cts.Token))
             {
                 var message = new Message(0);
-                await bus.SendReceive.SendAsync(queue, message, cts.Token).ConfigureAwait(false);
+                await bus.SendReceive.SendAsync(queue, message, cts.Token);
                 await rmqFixture.ManagementClient.KillAllConnectionsAsync(cts.Token);
-                await bus.SendReceive.SendAsync(queue, message, cts.Token).ConfigureAwait(false);
-                await messagesSink.WaitAllReceivedAsync(cts.Token).ConfigureAwait(false);
+                await bus.SendReceive.SendAsync(queue, message, cts.Token);
+                await messagesSink.WaitAllReceivedAsync(cts.Token);
             }
         }
     }

--- a/Source/EasyNetQ.IntegrationTests/SendReceive/When_send_receive_with_multiple_message_types.cs
+++ b/Source/EasyNetQ.IntegrationTests/SendReceive/When_send_receive_with_multiple_message_types.cs
@@ -42,13 +42,13 @@ namespace EasyNetQ.IntegrationTests.SendReceive
                 )
             )
             {
-                await bus.SendReceive.SendBatchAsync(queue, bunnies, cts.Token).ConfigureAwait(false);
-                await bus.SendReceive.SendBatchAsync(queue, rabbits, cts.Token).ConfigureAwait(false);
+                await bus.SendReceive.SendBatchAsync(queue, bunnies, cts.Token);
+                await bus.SendReceive.SendBatchAsync(queue, rabbits, cts.Token);
 
                 await Task.WhenAll(
                     bunniesSink.WaitAllReceivedAsync(cts.Token),
                     rabbitsSink.WaitAllReceivedAsync(cts.Token)
-                ).ConfigureAwait(false);
+                );
 
                 bunniesSink.ReceivedMessages.Should().Equal(bunnies);
                 rabbitsSink.ReceivedMessages.Should().Equal(rabbits);

--- a/Source/EasyNetQ.IntegrationTests/SendReceive/When_send_receive_with_publish_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/SendReceive/When_send_receive_with_publish_confirms.cs
@@ -36,9 +36,9 @@ namespace EasyNetQ.IntegrationTests.SendReceive
                 await bus.SendReceive.ReceiveAsync(queue, x => x.Add<Message>(messagesSink.Receive), cts.Token)
             )
             {
-                await bus.SendReceive.SendBatchAsync(queue, messages, cts.Token).ConfigureAwait(false);
+                await bus.SendReceive.SendBatchAsync(queue, messages, cts.Token);
 
-                await messagesSink.WaitAllReceivedAsync(cts.Token).ConfigureAwait(false);
+                await messagesSink.WaitAllReceivedAsync(cts.Token);
                 messagesSink.ReceivedMessages.Should().Equal(messages);
             }
         }

--- a/Source/EasyNetQ.IntegrationTests/Utils/BusExtensions.cs
+++ b/Source/EasyNetQ.IntegrationTests/Utils/BusExtensions.cs
@@ -16,7 +16,7 @@ namespace EasyNetQ.IntegrationTests.Utils
             foreach (var message in messages)
                 publishTasks.Add(pubSub.PublishAsync(message, cancellationToken));
 
-            await Task.WhenAll(publishTasks).ConfigureAwait(false);
+            await Task.WhenAll(publishTasks);
         }
 
         public static Task PublishBatchAsync<T>(
@@ -34,7 +34,7 @@ namespace EasyNetQ.IntegrationTests.Utils
         )
         {
             foreach (var message in messages)
-                await pubSub.PublishAsync(message, configuration, cancellationToken).ConfigureAwait(false);
+                await pubSub.PublishAsync(message, configuration, cancellationToken);
         }
 
         public static async Task FuturePublishBatchAsync<T>(
@@ -46,7 +46,7 @@ namespace EasyNetQ.IntegrationTests.Utils
         )
         {
             foreach (var message in messages)
-                await scheduler.FuturePublishAsync(message, delay, c => c.WithTopic(topic), cancellationToken).ConfigureAwait(false);
+                await scheduler.FuturePublishAsync(message, delay, c => c.WithTopic(topic), cancellationToken);
         }
 
         public static async Task SendBatchAsync<T>(
@@ -57,7 +57,7 @@ namespace EasyNetQ.IntegrationTests.Utils
         )
         {
             foreach (var message in messages)
-                await sendReceive.SendAsync(queue, message, cancellationToken).ConfigureAwait(false);
+                await sendReceive.SendAsync(queue, message, cancellationToken);
         }
     }
 }

--- a/Source/EasyNetQ.IntegrationTests/Utils/ManagementClientExtensions.cs
+++ b/Source/EasyNetQ.IntegrationTests/Utils/ManagementClientExtensions.cs
@@ -15,14 +15,14 @@ namespace EasyNetQ.IntegrationTests.Utils
             var wasClosed = false;
             do
             {
-                var connections = await client.GetConnectionsAsync(cancellationToken).ConfigureAwait(false);
+                var connections = await client.GetConnectionsAsync(cancellationToken);
                 foreach (var connection in connections)
                 {
-                    await client.CloseConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
+                    await client.CloseConnectionAsync(connection, cancellationToken);
                     wasClosed = true;
                 }
 
-                await Task.Delay(500, cancellationToken).ConfigureAwait(false);
+                await Task.Delay(500, cancellationToken);
             } while (!wasClosed);
         }
     }

--- a/Source/EasyNetQ.IntegrationTests/Utils/MessagesSink.cs
+++ b/Source/EasyNetQ.IntegrationTests/Utils/MessagesSink.cs
@@ -41,7 +41,7 @@ namespace EasyNetQ.IntegrationTests.Utils
                 )
             )
             {
-                await allMessagedReceived.Task.ConfigureAwait(false);
+                await allMessagedReceived.Task;
             }
         }
 

--- a/Source/EasyNetQ.Tests.Tasks/Tasks/TestSimpleService.cs
+++ b/Source/EasyNetQ.Tests.Tasks/Tasks/TestSimpleService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -94,7 +94,7 @@ namespace EasyNetQ.Tests.Tasks
 
         private static async Task<T> RunDelayed<T>(int millisecondsDelay, Func<T> func)
         {
-            await Task.Delay(millisecondsDelay).ConfigureAwait(false);
+            await Task.Delay(millisecondsDelay);
             return func();
         }
 

--- a/Source/EasyNetQ.Tests/ClientCommandDispatcherTests/When_an_action_is_invoked_that_throws_using_multi_channel.cs
+++ b/Source/EasyNetQ.Tests/ClientCommandDispatcherTests/When_an_action_is_invoked_that_throws_using_multi_channel.cs
@@ -1,4 +1,4 @@
-﻿// ReSharper disable InconsistentNaming
+// ReSharper disable InconsistentNaming
 
 using System;
 using System.Threading.Tasks;
@@ -36,7 +36,7 @@ namespace EasyNetQ.Tests.ClientCommandDispatcherTests
         {
             await Assert.ThrowsAsync<CrazyTestOnlyException>(
                 () => dispatcher.InvokeAsync<int>(x => throw new CrazyTestOnlyException(), ChannelDispatchOptions.Default)
-            ).ConfigureAwait(false);
+            );
         }
 
         [Fact]
@@ -44,9 +44,9 @@ namespace EasyNetQ.Tests.ClientCommandDispatcherTests
         {
             await Assert.ThrowsAsync<Exception>(
                 () => dispatcher.InvokeAsync<int>(x => throw new Exception(), ChannelDispatchOptions.Default)
-            ).ConfigureAwait(false);
+            );
 
-            var result = await dispatcher.InvokeAsync(x => 42, ChannelDispatchOptions.Default).ConfigureAwait(false);
+            var result = await dispatcher.InvokeAsync(x => 42, ChannelDispatchOptions.Default);
             result.Should().Be(42);
         }
 

--- a/Source/EasyNetQ.Tests/ClientCommandDispatcherTests/When_an_action_is_invoked_that_throws_using_single_channel.cs
+++ b/Source/EasyNetQ.Tests/ClientCommandDispatcherTests/When_an_action_is_invoked_that_throws_using_single_channel.cs
@@ -36,7 +36,7 @@ namespace EasyNetQ.Tests.ClientCommandDispatcherTests
         {
             await Assert.ThrowsAsync<CrazyTestOnlyException>(
                 () => dispatcher.InvokeAsync<int>(x => throw new CrazyTestOnlyException(), ChannelDispatchOptions.Default)
-            ).ConfigureAwait(false);
+            );
         }
 
         [Fact]
@@ -44,9 +44,9 @@ namespace EasyNetQ.Tests.ClientCommandDispatcherTests
         {
             await Assert.ThrowsAsync<Exception>(
                 () => dispatcher.InvokeAsync<int>(x => throw new Exception(), ChannelDispatchOptions.Default)
-            ).ConfigureAwait(false);
+            );
 
-            var result = await dispatcher.InvokeAsync(x => 42, ChannelDispatchOptions.Default).ConfigureAwait(false);
+            var result = await dispatcher.InvokeAsync(x => 42, ChannelDispatchOptions.Default);
             result.Should().Be(42);
         }
 

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_cancelled.cs
@@ -45,7 +45,7 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
             var handlerTask = handlerRunner.InvokeUserMessageHandlerAsync(context, default)
                 .ContinueWith(async x =>
                 {
-                    var ackStrategy = await x.ConfigureAwait(false);
+                    var ackStrategy = await x;
                     return ackStrategy(channel, 42);
                 }, TaskContinuationOptions.ExecuteSynchronously)
                 .Unwrap();

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_executed.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_executed.cs
@@ -1,4 +1,4 @@
-﻿// ReSharper disable InconsistentNaming
+// ReSharper disable InconsistentNaming
 
 using System;
 using System.Threading.Tasks;
@@ -30,7 +30,7 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
                         deliveredBody = body;
                         deliveredProperties = properties;
                         deliveredInfo = info;
-                    }).ConfigureAwait(false);
+                    });
                     return AckStrategies.Ack;
                 },
                 messageInfo,
@@ -41,7 +41,7 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
             var handlerTask = handlerRunner.InvokeUserMessageHandlerAsync(context, default)
                 .ContinueWith(async x =>
                 {
-                    var ackStrategy = await x.ConfigureAwait(false);
+                    var ackStrategy = await x;
                     return ackStrategy(channel, 42);
                 }, TaskContinuationOptions.ExecuteSynchronously)
                 .Unwrap();

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_failed.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_failed.cs
@@ -43,7 +43,7 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
             var handlerTask = handlerRunner.InvokeUserMessageHandlerAsync(context, default)
                 .ContinueWith(async x =>
                 {
-                    var ackStrategy = await x.ConfigureAwait(false);
+                    var ackStrategy = await x;
                     return ackStrategy(channel, 42);
                 }, TaskContinuationOptions.ExecuteSynchronously)
                 .Unwrap();

--- a/Source/EasyNetQ.Tests/Internals/AsyncLockTests.cs
+++ b/Source/EasyNetQ.Tests/Internals/AsyncLockTests.cs
@@ -18,7 +18,7 @@ namespace EasyNetQ.Tests.Internals
 
             await Assert.ThrowsAnyAsync<OperationCanceledException>(
                 () => mutex.AcquireAsync(cts.Token)
-            ).ConfigureAwait(false);
+            );
         }
 
         [Fact]
@@ -27,13 +27,13 @@ namespace EasyNetQ.Tests.Internals
             using var mutex = new AsyncLock();
             using var cts = new CancellationTokenSource();
 
-            using var releaser = await mutex.AcquireAsync(cts.Token).ConfigureAwait(false);
+            using var releaser = await mutex.AcquireAsync(cts.Token);
 
             cts.CancelAfter(50);
 
             await Assert.ThrowsAnyAsync<OperationCanceledException>(
                 () => mutex.AcquireAsync(cts.Token)
-            ).ConfigureAwait(false);
+            );
         }
     }
 }

--- a/Source/EasyNetQ.Tests/Internals/AsyncQueueTests.cs
+++ b/Source/EasyNetQ.Tests/Internals/AsyncQueueTests.cs
@@ -13,7 +13,7 @@ namespace EasyNetQ.Tests.Internals
         public async Task Should_be_empty_after_dequeue()
         {
             using var queue = new AsyncQueue<int>(new[] {42});
-            var element = await queue.DequeueAsync(CancellationToken.None).ConfigureAwait(false);
+            var element = await queue.DequeueAsync(CancellationToken.None);
             element.Should().Be(42);
             queue.Count.Should().Be(0);
         }
@@ -33,7 +33,7 @@ namespace EasyNetQ.Tests.Internals
             using var dequeueCts = new CancellationTokenSource();
             var dequeueTask = queue.DequeueAsync(dequeueCts.Token);
             var _ = Task.Run(dequeueCts.Cancel, CancellationToken.None);
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => dequeueTask).ConfigureAwait(false);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => dequeueTask);
         }
 
         [Fact]
@@ -46,9 +46,9 @@ namespace EasyNetQ.Tests.Internals
             queue.Enqueue(1);
             queue.Enqueue(2);
             queue.Enqueue(3);
-            (await firstTask.ConfigureAwait(false)).Should().Be(1);
-            (await secondTask.ConfigureAwait(false)).Should().Be(2);
-            (await thirdTask.ConfigureAwait(false)).Should().Be(3);
+            (await firstTask).Should().Be(1);
+            (await secondTask).Should().Be(2);
+            (await thirdTask).Should().Be(3);
             queue.Count.Should().Be(0);
         }
     }

--- a/Source/EasyNetQ.Tests/Internals/TaskExtensionsTests.cs
+++ b/Source/EasyNetQ.Tests/Internals/TaskExtensionsTests.cs
@@ -15,7 +15,7 @@ namespace EasyNetQ.Tests.Internals
              var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
              tcs.AttachCancellation(cts.Token);
              cts.Cancel();
-             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => tcs.Task).ConfigureAwait(false);
+             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => tcs.Task);
         }
     }
 }

--- a/Source/EasyNetQ.Tests/ProducerTests/PublishConfirmationListenerTest.cs
+++ b/Source/EasyNetQ.Tests/ProducerTests/PublishConfirmationListenerTest.cs
@@ -33,10 +33,10 @@ namespace EasyNetQ.Tests.ProducerTests
             eventBus.Publish(MessageConfirmationEvent.Nack(model, DeliveryTag, true));
             await Assert.ThrowsAsync<PublishNackedException>(
                 () => confirmation1.WaitAsync()
-            ).ConfigureAwait(false);
+            );
             await Assert.ThrowsAsync<PublishNackedException>(
                 () => confirmation2.WaitAsync()
-            ).ConfigureAwait(false);
+            );
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace EasyNetQ.Tests.ProducerTests
             eventBus.Publish(MessageConfirmationEvent.Nack(model, DeliveryTag, false));
             await Assert.ThrowsAsync<PublishNackedException>(
                 () => confirmation.WaitAsync()
-            ).ConfigureAwait(false);
+            );
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace EasyNetQ.Tests.ProducerTests
             model.NextPublishSeqNo.Returns(DeliveryTag);
             var confirmation = publishConfirmationListener.CreatePendingConfirmation(model);
             eventBus.Publish(MessageConfirmationEvent.Ack(model, DeliveryTag, false));
-            await confirmation.WaitAsync().ConfigureAwait(false);
+            await confirmation.WaitAsync();
         }
 
         [Fact]
@@ -66,8 +66,8 @@ namespace EasyNetQ.Tests.ProducerTests
             var confirmation1 = publishConfirmationListener.CreatePendingConfirmation(model);
             var confirmation2 = publishConfirmationListener.CreatePendingConfirmation(model);
             eventBus.Publish(MessageConfirmationEvent.Ack(model, DeliveryTag, true));
-            await confirmation1.WaitAsync().ConfigureAwait(false);
-            await confirmation2.WaitAsync().ConfigureAwait(false);
+            await confirmation1.WaitAsync();
+            await confirmation2.WaitAsync();
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace EasyNetQ.Tests.ProducerTests
             using var cts = new CancellationTokenSource(1000);
             await Assert.ThrowsAsync<TaskCanceledException>(
                 () => confirmation.WaitAsync(cts.Token)
-            ).ConfigureAwait(false);
+            );
         }
 
         [Fact]
@@ -89,11 +89,11 @@ namespace EasyNetQ.Tests.ProducerTests
             eventBus.Publish(new ChannelRecoveredEvent(model));
             await Assert.ThrowsAsync<PublishInterruptedException>(
                 () => confirmation1.WaitAsync()
-            ).ConfigureAwait(false);
+            );
 
             var confirmation2 = publishConfirmationListener.CreatePendingConfirmation(model);
             eventBus.Publish(MessageConfirmationEvent.Ack(model, DeliveryTag, false));
-            await confirmation2.WaitAsync().ConfigureAwait(false);
+            await confirmation2.WaitAsync();
         }
 
         [Fact]
@@ -118,7 +118,7 @@ namespace EasyNetQ.Tests.ProducerTests
             );
             await Assert.ThrowsAsync<PublishReturnedException>(
                 () => confirmation1.WaitAsync()
-            ).ConfigureAwait(false);
+            );
         }
     }
 }

--- a/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent_but_an_exception_is_thrown_by_responder.cs
+++ b/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent_but_an_exception_is_thrown_by_responder.cs
@@ -48,8 +48,8 @@ namespace EasyNetQ.Tests.ProducerTests
                     throw new TimeoutException();
 
                 DeliverMessage(null);
-                await task.ConfigureAwait(false);
-            }).ConfigureAwait(false);
+                await task;
+            });
         }
 
         [Fact]
@@ -68,8 +68,8 @@ namespace EasyNetQ.Tests.ProducerTests
 
                 DeliverMessage("Why you are so bad with me?");
 
-                await task.ConfigureAwait(false);
-            }).ConfigureAwait(false); // ,"Why you are so bad with me?"
+                await task;
+            }); // ,"Why you are so bad with me?"
         }
 
         private void DeliverMessage(string exceptionMessage)

--- a/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent_but_an_exception_is_thrown_by_responder.cs
+++ b/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent_but_an_exception_is_thrown_by_responder.cs
@@ -69,7 +69,7 @@ namespace EasyNetQ.Tests.ProducerTests
                 DeliverMessage("Why you are so bad with me?");
 
                 await task;
-            }); // ,"Why you are so bad with me?"
+            });
         }
 
         private void DeliverMessage(string exceptionMessage)

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -307,7 +307,7 @@ namespace EasyNetQ
 
         #endregion
 
-        #region Exchage, Queue, Binding
+        #region Exchange, Queue, Binding
 
         /// <inheritdoc />
         public Task<IQueue> QueueDeclareAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Since there is no synchronization context for test projects I suggest to remove all `ConfigureAwait(false)` to simplify code base.