### PR TITLE
Fix Argument exception is thrown on dispose of consumer dispatcher

### DIFF
--- a/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerDispatcher.cs
@@ -26,10 +26,10 @@ namespace EasyNetQ.Consumer
                     while (!cancellation.IsCancellationRequested)
                         try
                         {
-                            BlockingCollection<Action>.TakeFromAny(
-                                blockingCollections, out var action, cancellation.Token
-                            );
-                            action();
+                            if (BlockingCollection<Action>.TryTakeFromAny(blockingCollections, out var action, -1, cancellation.Token) >= 0)
+                            {
+                                action();
+                            }
                         }
                         catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
                         {


### PR DESCRIPTION
We have the issue when doing deployment of our service we get ArgumentExceptions in the log because it is thrown from .TakeFromAny - so i replaced it with TryTakeFromAny which does not throw this exception