### PR TITLE
Extend subscription configuration action with subscriptionInfo argument

### DIFF
--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async_with_subscription_configuration_action.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async_with_subscription_configuration_action.cs
@@ -25,7 +25,7 @@ namespace EasyNetQ.Tests.AutoSubscriberTests
             var autoSubscriber = new AutoSubscriber(bus, "my_app")
                 {
                         ConfigureSubscriptionConfiguration =
-                                c => c.WithAutoDelete()
+                                (c, info) => c.WithAutoDelete()
                                     .WithExpires(10)
                                     .WithPrefetchCount(10)
                                     .WithPriority(10)

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async_with_subscription_configuration_action_and_attribute.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async_with_subscription_configuration_action_and_attribute.cs
@@ -24,7 +24,7 @@ namespace EasyNetQ.Tests.AutoSubscriberTests
             var autoSubscriber = new AutoSubscriber(bus, "my_app")
             {
                 ConfigureSubscriptionConfiguration =
-                    c => c.WithAutoDelete(false)
+                    (c, info) => c.WithAutoDelete(false)
                         .WithExpires(11)
                         .WithPrefetchCount(11)
                         .WithPriority(11)

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_subscription_configuration_action.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_subscription_configuration_action.cs
@@ -25,7 +25,7 @@ namespace EasyNetQ.Tests.AutoSubscriberTests
             var autoSubscriber = new AutoSubscriber(bus, "my_app")
                 {
                         ConfigureSubscriptionConfiguration =
-                                c => c.WithAutoDelete()
+                            (c, info) => c.WithAutoDelete()
                                     .WithExpires(10)
                                     .WithPrefetchCount(10)
                                     .WithPriority(10)

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_subscription_configuration_action_and_attribute.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_subscription_configuration_action_and_attribute.cs
@@ -25,7 +25,7 @@ namespace EasyNetQ.Tests.AutoSubscriberTests
             var autoSubscriber = new AutoSubscriber(bus, "my_app")
                 {
                         ConfigureSubscriptionConfiguration =
-                                c => c.WithAutoDelete(false)
+                            (c, info) => c.WithAutoDelete(false)
                                     .WithExpires(11)
                                     .WithPrefetchCount(11)
                                     .WithPriority(11)

--- a/Source/EasyNetQ/AutoSubscribe/AutoSubscriber.cs
+++ b/Source/EasyNetQ/AutoSubscribe/AutoSubscriber.cs
@@ -47,7 +47,7 @@ namespace EasyNetQ.AutoSubscribe
         /// the values may be overriden for particular consumer
         /// methods by using an <see cref="SubscriptionConfigurationAttribute"/>.
         /// </summary>
-        public Action<ISubscriptionConfiguration> ConfigureSubscriptionConfiguration { protected get; set; }
+        public Action<ISubscriptionConfiguration, AutoSubscriberConsumerInfo> ConfigureSubscriptionConfiguration { protected get; set; }
 
         public AutoSubscriber(IBus bus, string subscriptionIdPrefix)
         {
@@ -58,7 +58,7 @@ namespace EasyNetQ.AutoSubscribe
             SubscriptionIdPrefix = subscriptionIdPrefix;
             AutoSubscriberMessageDispatcher = new DefaultAutoSubscriberMessageDispatcher();
             GenerateSubscriptionId = DefaultSubscriptionIdGenerator;
-            ConfigureSubscriptionConfiguration = subscriptionConfiguration => { };
+            ConfigureSubscriptionConfiguration = (subscriptionConfiguration, consumerInfo) => { };
         }
 
         /// <summary>
@@ -166,7 +166,7 @@ namespace EasyNetQ.AutoSubscribe
         {
             return sc =>
                 {
-                    ConfigureSubscriptionConfiguration(sc);
+                    ConfigureSubscriptionConfiguration(sc, subscriptionInfo);
                     TopicInfo(subscriptionInfo)(sc);
                     AutoSubscriberConsumerInfo(subscriptionInfo)(sc);
                 };


### PR DESCRIPTION
Make autosubscriber more flexible to allow pre-define subscription configuration based on subscription info