### PR TITLE
Add .NET Core 3.1 support

### DIFF
--- a/Source/EasyNetQ.DI.Autofac/EasyNetQ.DI.Autofac.csproj
+++ b/Source/EasyNetQ.DI.Autofac/EasyNetQ.DI.Autofac.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>An adaptor to allow EasyNetQ to use Autofac as its internal IoC container</Description>
     <PackageIconUrl>https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/gh-pages/design/logo_design.png</PackageIconUrl>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp3.1</TargetFrameworks>
     <PackageTags>Autofac;RabbitMQ;Messaging;AMQP;C#</PackageTags>
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/Source/EasyNetQ.DI.LightInject/EasyNetQ.DI.LightInject.csproj
+++ b/Source/EasyNetQ.DI.LightInject/EasyNetQ.DI.LightInject.csproj
@@ -5,7 +5,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/gh-pages/design/logo_design.png</PackageIconUrl>
     <PackageTags>LightInject;RabbitMQ;Messaging;AMQP;C#</PackageTags>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp3.1</TargetFrameworks>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/Source/EasyNetQ.DI.Microsoft/EasyNetQ.DI.Microsoft.csproj
+++ b/Source/EasyNetQ.DI.Microsoft/EasyNetQ.DI.Microsoft.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <Description>An adaptor to allow EasyNetQ to use Microsoft.Extensions.DependencyInjection as its internal IoC container</Description>
     <PackageIconUrl>https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/gh-pages/design/logo_design.png</PackageIconUrl>
     <PackageTags>DependencyInjection;RabbitMQ;Messaging;AMQP;C#</PackageTags>
@@ -14,8 +14,22 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
   </PropertyGroup>
+
+  <Choose>
+    <When Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
+      </ItemGroup>
+    </When>
+
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="GitVersionTask" Version="5.0.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/EasyNetQ.DI.Ninject/EasyNetQ.DI.Ninject.csproj
+++ b/Source/EasyNetQ.DI.Ninject/EasyNetQ.DI.Ninject.csproj
@@ -5,7 +5,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/gh-pages/design/logo_design.png</PackageIconUrl>
     <PackageTags>Ninject;RabbitMQ;Messaging;AMQP;C#</PackageTags>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp3.1</TargetFrameworks>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/Source/EasyNetQ.DI.SimpleInjector/EasyNetQ.DI.SimpleInjector.csproj
+++ b/Source/EasyNetQ.DI.SimpleInjector/EasyNetQ.DI.SimpleInjector.csproj
@@ -5,7 +5,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/gh-pages/design/logo_design.png</PackageIconUrl>
     <PackageTags>SimpleInjector;RabbitMQ;Messaging;AMQP;C#</PackageTags>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp3.1</TargetFrameworks>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/Source/EasyNetQ.DI.StructureMap/EasyNetQ.DI.StructureMap.csproj
+++ b/Source/EasyNetQ.DI.StructureMap/EasyNetQ.DI.StructureMap.csproj
@@ -5,7 +5,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/gh-pages/design/logo_design.png</PackageIconUrl>
     <PackageTags>StructureMap;RabbitMQ;Messaging;AMQP;C#</PackageTags>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp3.1</TargetFrameworks>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
+++ b/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
@@ -39,7 +39,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/EasyNetQ.DI.Windsor/EasyNetQ.DI.Windsor.csproj
+++ b/Source/EasyNetQ.DI.Windsor/EasyNetQ.DI.Windsor.csproj
@@ -5,7 +5,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/gh-pages/design/logo_design.png</PackageIconUrl>
     <PackageTags>Windsor;RabbitMQ;Messaging;AMQP;C#</PackageTags>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp3.1</TargetFrameworks>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/Source/EasyNetQ.Scheduler.Mongo.Core/EasyNetQ.Scheduler.Mongo.Core.csproj
+++ b/Source/EasyNetQ.Scheduler.Mongo.Core/EasyNetQ.Scheduler.Mongo.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>EasyNetQ.Scheduler.Mongo.Core</Description>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\EasyNetQ\EasyNetQ.csproj" />

--- a/Source/EasyNetQ.Tests.Common/EasyNetQ.Tests.Common.csproj
+++ b/Source/EasyNetQ.Tests.Common/EasyNetQ.Tests.Common.csproj
@@ -4,7 +4,7 @@
     <Description>Common library for EasyNetQ.Tests</Description>
     <AssemblyTitle>EasyNetQ.Tests.Common</AssemblyTitle>
     <VersionPrefix>2.0.4-netcore1435</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>EasyNetQ.Tests.Common</AssemblyName>
     <PackageId>EasyNetQ.Tests.Common</PackageId>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Source/EasyNetQ/EasyNetQ.csproj
+++ b/Source/EasyNetQ/EasyNetQ.csproj
@@ -6,7 +6,7 @@
     <PackageTags>RabbitMQ;Messaging;AMQP;C#</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/gh-pages/design/logo_design.png</PackageIconUrl>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp3.1</TargetFrameworks>
     <DefineConstants>$(DefineConstants);LIBLOG_PUBLIC;LIBLOG_PORTABLE</DefineConstants>
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
Resolves #1126 

Adds support, to required projects, for .NET Core 3.1. 

Also uses conditional logic on the `EasyNetQ.DI.Microsoft` project to choose the `Microsoft.Extensions.DependencyInjection` version based on the target runtime. This is more of a defensive action in anticipation for any unexpected behaviour when referencing `Microsoft.Extensions.DependencyInjection 3.1.8` in a .NET Core 2.x app. This is something I've experienced many times when migrating across versions of ASP.NET Core; I can remove this and target 3.1.8 if it's not desirable.

.NET Core 3.1 is supported until Q4 2022, I'll see you all then 😅