### PR TITLE
Enhanced support of amqp connection string

### DIFF
--- a/Source/EasyNetQ.Tests/ConnectionString/AmqpConnectionStringParserTests.cs
+++ b/Source/EasyNetQ.Tests/ConnectionString/AmqpConnectionStringParserTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using EasyNetQ.ConnectionString;
+using FluentAssertions;
+using Xunit;
+
+namespace EasyNetQ.Tests.ConnectionString
+{
+    public class AmqpConnectionStringParserTests
+    {
+        private readonly AmqpConnectionStringParser connectionStringParser = new AmqpConnectionStringParser();
+
+        [Theory]
+        [MemberData(nameof(AppendixAExamples))]
+        public void Should_parse_amqp(AmqpSpecification spec)
+        {
+            var configuration = connectionStringParser.Parse(spec.Uri);
+
+            configuration.Should().BeEquivalentTo(spec.Configuration);
+        }
+
+        public static IEnumerable<object[]> AppendixAExamples()
+        {
+            object[] Spec(string uri, ConnectionConfiguration configuration)
+            {
+                return new[] {new AmqpSpecification(uri, configuration)};
+            }
+
+            yield return Spec(
+                "amqp://user:pass@host:10000/vhost",
+                new ConnectionConfiguration
+                {
+                    Hosts = new[] {new HostConfiguration {Host = "host", Port = 10000}},
+                    VirtualHost = "vhost",
+                    UserName = "user",
+                    Password = "pass"
+                }
+            );
+            yield return Spec(
+                "amqp://",
+                new ConnectionConfiguration
+                {
+                    Hosts = new[] {new HostConfiguration {Host = "localhost", Port = 5672}},
+                }
+            );
+            yield return Spec(
+                "amqp://host",
+                new ConnectionConfiguration
+                {
+                    Hosts = new[] {new HostConfiguration {Host = "host", Port = 5672}},
+                }
+            );
+            yield return Spec(
+                "amqps://host",
+                new ConnectionConfiguration
+                {
+                    Hosts = new[]
+                    {
+                        new HostConfiguration {Host = "host", Port = 5671, Ssl = {Enabled = true, ServerName = "host"}}
+                    },
+                }
+            );
+            yield return Spec(
+                "amqp://?" + string.Join(
+                    "&",
+                    "persistentMessages=false",
+                    "prefetchCount=2",
+                    "timeout=1",
+                    "publisherConfirms=true",
+                    "name=unit-test",
+                    "mandatoryPublish=true",
+                    "connectIntervalAttempt=2",
+                    "product=product",
+                    "platform=platform"
+                ),
+                new ConnectionConfiguration
+                {
+                    Hosts = new[] {new HostConfiguration {Host = "localhost", Port = 5672}},
+                    PersistentMessages = false,
+                    PrefetchCount = 2,
+                    Timeout = TimeSpan.FromSeconds(1),
+                    ConnectIntervalAttempt = TimeSpan.FromSeconds(2),
+                    PublisherConfirms = true,
+                    Name = "unit-test",
+                    MandatoryPublish = true,
+                    Product = "product",
+                    Platform = "platform"
+                }
+            );
+        }
+
+        public class AmqpSpecification
+        {
+            public readonly string Uri;
+            public readonly ConnectionConfiguration Configuration;
+
+            public AmqpSpecification(string uri, ConnectionConfiguration configuration)
+            {
+                Uri = uri;
+                Configuration = configuration;
+            }
+
+            public override string ToString() => $"Uri: {Uri}";
+        }
+    }
+}

--- a/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
+++ b/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
@@ -21,7 +21,7 @@ namespace EasyNetQ.Tests.ConnectionString
         private const string connectionString =
             "virtualHost=Copa;username=Copa;host=192.168.1.1;password=abc_xyz;port=12345;" +
             "requestedHeartbeat=3;prefetchcount=2;timeout=12;publisherConfirms=true;" +
-            "name=unit-test";
+            "name=unit-test;mandatoryPublish=true";
 
         [Theory]
         [MemberData(nameof(AppendixAExamples))]
@@ -82,18 +82,19 @@ namespace EasyNetQ.Tests.ConnectionString
         [Fact]
         public void Should_correctly_parse_connection_string()
         {
-            var connectionConfiguration = connectionStringParser.Parse(connectionString);
+            var configuration = connectionStringParser.Parse(connectionString);
 
-            connectionConfiguration.Hosts.First().Host.Should().Be("192.168.1.1");
-            connectionConfiguration.VirtualHost.Should().Be("Copa");
-            connectionConfiguration.UserName.Should().Be("Copa");
-            connectionConfiguration.Password.Should().Be("abc_xyz");
-            connectionConfiguration.Port.Should().Be(12345);
-            connectionConfiguration.RequestedHeartbeat.Should().Be(TimeSpan.FromSeconds(3));
-            connectionConfiguration.PrefetchCount.Should().Be(2);
-            connectionConfiguration.Timeout.Should().Be(TimeSpan.FromSeconds(12));
-            connectionConfiguration.PublisherConfirms.Should().BeTrue();
-            connectionConfiguration.Name.Should().Be("unit-test");
+            configuration.Hosts.First().Host.Should().Be("192.168.1.1");
+            configuration.VirtualHost.Should().Be("Copa");
+            configuration.UserName.Should().Be("Copa");
+            configuration.Password.Should().Be("abc_xyz");
+            configuration.Port.Should().Be(12345);
+            configuration.RequestedHeartbeat.Should().Be(TimeSpan.FromSeconds(3));
+            configuration.PrefetchCount.Should().Be(2);
+            configuration.Timeout.Should().Be(TimeSpan.FromSeconds(12));
+            configuration.PublisherConfirms.Should().BeTrue();
+            configuration.Name.Should().Be("unit-test");
+            configuration.MandatoryPublish.Should().BeTrue();
         }
 
         [Fact]

--- a/Source/EasyNetQ/ConnectionConfiguration.cs
+++ b/Source/EasyNetQ/ConnectionConfiguration.cs
@@ -80,6 +80,7 @@ namespace EasyNetQ
         /// <summary>
         ///     The connection string used for the connection.
         /// </summary>
+        [Obsolete("Will be removed in next major version")]
         public Uri AmqpConnectionString { get; set; }
 
         /// <summary>

--- a/Source/EasyNetQ/ConnectionString/AmqpConnectionStringParser.cs
+++ b/Source/EasyNetQ/ConnectionString/AmqpConnectionStringParser.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Security.Authentication;
+using EasyNetQ.Internals;
+
+namespace EasyNetQ.ConnectionString
+{
+    using UpdateConfiguration = Func<ConnectionConfiguration, Dictionary<string, string>, ConnectionConfiguration>;
+
+    /// <inheritdoc />
+    public class AmqpConnectionStringParser : IConnectionStringParser
+    {
+        private static readonly IReadOnlyCollection<string> SupportedSchemes = new[] {"amqp", "amqps"};
+
+        private static readonly List<UpdateConfiguration> Parsers = new List<UpdateConfiguration>
+        {
+            BuildKeyValueParser("requestedHeartbeat", c => TimeSpan.FromSeconds(int.Parse(c)), c => c.RequestedHeartbeat),
+            BuildKeyValueParser("prefetchCount", ushort.Parse, c => c.PrefetchCount),
+            BuildKeyValueParser("timeout", c => TimeSpan.FromSeconds(int.Parse(c)), c => c.Timeout),
+            BuildKeyValueParser("connectIntervalAttempt", c => TimeSpan.FromSeconds(int.Parse(c)), c => c.ConnectIntervalAttempt),
+            BuildKeyValueParser("publisherConfirms", bool.Parse, c => c.PublisherConfirms),
+            BuildKeyValueParser("persistentMessages", bool.Parse, c => c.PersistentMessages),
+            BuildKeyValueParser("product", c => c, c => c.Product),
+            BuildKeyValueParser("platform", c => c, c => c.Platform),
+            BuildKeyValueParser("name", c => c, c => c.Name),
+            BuildKeyValueParser("mandatoryPublish", bool.Parse, c => c.MandatoryPublish)
+        };
+
+        /// <inheritdoc />
+        public ConnectionConfiguration Parse(string connectionString)
+        {
+            var uri = new Uri(connectionString, UriKind.Absolute);
+            if (!SupportedSchemes.Contains(uri.Scheme))
+                throw new ArgumentException($"Wrong scheme in AMQP URI: {uri.Scheme}");
+
+            var secured = uri.Scheme == "amqps";
+            var host = new HostConfiguration
+            {
+                Host = string.IsNullOrEmpty(uri.Host) ? "localhost" : uri.Host,
+                Port = uri.Port == -1
+                    ? (ushort) (secured ? ConnectionConfiguration.DefaultAmqpsPort : ConnectionConfiguration.DefaultPort)
+                    : (ushort) uri.Port,
+            };
+            if (secured)
+            {
+                host.Ssl.Enabled = true;
+                host.Ssl.Version = SslProtocols.None;
+                host.Ssl.ServerName = host.Host;
+            }
+
+            var configuration = new ConnectionConfiguration();
+            configuration.Hosts.Add(host);
+
+            var userInfo = uri.UserInfo;
+            if (!string.IsNullOrEmpty(userInfo))
+            {
+                var userPass = userInfo.Split(':');
+                if (userPass.Length > 2)
+                    throw new ArgumentException($"Bad user info in AMQP URI: {userInfo}");
+
+                configuration.UserName = Uri.EscapeUriString(userPass[0]);
+                if (userPass.Length == 2) configuration.Password = Uri.EscapeUriString(userPass[1]);
+            }
+
+            if (uri.Segments.Length > 2)
+                throw new ArgumentException($"Multiple segments in path of AMQP URI: {string.Join(", ", uri.Segments)}");
+
+            if (uri.Segments.Length == 2) configuration.VirtualHost = Uri.EscapeUriString(uri.Segments[1]);
+
+            var query = uri.ParseQuery();
+            return Parsers.Aggregate(configuration, (current, parser) => parser(current, query));
+        }
+
+        private static UpdateConfiguration BuildKeyValueParser<T>(
+            string keyName,
+            Func<string, T> valueParser,
+            Expression<Func<ConnectionConfiguration, T>> getter
+        )
+        {
+            return (configuration, keyValues) =>
+            {
+                if (keyValues != null && keyValues.TryGetValue(keyName, out var keyValue))
+                {
+                    var parsedValue = valueParser(keyValue);
+                    CreateSetter(getter)(configuration, parsedValue);
+                }
+
+                return configuration;
+            };
+        }
+
+        private static Action<ConnectionConfiguration, T> CreateSetter<T>(Expression<Func<ConnectionConfiguration, T>> getter)
+        {
+            return CreateSetter<ConnectionConfiguration, T>(getter);
+        }
+
+        /// <summary>
+        /// Stolen from SO:
+        /// http://stackoverflow.com/questions/4596453/create-an-actiont-to-set-a-property-when-i-am-provided-with-the-linq-expres
+        /// </summary>
+        /// <typeparam name="TContaining"></typeparam>
+        /// <typeparam name="TProperty"></typeparam>
+        /// <param name="getter"></param>
+        /// <returns></returns>
+        private static Action<TContaining, TProperty> CreateSetter<TContaining, TProperty>(Expression<Func<TContaining, TProperty>> getter)
+        {
+            Preconditions.CheckNotNull(getter, "getter");
+
+            var memberEx = getter.Body as MemberExpression;
+
+            Preconditions.CheckNotNull(memberEx, "getter", "Body is not a member-expression.");
+
+            var property = memberEx.Member as PropertyInfo;
+
+            Preconditions.CheckNotNull(property, "getter", "Member is not a property.");
+            Preconditions.CheckTrue(property.CanWrite, "getter", "Member is not a writeable property.");
+
+#if !NETFX
+            return (Action<TContaining, TProperty>) property.GetSetMethod().CreateDelegate(typeof(Action<TContaining, TProperty>));
+
+#else
+            return (Action<TContaining, TProperty>) Delegate.CreateDelegate(typeof(Action<TContaining, TProperty>), property.GetSetMethod());
+#endif
+        }
+    }
+}

--- a/Source/EasyNetQ/ConnectionString/CompositeConnectionStringParser.cs
+++ b/Source/EasyNetQ/ConnectionString/CompositeConnectionStringParser.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace EasyNetQ.ConnectionString
+{
+    internal sealed class CompositeConnectionStringParser : IConnectionStringParser
+    {
+        private readonly AmqpConnectionStringParser amqpConnectionStringParser;
+        private readonly ConnectionStringParser connectionStringParser;
+
+        public CompositeConnectionStringParser(
+            AmqpConnectionStringParser amqpConnectionStringParser,
+            ConnectionStringParser connectionStringParser
+        )
+        {
+            this.amqpConnectionStringParser = amqpConnectionStringParser;
+            this.connectionStringParser = connectionStringParser;
+        }
+
+        public ConnectionConfiguration Parse(string connectionString)
+        {
+            return Uri.TryCreate(connectionString, UriKind.Absolute, out _)
+                ? amqpConnectionStringParser.Parse(connectionString)
+                : connectionStringParser.Parse(connectionString);
+        }
+    }
+}

--- a/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
+++ b/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
@@ -44,7 +44,7 @@ namespace EasyNetQ.ConnectionString
             BuildKeyValueParser("password", Text, c => c.Password),
             BuildKeyValueParser("prefetchCount", UShortNumber, c => c.PrefetchCount),
             BuildKeyValueParser("timeout", TimeSpanSeconds, c => c.Timeout),
-            BuildKeyValueParser("connectTimeoutAttempt", TimeSpanSeconds, c => c.ConnectIntervalAttempt),
+            BuildKeyValueParser("connectIntervalAttempt", TimeSpanSeconds, c => c.ConnectIntervalAttempt),
             BuildKeyValueParser("publisherConfirms", Bool, c => c.PublisherConfirms),
             BuildKeyValueParser("persistentMessages", Bool, c => c.PersistentMessages),
             BuildKeyValueParser("product", Text, c => c.Product),

--- a/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
+++ b/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
@@ -44,6 +44,7 @@ namespace EasyNetQ.ConnectionString
             BuildKeyValueParser("password", Text, c => c.Password),
             BuildKeyValueParser("prefetchCount", UShortNumber, c => c.PrefetchCount),
             BuildKeyValueParser("timeout", TimeSpanSeconds, c => c.Timeout),
+            BuildKeyValueParser("connectTimeoutAttempt", TimeSpanSeconds, c => c.ConnectIntervalAttempt),
             BuildKeyValueParser("publisherConfirms", Bool, c => c.PublisherConfirms),
             BuildKeyValueParser("persistentMessages", Bool, c => c.PersistentMessages),
             BuildKeyValueParser("product", Text, c => c.Product),

--- a/Source/EasyNetQ/ConnectionString/ConnectionStringParser.cs
+++ b/Source/EasyNetQ/ConnectionString/ConnectionStringParser.cs
@@ -1,0 +1,27 @@
+using System.Linq;
+using EasyNetQ.Sprache;
+
+namespace EasyNetQ.ConnectionString
+{
+    /// <inheritdoc />
+    public class ConnectionStringParser : IConnectionStringParser
+    {
+        /// <inheritdoc />
+        public ConnectionConfiguration Parse(string connectionString)
+        {
+            try
+            {
+                var updater = ConnectionStringGrammar.ParseConnectionString(connectionString);
+                var configuration = updater.Aggregate(
+                    new ConnectionConfiguration(), (current, updateFunction) => updateFunction(current)
+                );
+                configuration.SetDefaultProperties();
+                return configuration;
+            }
+            catch (ParseException parseException)
+            {
+                throw new EasyNetQException("Connection String {0}", parseException.Message);
+            }
+        }
+    }
+}

--- a/Source/EasyNetQ/ConnectionString/IConnectionStringParser.cs
+++ b/Source/EasyNetQ/ConnectionString/IConnectionStringParser.cs
@@ -1,7 +1,4 @@
-﻿using System.Linq;
-using EasyNetQ.Sprache;
-
-namespace EasyNetQ.ConnectionString
+﻿namespace EasyNetQ.ConnectionString
 {
     /// <summary>
     ///     Allows to create ConnectionConfiguration from string
@@ -14,26 +11,5 @@ namespace EasyNetQ.ConnectionString
         /// <param name="connectionString">The connection string</param>
         /// <returns>Parsed ConnectionConfiguration</returns>
         ConnectionConfiguration Parse(string connectionString);
-    }
-
-    /// <inheritdoc />
-    public class ConnectionStringParser : IConnectionStringParser
-    {
-        /// <inheritdoc />
-        public ConnectionConfiguration Parse(string connectionString)
-        {
-            try
-            {
-                var updater = ConnectionStringGrammar.ParseConnectionString(connectionString);
-                var configuration = updater.Aggregate(new ConnectionConfiguration(),
-                    (current, updateFunction) => updateFunction(current));
-                configuration.SetDefaultProperties();
-                return configuration;
-            }
-            catch (ParseException parseException)
-            {
-                throw new EasyNetQException("Connection String {0}", parseException.Message);
-            }
-        }
     }
 }

--- a/Source/EasyNetQ/EasyNetQ.csproj
+++ b/Source/EasyNetQ/EasyNetQ.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
   <PropertyGroup>
     <Title>EasyNetQ</Title>
-    <Description>A Nice .NET API for RabbitMQ</Description>
+    <Description>A nice .NET API for RabbitMQ</Description>
     <PackageTags>RabbitMQ;Messaging;AMQP;C#</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/gh-pages/design/logo_design.png</PackageIconUrl>
     <LangVersion>latest</LangVersion>

--- a/Source/EasyNetQ/EasyNetQ.csproj
+++ b/Source/EasyNetQ/EasyNetQ.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
   <PropertyGroup>
     <Title>EasyNetQ</Title>
-    <Description>EasyNetQ</Description>
+    <Description>A Nice .NET API for RabbitMQ</Description>
     <PackageTags>RabbitMQ;Messaging;AMQP;C#</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/EasyNetQ/EasyNetQ/gh-pages/design/logo_design.png</PackageIconUrl>
     <LangVersion>latest</LangVersion>

--- a/Source/EasyNetQ/Internals/UriExtensions.cs
+++ b/Source/EasyNetQ/Internals/UriExtensions.cs
@@ -31,7 +31,7 @@ namespace EasyNetQ.Internals
             {
                 var keyValueParts = keyValue.Split(new[] {'='}, StringSplitOptions.RemoveEmptyEntries);
                 if (keyValueParts.Length == 2)
-                    query.Add(keyValueParts[0], keyValueParts[1]);
+                    query.Add(Uri.UnescapeDataString(keyValueParts[0]), Uri.UnescapeDataString(keyValueParts[1]));
             }
             return query;
         }

--- a/Source/EasyNetQ/Internals/UriExtensions.cs
+++ b/Source/EasyNetQ/Internals/UriExtensions.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+
+namespace EasyNetQ.Internals
+{
+    /// <summary>
+    ///     This is an internal API that supports the EasyNetQ infrastructure and not subject to
+    ///     the same compatibility as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new EasyNetQ release.
+    /// </summary>
+    public static class UriExtensions
+    {
+        /// <summary>
+        /// Parse a query string
+        /// There could be multiple values per key, but it doesn't matter for configuration purposes
+        /// </summary>
+        /// <returns>A collection of parsed keys and values, null if there are no entries.</returns>
+        public static Dictionary<string, string> ParseQuery(this Uri uri)
+        {
+            var queryString = uri.Query;
+            if (string.IsNullOrEmpty(queryString) || queryString == "?")
+                return null;
+
+            if (queryString[0] == '?')
+                queryString = queryString.Substring(1);
+
+            var query = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+            var keyValues = queryString.Split(new[] {'&'}, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var keyValue in keyValues)
+            {
+                var keyValueParts = keyValue.Split(new[] {'='}, StringSplitOptions.RemoveEmptyEntries);
+                if (keyValueParts.Length == 2)
+                    query.Add(keyValueParts[0], keyValueParts[1]);
+            }
+            return query;
+        }
+    }
+}

--- a/Source/EasyNetQ/ServiceRegisterExtensions.cs
+++ b/Source/EasyNetQ/ServiceRegisterExtensions.cs
@@ -26,7 +26,9 @@ namespace EasyNetQ
             // Note: IConnectionConfiguration gets registered when RabbitHutch.CreateBus(..) is run.
             // default service registration
             serviceRegister
-                .Register<IConnectionStringParser, ConnectionStringParser>()
+                .Register<IConnectionStringParser>(
+                    x => new CompositeConnectionStringParser(new AmqpConnectionStringParser(), new ConnectionStringParser())
+                )
                 .Register<ISerializer>(_ => new JsonSerializer())
                 .Register<IConventions, Conventions>()
                 .Register<IEventBus, EventBus>()
@@ -43,11 +45,7 @@ namespace EasyNetQ
                 .Register<IHandlerRunner, HandlerRunner>()
                 .Register<IInternalConsumerFactory, InternalConsumerFactory>()
                 .Register<IConsumerFactory, ConsumerFactory>()
-                .Register(c =>
-                {
-                    var connectionConfiguration = c.Resolve<ConnectionConfiguration>();
-                    return ConnectionFactoryFactory.CreateConnectionFactory(connectionConfiguration);
-                })
+                .Register(c => ConnectionFactoryFactory.CreateConnectionFactory(c.Resolve<ConnectionConfiguration>()))
                 .Register<IClientCommandDispatcher, SingleChannelClientCommandDispatcher>()
                 .Register<IPersistentConnection, PersistentConnection>()
                 .Register<IPersistentChannelFactory, PersistentChannelFactory>()


### PR DESCRIPTION
Fixes #1151, #1086

The goal of the PR is to support this kind of connection string:

`amqp://user:pass@host:10000/vhost?persistentMessages=false&prefetchCount=2&timeout=1&publisherConfirms=true&name=unit-test&mandatoryPublish=true&connectIntervalAttempt=2&product=product&platform=platform`

`ConnectionConfiguration.AmqpConnectionString` is deprecated and preferred way to get `ConnectionConfiguration` from amqp connection string is to call `ConnectionStringParser.Parse`.

Also it fixes support of `amqps` connection strings.