### PR TITLE
Dispose only via DI container

### DIFF
--- a/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_polymorphic.cs
+++ b/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_polymorphic.cs
@@ -26,7 +26,7 @@ namespace EasyNetQ.IntegrationTests.Rpc
         {
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
-            using (await bus.Rpc.RespondAsync<Request, Response>(x =>
+            using var _ = await bus.Rpc.RespondAsync<Request, Response>(x =>
             {
                 return x switch
                 {
@@ -34,18 +34,17 @@ namespace EasyNetQ.IntegrationTests.Rpc
                     RabbitRequest r => new RabbitResponse(r.Id),
                     _ => throw new ArgumentOutOfRangeException(nameof(x), x, null)
                 };
-            }, cts.Token))
-            {
-                var bunnyResponse = await bus.Rpc.RequestAsync<Request, Response>(
-                    new BunnyRequest(42), cts.Token
-                );
-                bunnyResponse.Should().Be(new BunnyResponse(42));
+            }, cts.Token);
 
-                var rabbitResponse = await bus.Rpc.RequestAsync<Request, Response>(
-                    new RabbitRequest(42), cts.Token
-                );
-                rabbitResponse.Should().Be(new RabbitResponse(42));
-            }
+            var bunnyResponse = await bus.Rpc.RequestAsync<Request, Response>(
+                new BunnyRequest(42), cts.Token
+            );
+            bunnyResponse.Should().Be(new BunnyResponse(42));
+
+            var rabbitResponse = await bus.Rpc.RequestAsync<Request, Response>(
+                new RabbitRequest(42), cts.Token
+            );
+            rabbitResponse.Should().Be(new RabbitResponse(42));
         }
     }
 }

--- a/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_default_options.cs
+++ b/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_default_options.cs
@@ -30,10 +30,9 @@ namespace EasyNetQ.IntegrationTests.Rpc
         {
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
-            using var _ =
-                await bus.Rpc.RespondAsync<Request, Response>(
-                    x => Task.FromException<Response>(new RequestFailedException()), cts.Token
-                );
+            using var _ = await bus.Rpc.RespondAsync<Request, Response>(
+                x => Task.FromException<Response>(new RequestFailedException()), cts.Token
+            );
 
             await Assert.ThrowsAsync<EasyNetQResponderException>(
                 () => bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token)

--- a/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_legacy_options.cs
+++ b/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_legacy_options.cs
@@ -29,17 +29,14 @@ namespace EasyNetQ.IntegrationTests.Rpc
         {
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
-            using (
-                await bus.Rpc.RespondAsync<Request, Response>(x =>
-                        Task.FromException<Response>(new RequestFailedException("Oops")), cts.Token
-                )
-            )
-            {
-                var exception = await Assert.ThrowsAsync<EasyNetQResponderException>(
-                    () => bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token)
-                );
-                exception.Message.Should().Be("Oops");
-            }
+            using var _ = await bus.Rpc.RespondAsync<Request, Response>(x =>
+                    Task.FromException<Response>(new RequestFailedException("Oops")), cts.Token
+            );
+
+            var exception = await Assert.ThrowsAsync<EasyNetQResponderException>(
+                () => bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token)
+            );
+            exception.Message.Should().Be("Oops");
         }
 
         [Fact]

--- a/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_publish_confirms.cs
+++ b/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_publish_confirms.cs
@@ -26,16 +26,13 @@ namespace EasyNetQ.IntegrationTests.Rpc
         {
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
-            using (
-                await bus.Rpc.RespondAsync<Request, Response>(
-                    x => Task.FromException<Response>(new RequestFailedException()), cts.Token
-                )
-            )
-            {
-                await Assert.ThrowsAsync<EasyNetQResponderException>(
-                    () => bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token)
-                );
-            }
+            using var _ = await bus.Rpc.RespondAsync<Request, Response>(
+                x => Task.FromException<Response>(new RequestFailedException()), cts.Token
+            );
+
+            await Assert.ThrowsAsync<EasyNetQResponderException>(
+                () => bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token)
+            );
         }
 
         [Fact]
@@ -43,11 +40,10 @@ namespace EasyNetQ.IntegrationTests.Rpc
         {
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
-            using (await bus.Rpc.RespondAsync<Request, Response>(x => new Response(x.Id), cts.Token))
-            {
-                var response = await bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token);
-                response.Should().Be(new Response(42));
-            }
+            using var _ = await bus.Rpc.RespondAsync<Request, Response>(x => new Response(x.Id), cts.Token);
+
+            var response = await bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token);
+            response.Should().Be(new Response(42));
         }
     }
 }

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing.cs
@@ -34,10 +34,7 @@ namespace EasyNetQ.Tests.AutoSubscriberTests
             autoSubscriber.Subscribe(new[] { typeof(MyConsumer), typeof(MyGenericAbstractConsumer<>) });
         }
 
-        public void Dispose()
-        {
-            mockBuilder.Bus.Dispose();
-        }
+        public void Dispose() => mockBuilder.Dispose();
 
         [Fact]
         public void Should_have_declared_the_queues()

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing.cs
@@ -14,7 +14,8 @@ namespace EasyNetQ.Tests.AutoSubscriberTests
 {
     public class When_autosubscribing : IDisposable
     {
-        private MockBuilder mockBuilder;
+        private readonly MockBuilder mockBuilder;
+        private readonly IDisposable subscription;
 
         private const string expectedQueueName1 =
             "EasyNetQ.Tests.AutoSubscriberTests.When_autosubscribing+MessageA, EasyNetQ.Tests_my_app:d7617d39b90b6b695b90c630539a12e2";
@@ -31,10 +32,14 @@ namespace EasyNetQ.Tests.AutoSubscriberTests
             mockBuilder = new MockBuilder();
 
             var autoSubscriber = new AutoSubscriber(mockBuilder.Bus, "my_app");
-            autoSubscriber.Subscribe(new[] { typeof(MyConsumer), typeof(MyGenericAbstractConsumer<>) });
+            subscription = autoSubscriber.Subscribe(new[] { typeof(MyConsumer), typeof(MyGenericAbstractConsumer<>) });
         }
 
-        public void Dispose() => mockBuilder.Dispose();
+        public void Dispose()
+        {
+            subscription.Dispose();
+            mockBuilder.Dispose();
+        }
 
         [Fact]
         public void Should_have_declared_the_queues()

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async.cs
@@ -33,10 +33,7 @@ namespace EasyNetQ.Tests.AutoSubscriberTests
             autoSubscriber.Subscribe(new[] { typeof(MyAsyncConsumer) });
         }
 
-        public void Dispose()
-        {
-            mockBuilder.Bus.Dispose();
-        }
+        public void Dispose() => mockBuilder.Dispose();
 
         [Fact]
         public void Should_have_declared_the_queues()

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_async.cs
@@ -14,6 +14,7 @@ namespace EasyNetQ.Tests.AutoSubscriberTests
     public class When_autosubscribing_async : IDisposable
     {
         private readonly MockBuilder mockBuilder;
+        private readonly IDisposable subscription;
 
         private const string expectedQueueName1 =
             "EasyNetQ.Tests.AutoSubscriberTests.When_autosubscribing_async+MessageA, EasyNetQ.Tests_my_app:9a0467719db423b16b7e5c35d25b877c";
@@ -26,14 +27,17 @@ namespace EasyNetQ.Tests.AutoSubscriberTests
 
         public When_autosubscribing_async()
         {
-            //mockBuilder = new MockBuilder();
             mockBuilder = new MockBuilder();
 
             var autoSubscriber = new AutoSubscriber(mockBuilder.Bus, "my_app");
-            autoSubscriber.Subscribe(new[] { typeof(MyAsyncConsumer) });
+            subscription = autoSubscriber.Subscribe(new[] { typeof(MyAsyncConsumer) });
         }
 
-        public void Dispose() => mockBuilder.Dispose();
+        public void Dispose()
+        {
+            subscription.Dispose();
+            mockBuilder.Dispose();
+        }
 
         [Fact]
         public void Should_have_declared_the_queues()

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_explicit_implementation.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_explicit_implementation.cs
@@ -14,7 +14,8 @@ namespace EasyNetQ.Tests.AutoSubscriberTests
 {
     public class When_autosubscribing_with_explicit_implementation : IDisposable
     {
-        private MockBuilder mockBuilder;
+        private readonly MockBuilder mockBuilder;
+        private readonly IDisposable subscription;
 
         private const string expectedQueueName1 =
             "EasyNetQ.Tests.AutoSubscriberTests.When_autosubscribing_with_explicit_implementation+MessageA, EasyNetQ.Tests_my_app:fe528c6fdb14f1b5a2216b78ab508ca9";
@@ -31,10 +32,14 @@ namespace EasyNetQ.Tests.AutoSubscriberTests
             mockBuilder = new MockBuilder();
 
             var autoSubscriber = new AutoSubscriber(mockBuilder.Bus, "my_app");
-            autoSubscriber.Subscribe(new[] { typeof(MyConsumer), typeof(MyGenericAbstractConsumer<>) });
+            subscription = autoSubscriber.Subscribe(new[] { typeof(MyConsumer), typeof(MyGenericAbstractConsumer<>) });
         }
 
-        public void Dispose() => mockBuilder.Dispose();
+        public void Dispose()
+        {
+            subscription.Dispose();
+            mockBuilder.Dispose();
+        }
 
         [Fact]
         public void Should_have_declared_the_queues()

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_explicit_implementation.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_autosubscribing_with_explicit_implementation.cs
@@ -34,10 +34,7 @@ namespace EasyNetQ.Tests.AutoSubscriberTests
             autoSubscriber.Subscribe(new[] { typeof(MyConsumer), typeof(MyGenericAbstractConsumer<>) });
         }
 
-        public void Dispose()
-        {
-            mockBuilder.Bus.Dispose();
-        }
+        public void Dispose() => mockBuilder.Dispose();
 
         [Fact]
         public void Should_have_declared_the_queues()

--- a/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
@@ -45,10 +45,7 @@ namespace EasyNetQ.Tests.ConsumeTests
             AdditionalSetUp();
         }
 
-        public void Dispose()
-        {
-            MockBuilder.Bus.Dispose();
-        }
+        public void Dispose() => MockBuilder.Dispose();
 
         protected abstract void AdditionalSetUp();
 

--- a/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
@@ -25,6 +25,7 @@ namespace EasyNetQ.Tests.ConsumeTests
         // populated when a message is delivered
         protected IBasicProperties OriginalProperties;
         protected byte[] OriginalBody;
+        private IDisposable consumer;
         protected const ulong DeliverTag = 10101;
 
         public ConsumerTestBase()
@@ -45,7 +46,11 @@ namespace EasyNetQ.Tests.ConsumeTests
             AdditionalSetUp();
         }
 
-        public void Dispose() => MockBuilder.Dispose();
+        public void Dispose()
+        {
+            consumer?.Dispose();
+            MockBuilder.Dispose();
+        }
 
         protected abstract void AdditionalSetUp();
 
@@ -53,7 +58,7 @@ namespace EasyNetQ.Tests.ConsumeTests
         {
             ConsumerWasInvoked = false;
             var queue = new Queue("my_queue", false);
-            MockBuilder.Bus.Advanced.Consume(queue, (body, properties, messageInfo) =>
+            consumer = MockBuilder.Bus.Advanced.Consume(queue, (body, properties, messageInfo) =>
             {
                 return Task.Run(() =>
                 {

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_has_multiple_handlers.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_has_multiple_handlers.cs
@@ -47,10 +47,7 @@ namespace EasyNetQ.Tests.ConsumeTests
             if (!countdownEvent.Wait(5000)) throw new TimeoutException();
         }
 
-        public void Dispose()
-        {
-            mockBuilder.Bus.Dispose();
-        }
+        public void Dispose() => mockBuilder.Dispose();
 
         private readonly MockBuilder mockBuilder;
 

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_has_multiple_handlers.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_has_multiple_handlers.cs
@@ -21,7 +21,7 @@ namespace EasyNetQ.Tests.ConsumeTests
 
             var countdownEvent = new CountdownEvent(3);
 
-            mockBuilder.Bus.Advanced.Consume(
+            consumer = mockBuilder.Bus.Advanced.Consume(
                 queue,
                 x => x.Add<MyMessage>((message, info) =>
                     {
@@ -47,13 +47,18 @@ namespace EasyNetQ.Tests.ConsumeTests
             if (!countdownEvent.Wait(5000)) throw new TimeoutException();
         }
 
-        public void Dispose() => mockBuilder.Dispose();
+        public void Dispose()
+        {
+            consumer.Dispose();
+            mockBuilder.Dispose();
+        }
 
         private readonly MockBuilder mockBuilder;
 
         private MyMessage myMessageResult;
         private MyOtherMessage myOtherMessageResult;
         private IAnimal animalResult;
+        private readonly IDisposable consumer;
 
         private void Deliver<T>(T message) where T : class
         {

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_received.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_received.cs
@@ -17,12 +17,13 @@ namespace EasyNetQ.Tests.ConsumeTests
         private readonly MockBuilder mockBuilder;
         private MyMessage deliveredMyMessage;
         private MyOtherMessage deliveredMyOtherMessage;
+        private readonly IDisposable receiver;
 
         public When_a_message_is_received()
         {
             mockBuilder = new MockBuilder();
 
-            mockBuilder.SendReceive.Receive("the_queue", x => x
+            receiver = mockBuilder.SendReceive.Receive("the_queue", x => x
                 .Add<MyMessage>(message => deliveredMyMessage = message)
                 .Add<MyOtherMessage>(message => deliveredMyOtherMessage = message));
 
@@ -33,7 +34,8 @@ namespace EasyNetQ.Tests.ConsumeTests
 
         public void Dispose()
         {
-            mockBuilder.Bus.Dispose();
+            receiver.Dispose();
+            mockBuilder.Dispose();
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_nack_received_from_the_message_handler.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_nack_received_from_the_message_handler.cs
@@ -19,14 +19,6 @@ namespace EasyNetQ.Tests.ConsumeTests
         {
             MockBuilder.Channels[0].Received().BasicNack(DeliverTag, false, true);
         }
-
-        [Fact]
-        public void Should_dispose_of_the_consumer_error_strategy_when_the_bus_is_disposed()
-        {
-            MockBuilder.Bus.Dispose();
-
-            ConsumerErrorStrategy.Received().Dispose();
-        }
     }
 }
 

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
@@ -17,6 +17,7 @@ namespace EasyNetQ.Tests.ConsumeTests
         private readonly IConventions conventions;
         private readonly ITypeNameSerializer typeNameSerializer;
         private readonly ISerializer serializer;
+        private readonly IDisposable responder;
 
         public When_a_responder_is_cancelled()
         {
@@ -26,7 +27,7 @@ namespace EasyNetQ.Tests.ConsumeTests
             typeNameSerializer = mockBuilder.Bus.Advanced.Container.Resolve<ITypeNameSerializer>();
             serializer = mockBuilder.Bus.Advanced.Container.Resolve<ISerializer>();
 
-            mockBuilder.Rpc.Respond<RpcRequest, RpcResponse>(m =>
+            responder = mockBuilder.Rpc.Respond<RpcRequest, RpcResponse>(m =>
             {
                 var tcs = new TaskCompletionSource<RpcResponse>();
                 tcs.SetCanceled();
@@ -38,7 +39,8 @@ namespace EasyNetQ.Tests.ConsumeTests
 
         public void Dispose()
         {
-            mockBuilder.Bus.Dispose();
+            responder.Dispose();
+            mockBuilder.Dispose();
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_an_error_occurs_in_the_message_handler.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_an_error_occurs_in_the_message_handler.cs
@@ -39,14 +39,6 @@ namespace EasyNetQ.Tests.ConsumeTests
         {
             MockBuilder.Channels[0].Received().BasicAck(DeliverTag, false);
         }
-
-        [Fact]
-        public void Should_dispose_of_the_consumer_error_strategy_when_the_bus_is_disposed()
-        {
-            MockBuilder.Bus.Dispose();
-
-            ConsumerErrorStrategy.Received().Dispose();
-        }
     }
 }
 

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_cancellation_of_message_handler_occurs.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_cancellation_of_message_handler_occurs.cs
@@ -27,24 +27,19 @@ namespace EasyNetQ.Tests.ConsumeTests
         public void Should_invoke_the_cancellation_strategy()
         {
             ConsumerErrorStrategy.Received().HandleConsumerCancelled(
-               Arg.Is<ConsumerExecutionContext>(args => args.ReceivedInfo.ConsumerTag == ConsumerTag &&
-                                                        args.ReceivedInfo.DeliveryTag == DeliverTag &&
-                                                        args.ReceivedInfo.Exchange == "the_exchange" &&
-                                                        args.Body.SequenceEqual(OriginalBody)));
+                Arg.Is<ConsumerExecutionContext>(
+                    args => args.ReceivedInfo.ConsumerTag == ConsumerTag &&
+                            args.ReceivedInfo.DeliveryTag == DeliverTag &&
+                            args.ReceivedInfo.Exchange == "the_exchange" &&
+                            args.Body.SequenceEqual(OriginalBody)
+                )
+            );
         }
 
         [Fact]
         public void Should_ack()
         {
             MockBuilder.Channels[0].Received().BasicAck(DeliverTag, false);
-        }
-
-        [Fact]
-        public void Should_dispose_of_the_consumer_error_strategy_when_the_bus_is_disposed()
-        {
-            MockBuilder.Bus.Dispose();
-
-            ConsumerErrorStrategy.Received().Dispose();
         }
     }
 }

--- a/Source/EasyNetQ.Tests/ConventionsTests.cs
+++ b/Source/EasyNetQ.Tests/ConventionsTests.cs
@@ -219,12 +219,9 @@ namespace EasyNetQ.Tests
             mockBuilder.Rpc.Respond<TestMessage, TestMessage>(t => new TestMessage());
         }
 
-        public void Dispose()
-        {
-            mockBuilder.Bus.Dispose();
-        }
+        public void Dispose() => mockBuilder.Dispose();
 
-        private MockBuilder mockBuilder;
+        private readonly MockBuilder mockBuilder;
 
         [Fact]
         public void Should_correctly_bind_using_new_conventions()

--- a/Source/EasyNetQ.Tests/ConventionsTests.cs
+++ b/Source/EasyNetQ.Tests/ConventionsTests.cs
@@ -216,12 +216,17 @@ namespace EasyNetQ.Tests
 
             mockBuilder = new MockBuilder(x => x.Register<IConventions>(customConventions));
 
-            mockBuilder.Rpc.Respond<TestMessage, TestMessage>(t => new TestMessage());
+            responder = mockBuilder.Rpc.Respond<TestMessage, TestMessage>(t => new TestMessage());
         }
 
-        public void Dispose() => mockBuilder.Dispose();
+        public void Dispose()
+        {
+            responder.Dispose();
+            mockBuilder.Dispose();
+        }
 
         private readonly MockBuilder mockBuilder;
+        private readonly IDisposable responder;
 
         [Fact]
         public void Should_correctly_bind_using_new_conventions()

--- a/Source/EasyNetQ.Tests/Mocking/MockBuilder.cs
+++ b/Source/EasyNetQ.Tests/Mocking/MockBuilder.cs
@@ -8,7 +8,7 @@ using RabbitMQ.Client;
 
 namespace EasyNetQ.Tests.Mocking
 {
-    public class MockBuilder
+    public class MockBuilder : IDisposable
     {
         private readonly IBasicProperties basicProperties = new BasicProperties();
         private readonly IBus bus;
@@ -76,10 +76,6 @@ namespace EasyNetQ.Tests.Mocking
                 registerServices(x);
                 x.Register(connectionFactory);
             });
-
-            bus.Should().NotBeNull();
-            bus.Advanced.Should().NotBeNull();
-            bus.Advanced.Container.Should().NotBeNull();
         }
 
         public IPubSub PubSub => bus.PubSub;
@@ -109,5 +105,7 @@ namespace EasyNetQ.Tests.Mocking
         public IPersistentConnection PersistentConnection => ServiceProvider.Resolve<IPersistentConnection>();
 
         public List<string> ConsumerQueueNames => consumerQueueNames;
+
+        public void Dispose() => bus.Dispose();
     }
 }

--- a/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent.cs
+++ b/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent.cs
@@ -38,10 +38,7 @@ namespace EasyNetQ.Tests.ProducerTests
             responseMessage = task.GetAwaiter().GetResult();
         }
 
-        public void Dispose()
-        {
-            mockBuilder.Bus.Dispose();
-        }
+        public void Dispose() => mockBuilder.Dispose();
 
         private readonly MockBuilder mockBuilder;
         private readonly TestResponseMessage responseMessage;

--- a/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent.cs
+++ b/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent.cs
@@ -20,7 +20,7 @@ namespace EasyNetQ.Tests.ProducerTests
             var correlationId = Guid.NewGuid().ToString();
             mockBuilder = new MockBuilder(
                 c => c.Register<ICorrelationIdGenerationStrategy>(
-                    _ => new StaticCorrelationIdGenerationStrategy(correlationId)
+                    x => new StaticCorrelationIdGenerationStrategy(correlationId)
                 )
             );
 

--- a/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent.cs
+++ b/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent.cs
@@ -26,8 +26,8 @@ namespace EasyNetQ.Tests.ProducerTests
 
             var waiter = new CountdownEvent(2);
 
-            mockBuilder.EventBus.Subscribe<PublishedMessageEvent>(_ => waiter.Signal());
-            mockBuilder.EventBus.Subscribe<StartConsumingSucceededEvent>(_ => waiter.Signal());
+            using var _ = mockBuilder.EventBus.Subscribe<PublishedMessageEvent>(x => waiter.Signal());
+            using var __ = mockBuilder.EventBus.Subscribe<StartConsumingSucceededEvent>(x => waiter.Signal());
 
             var task = mockBuilder.Rpc.RequestAsync<TestRequestMessage, TestResponseMessage>(new TestRequestMessage());
             if (!waiter.Wait(5000))

--- a/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent_but_an_exception_is_thrown_by_responder.cs
+++ b/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent_but_an_exception_is_thrown_by_responder.cs
@@ -24,7 +24,6 @@ namespace EasyNetQ.Tests.ProducerTests
                     _ => new StaticCorrelationIdGenerationStrategy(correlationId)
                 )
             );
-
             requestMessage = new TestRequestMessage();
         }
 
@@ -56,8 +55,8 @@ namespace EasyNetQ.Tests.ProducerTests
             {
                 var waiter = new CountdownEvent(2);
 
-                mockBuilder.EventBus.Subscribe<PublishedMessageEvent>(_ => waiter.Signal());
-                mockBuilder.EventBus.Subscribe<StartConsumingSucceededEvent>(_ => waiter.Signal());
+                using var _ = mockBuilder.EventBus.Subscribe<PublishedMessageEvent>(x => waiter.Signal());
+                using var __ = mockBuilder.EventBus.Subscribe<StartConsumingSucceededEvent>(x => waiter.Signal());
 
                 var task = mockBuilder.Rpc.RequestAsync<TestRequestMessage, TestResponseMessage>(requestMessage);
                 if (!waiter.Wait(5000))

--- a/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent_but_an_exception_is_thrown_by_responder.cs
+++ b/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent_but_an_exception_is_thrown_by_responder.cs
@@ -28,10 +28,7 @@ namespace EasyNetQ.Tests.ProducerTests
             requestMessage = new TestRequestMessage();
         }
 
-        public void Dispose()
-        {
-            mockBuilder.Bus.Dispose();
-        }
+        public void Dispose() => mockBuilder.Dispose();
 
         [Fact]
         public async Task Should_throw_an_EasyNetQResponderException()

--- a/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent_but_an_exception_is_thrown_by_responder.cs
+++ b/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent_but_an_exception_is_thrown_by_responder.cs
@@ -37,8 +37,8 @@ namespace EasyNetQ.Tests.ProducerTests
             {
                 var waiter = new CountdownEvent(2);
 
-                mockBuilder.EventBus.Subscribe<PublishedMessageEvent>(_ => waiter.Signal());
-                mockBuilder.EventBus.Subscribe<StartConsumingSucceededEvent>(_ => waiter.Signal());
+                using var _ = mockBuilder.EventBus.Subscribe<PublishedMessageEvent>(x => waiter.Signal());
+                using var __ = mockBuilder.EventBus.Subscribe<StartConsumingSucceededEvent>(x => waiter.Signal());
 
                 var task = mockBuilder.Rpc.RequestAsync<TestRequestMessage, TestResponseMessage>(requestMessage);
                 if (!waiter.Wait(5000))

--- a/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent_but_no_reply_is_received.cs
+++ b/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent_but_no_reply_is_received.cs
@@ -16,10 +16,7 @@ namespace EasyNetQ.Tests.ProducerTests
             mockBuilder = new MockBuilder("host=localhost;timeout=1");
         }
 
-        public void Dispose()
-        {
-            mockBuilder.Bus.Dispose();
-        }
+        public void Dispose() => mockBuilder.Dispose();
 
         [Fact]
         public Task Should_throw_a_cancelled_exception()

--- a/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
+++ b/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
@@ -33,7 +33,6 @@ namespace EasyNetQ.Consumer
         private readonly ConnectionConfiguration configuration;
 
         private bool disposed;
-        private bool disposing;
 
         public DefaultConsumerErrorStrategy(
             IPersistentConnection connection,
@@ -63,7 +62,7 @@ namespace EasyNetQ.Consumer
             Preconditions.CheckNotNull(context, "context");
             Preconditions.CheckNotNull(exception, "exception");
 
-            if (disposed || disposing)
+            if (disposed)
             {
                 logger.ErrorFormat(
                     "ErrorStrategy was already disposed, when attempting to handle consumer error. Error message will not be published and message with receivedInfo={receivedInfo} will be requeued",
@@ -133,11 +132,6 @@ namespace EasyNetQ.Consumer
         /// <inheritdoc />
         public virtual void Dispose()
         {
-            if (disposed) return;
-            disposing = true;
-
-            connection.Dispose();
-
             disposed = true;
         }
 

--- a/Source/EasyNetQ/Consumer/HandlerRunner.cs
+++ b/Source/EasyNetQ/Consumer/HandlerRunner.cs
@@ -103,7 +103,6 @@ namespace EasyNetQ.Consumer
         /// <inheritdoc />
         public void Dispose()
         {
-            consumerErrorStrategy.Dispose();
         }
     }
 }

--- a/Source/EasyNetQ/Consumer/InternalConsumerFactory.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumerFactory.cs
@@ -52,8 +52,6 @@ namespace EasyNetQ.Consumer
         /// <inheritdoc />
         public void Dispose()
         {
-            consumerDispatcherFactory.Dispose();
-            handlerRunner.Dispose();
         }
     }
 }

--- a/Source/EasyNetQ/Consumer/TransientConsumer.cs
+++ b/Source/EasyNetQ/Consumer/TransientConsumer.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
-using EasyNetQ.Events;
+﻿using EasyNetQ.Events;
 using EasyNetQ.Topology;
 
 namespace EasyNetQ.Consumer
@@ -14,7 +11,7 @@ namespace EasyNetQ.Consumer
         private readonly MessageHandler onMessage;
         private readonly IQueue queue;
 
-        private bool disposed;
+        private volatile bool disposed;
 
         private IInternalConsumer internalConsumer;
 

--- a/Source/EasyNetQ/DI/DefaultServiceContainer.cs
+++ b/Source/EasyNetQ/DI/DefaultServiceContainer.cs
@@ -2,7 +2,7 @@
 
 namespace EasyNetQ.DI
 {
-    public class DefaultServiceContainer : IServiceRegister
+    public class DefaultServiceContainer : IServiceRegister, IDisposable
     {
         private readonly LightInject.ServiceContainer container = new LightInject.ServiceContainer();
 
@@ -34,7 +34,7 @@ namespace EasyNetQ.DI
 
         public TService Resolve<TService>()
         {
-            return (TService)container.GetInstance(typeof(TService));
+            return (TService) container.GetInstance(typeof(TService));
         }
 
         private static LightInject.ILifetime ToLifetime(Lifetime lifetime)
@@ -61,7 +61,7 @@ namespace EasyNetQ.DI
 
             public TService Resolve<TService>() where TService : class
             {
-                return (TService)serviceFactory.GetInstance(typeof(TService));
+                return (TService) serviceFactory.GetInstance(typeof(TService));
             }
 
             public IServiceResolverScope CreateScope()
@@ -69,5 +69,7 @@ namespace EasyNetQ.DI
                 return new ServiceResolverScope(this);
             }
         }
+
+        public void Dispose() => container.Dispose();
     }
 }

--- a/Source/EasyNetQ/DefaultPubSub.cs
+++ b/Source/EasyNetQ/DefaultPubSub.cs
@@ -131,7 +131,7 @@ namespace EasyNetQ
 
             var consumerCancellation = advancedBus.Consume<T>(
                 queue,
-                (message, messageReceivedInfo) => onMessage(message.Body, default),
+                (m, _, c) => onMessage(m.Body, c),
                 x => x.WithPriority(subscriptionConfiguration.Priority)
                     .WithPrefetchCount(subscriptionConfiguration.PrefetchCount)
                     .WithExclusive(subscriptionConfiguration.IsExclusive)

--- a/Source/EasyNetQ/DefaultRpc.cs
+++ b/Source/EasyNetQ/DefaultRpc.cs
@@ -121,8 +121,7 @@ namespace EasyNetQ
         public void Dispose()
         {
             eventSubscription.Dispose();
-            foreach (var responseSubscription in responseSubscriptions.Values)
-                responseSubscription.Unsubscribe();
+            responseSubscriptions.ClearAndDispose(x => x.Unsubscribe());
         }
 
         private void OnConnectionRecovered(ConnectionRecoveredEvent @event)

--- a/Source/EasyNetQ/Internals/AsyncCountdownEvent.cs
+++ b/Source/EasyNetQ/Internals/AsyncCountdownEvent.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace EasyNetQ.Internals
+{
+    /// <summary>
+    ///     This is an internal API that supports the EasyNetQ infrastructure and not subject to
+    ///     the same compatibility as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new EasyNetQ release.
+    /// </summary>
+    public sealed class AsyncCountdownEvent : IDisposable
+    {
+        private readonly object mutex = new object();
+        private readonly Queue<TaskCompletionSource<bool>> waiters = new Queue<TaskCompletionSource<bool>>();
+        private long count;
+
+        /// <summary>
+        ///     Creates event
+        /// </summary>
+        public AsyncCountdownEvent() : this(0)
+        {
+        }
+
+        /// <summary>
+        ///     Creates event with customer initial count
+        /// </summary>
+        public AsyncCountdownEvent(long initialCount)
+        {
+            count = initialCount;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            lock (mutex)
+            {
+                while (waiters.Count > 0)
+                {
+                    var waiter = waiters.Dequeue();
+                    waiter.TrySetCanceled();
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Increments counter
+        /// </summary>
+        public void Increment()
+        {
+            lock (mutex)
+            {
+                count += 1;
+            }
+        }
+
+        /// <summary>
+        ///     Decrements counter
+        /// </summary>
+        public void Decrement()
+        {
+            lock (mutex)
+            {
+                count -= 1;
+                while (count == 0 && waiters.Count > 0)
+                {
+                    var waiter = waiters.Dequeue();
+                    if (waiter.TrySetResult(true))
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Waits until counter is zero
+        /// </summary>
+        public void Wait()
+        {
+            TaskCompletionSource<bool> waiter = null;
+            lock (mutex)
+            {
+                if (count > 0)
+                {
+                    waiter = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    waiters.Enqueue(waiter);
+                }
+            }
+            waiter?.Task.GetAwaiter().GetResult();
+        }
+    }
+}

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -78,20 +78,11 @@ namespace EasyNetQ
             this.advancedBusEventHandlers = advancedBusEventHandlers;
             this.Conventions = conventions;
 
-            if (advancedBusEventHandlers.Connected != null)
-                Connected += advancedBusEventHandlers.Connected;
-
-            if (advancedBusEventHandlers.Disconnected != null)
-                Disconnected += advancedBusEventHandlers.Disconnected;
-
-            if (advancedBusEventHandlers.Blocked != null)
-                Blocked += advancedBusEventHandlers.Blocked;
-
-            if (advancedBusEventHandlers.Unblocked != null)
-                Unblocked += advancedBusEventHandlers.Unblocked;
-
-            if (advancedBusEventHandlers.MessageReturned != null)
-                MessageReturned += advancedBusEventHandlers.MessageReturned;
+            Connected += advancedBusEventHandlers.Connected;
+            Disconnected += advancedBusEventHandlers.Disconnected;
+            Blocked += advancedBusEventHandlers.Blocked;
+            Unblocked += advancedBusEventHandlers.Unblocked;
+            MessageReturned += advancedBusEventHandlers.MessageReturned;
 
             eventSubscriptions = new[]
             {
@@ -653,20 +644,11 @@ namespace EasyNetQ
             foreach (var eventSubscription in eventSubscriptions)
                 eventSubscription.Dispose();
 
-            if (advancedBusEventHandlers.Connected != null)
-                Connected -= advancedBusEventHandlers.Connected;
-
-            if (advancedBusEventHandlers.Disconnected != null)
-                Disconnected -= advancedBusEventHandlers.Disconnected;
-
-            if (advancedBusEventHandlers.Blocked != null)
-                Blocked -= advancedBusEventHandlers.Blocked;
-
-            if (advancedBusEventHandlers.Unblocked != null)
-                Unblocked -= advancedBusEventHandlers.Unblocked;
-
-            if (advancedBusEventHandlers.MessageReturned != null)
-                MessageReturned -= advancedBusEventHandlers.MessageReturned;
+            Connected -= advancedBusEventHandlers.Connected;
+            Disconnected -= advancedBusEventHandlers.Disconnected;
+            Blocked -= advancedBusEventHandlers.Blocked;
+            Unblocked -= advancedBusEventHandlers.Unblocked;
+            MessageReturned -= advancedBusEventHandlers.MessageReturned;
         }
 
         private void OnConnectionCreated(ConnectionCreatedEvent @event)

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -29,9 +29,9 @@ namespace EasyNetQ
         private readonly IPullingConsumerFactory pullingConsumerFactory;
         private readonly AdvancedBusEventHandlers advancedBusEventHandlers;
         private readonly IProduceConsumeInterceptor produceConsumeInterceptor;
-
-        private bool disposed;
         private readonly IDisposable[] eventSubscriptions;
+
+        private volatile bool disposed;
 
         /// <summary>
         ///     Creates RabbitAdvancedBus
@@ -648,6 +648,8 @@ namespace EasyNetQ
         {
             if (disposed) return;
 
+            disposed = true;
+
             foreach (var eventSubscription in eventSubscriptions)
                 eventSubscription.Dispose();
 
@@ -665,8 +667,6 @@ namespace EasyNetQ
 
             if (advancedBusEventHandlers.MessageReturned != null)
                 MessageReturned -= advancedBusEventHandlers.MessageReturned;
-
-            disposed = true;
         }
 
         private void OnConnectionCreated(ConnectionCreatedEvent @event)

--- a/Source/EasyNetQ/RabbitBus.cs
+++ b/Source/EasyNetQ/RabbitBus.cs
@@ -50,7 +50,6 @@ namespace EasyNetQ
         /// <inheritdoc />
         public virtual void Dispose()
         {
-            Advanced.Dispose();
         }
     }
 }

--- a/Source/EasyNetQ/RabbitHutch.cs
+++ b/Source/EasyNetQ/RabbitHutch.cs
@@ -188,7 +188,7 @@ namespace EasyNetQ
         {
             var container = new DefaultServiceContainer();
             RegisterBus(container, connectionConfigurationFactory, registerServices);
-            return container.Resolve<IBus>();
+            return new BusWithCustomDisposer(container.Resolve<IBus>(), container.Dispose);
         }
 
         /// <summary>
@@ -219,6 +219,26 @@ namespace EasyNetQ
 
             serviceRegister.RegisterDefaultServices();
             registerServices(serviceRegister);
+        }
+
+        private class BusWithCustomDisposer : IBus
+        {
+            private readonly IBus bus;
+            private readonly Action disposer;
+
+            public BusWithCustomDisposer(IBus bus, Action disposer)
+            {
+                this.bus = bus;
+                this.disposer = disposer;
+            }
+
+            public void Dispose() => disposer();
+
+            public IPubSub PubSub => bus.PubSub;
+            public IRpc Rpc => bus.Rpc;
+            public ISendReceive SendReceive => bus.SendReceive;
+            public IScheduler Scheduler => bus.Scheduler;
+            public IAdvancedBus Advanced => bus.Advanced;
         }
     }
 }


### PR DESCRIPTION
Probably fixes #671

Motivation of this PR is to move responsibility of disposing object to DI container completely: if a depency is passed to class as constructor dependency - do not dispose it, otherwise - dispose.