### PR TITLE
Do not call SetDefaultProperties twice

### DIFF
--- a/Source/EasyNetQ/ConnectionString/ConnectionStringParser.cs
+++ b/Source/EasyNetQ/ConnectionString/ConnectionStringParser.cs
@@ -12,10 +12,9 @@ namespace EasyNetQ.ConnectionString
             try
             {
                 var updater = ConnectionStringGrammar.ParseConnectionString(connectionString);
-                var configuration = updater.Aggregate(
+                return updater.Aggregate(
                     new ConnectionConfiguration(), (current, updateFunction) => updateFunction(current)
                 );
-                return configuration;
             }
             catch (ParseException parseException)
             {

--- a/Source/EasyNetQ/ConnectionString/ConnectionStringParser.cs
+++ b/Source/EasyNetQ/ConnectionString/ConnectionStringParser.cs
@@ -15,7 +15,6 @@ namespace EasyNetQ.ConnectionString
                 var configuration = updater.Aggregate(
                     new ConnectionConfiguration(), (current, updateFunction) => updateFunction(current)
                 );
-                configuration.SetDefaultProperties();
                 return configuration;
             }
             catch (ParseException parseException)


### PR DESCRIPTION
`SetDefaultProperties` will be called for `ConnectionConfiguration` [here](https://github.com/EasyNetQ/EasyNetQ/blob/develop/Source/EasyNetQ/RabbitHutch.cs#L174), so there is no need to call it anywhere else.