### PR TITLE
Structify events

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -91,19 +91,19 @@ namespace EasyNetQ
     }
     public static class ConsumeConfigurationExtensions
     {
-        public static EasyNetQ.IConsumeConfiguration ForQueue(this EasyNetQ.IConsumeConfiguration configuration, EasyNetQ.Topology.Queue queue, EasyNetQ.Consumer.MessageHandler handler) { }
-        public static EasyNetQ.IConsumeConfiguration ForQueue(this EasyNetQ.IConsumeConfiguration configuration, EasyNetQ.Topology.Queue queue, System.Func<System.ReadOnlyMemory<byte>, EasyNetQ.MessageProperties, EasyNetQ.MessageReceivedInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler) { }
-        public static EasyNetQ.IConsumeConfiguration ForQueue(this EasyNetQ.IConsumeConfiguration configuration, EasyNetQ.Topology.Queue queue, System.Func<System.ReadOnlyMemory<byte>, EasyNetQ.MessageProperties, EasyNetQ.MessageReceivedInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Action<EasyNetQ.IPerQueueConsumeConfiguration> configure) { }
-        public static EasyNetQ.IConsumeConfiguration ForQueue<T>(this EasyNetQ.IConsumeConfiguration configuration, EasyNetQ.Topology.Queue queue, EasyNetQ.Consumer.IMessageHandler<T> handler) { }
-        public static EasyNetQ.IConsumeConfiguration ForQueue<T>(this EasyNetQ.IConsumeConfiguration configuration, EasyNetQ.Topology.Queue queue, System.Action<EasyNetQ.IMessage<T>, EasyNetQ.MessageReceivedInfo> handler) { }
-        public static EasyNetQ.IConsumeConfiguration ForQueue<T>(this EasyNetQ.IConsumeConfiguration configuration, EasyNetQ.Topology.Queue queue, System.Func<EasyNetQ.IMessage<T>, EasyNetQ.MessageReceivedInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler) { }
-        public static EasyNetQ.IConsumeConfiguration ForQueue<T>(this EasyNetQ.IConsumeConfiguration configuration, EasyNetQ.Topology.Queue queue, EasyNetQ.Consumer.IMessageHandler<T> handler, System.Action<EasyNetQ.IPerQueueConsumeConfiguration> configure) { }
-        public static EasyNetQ.IConsumeConfiguration ForQueue<T>(this EasyNetQ.IConsumeConfiguration configuration, EasyNetQ.Topology.Queue queue, System.Action<EasyNetQ.IMessage<T>, EasyNetQ.MessageReceivedInfo> handler, System.Action<EasyNetQ.IPerQueueConsumeConfiguration> configure) { }
-        public static EasyNetQ.IConsumeConfiguration ForQueue<T>(this EasyNetQ.IConsumeConfiguration configuration, EasyNetQ.Topology.Queue queue, System.Func<EasyNetQ.IMessage<T>, EasyNetQ.MessageReceivedInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Action<EasyNetQ.IPerQueueConsumeConfiguration> configure) { }
+        public static EasyNetQ.IConsumeConfiguration ForQueue(this EasyNetQ.IConsumeConfiguration configuration, in EasyNetQ.Topology.Queue queue, EasyNetQ.Consumer.MessageHandler handler) { }
+        public static EasyNetQ.IConsumeConfiguration ForQueue(this EasyNetQ.IConsumeConfiguration configuration, in EasyNetQ.Topology.Queue queue, System.Func<System.ReadOnlyMemory<byte>, EasyNetQ.MessageProperties, EasyNetQ.MessageReceivedInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler) { }
+        public static EasyNetQ.IConsumeConfiguration ForQueue(this EasyNetQ.IConsumeConfiguration configuration, in EasyNetQ.Topology.Queue queue, System.Func<System.ReadOnlyMemory<byte>, EasyNetQ.MessageProperties, EasyNetQ.MessageReceivedInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Action<EasyNetQ.IPerQueueConsumeConfiguration> configure) { }
+        public static EasyNetQ.IConsumeConfiguration ForQueue<T>(this EasyNetQ.IConsumeConfiguration configuration, in EasyNetQ.Topology.Queue queue, EasyNetQ.Consumer.IMessageHandler<T> handler) { }
+        public static EasyNetQ.IConsumeConfiguration ForQueue<T>(this EasyNetQ.IConsumeConfiguration configuration, in EasyNetQ.Topology.Queue queue, System.Action<EasyNetQ.IMessage<T>, EasyNetQ.MessageReceivedInfo> handler) { }
+        public static EasyNetQ.IConsumeConfiguration ForQueue<T>(this EasyNetQ.IConsumeConfiguration configuration, in EasyNetQ.Topology.Queue queue, System.Func<EasyNetQ.IMessage<T>, EasyNetQ.MessageReceivedInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler) { }
+        public static EasyNetQ.IConsumeConfiguration ForQueue<T>(this EasyNetQ.IConsumeConfiguration configuration, in EasyNetQ.Topology.Queue queue, EasyNetQ.Consumer.IMessageHandler<T> handler, System.Action<EasyNetQ.IPerQueueConsumeConfiguration> configure) { }
+        public static EasyNetQ.IConsumeConfiguration ForQueue<T>(this EasyNetQ.IConsumeConfiguration configuration, in EasyNetQ.Topology.Queue queue, System.Action<EasyNetQ.IMessage<T>, EasyNetQ.MessageReceivedInfo> handler, System.Action<EasyNetQ.IPerQueueConsumeConfiguration> configure) { }
+        public static EasyNetQ.IConsumeConfiguration ForQueue<T>(this EasyNetQ.IConsumeConfiguration configuration, in EasyNetQ.Topology.Queue queue, System.Func<EasyNetQ.IMessage<T>, EasyNetQ.MessageReceivedInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Action<EasyNetQ.IPerQueueConsumeConfiguration> configure) { }
     }
     public readonly struct ConsumedMessage
     {
-        public ConsumedMessage(EasyNetQ.MessageReceivedInfo receivedInfo, EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body) { }
+        public ConsumedMessage(EasyNetQ.MessageReceivedInfo receivedInfo, EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
         public System.ReadOnlyMemory<byte> Body { get; }
         public EasyNetQ.MessageProperties Properties { get; }
         public EasyNetQ.MessageReceivedInfo ReceivedInfo { get; }
@@ -137,7 +137,7 @@ namespace EasyNetQ
     public class DefaultMessageSerializationStrategy : EasyNetQ.IMessageSerializationStrategy
     {
         public DefaultMessageSerializationStrategy(EasyNetQ.ITypeNameSerializer typeNameSerializer, EasyNetQ.ISerializer serializer, EasyNetQ.ICorrelationIdGenerationStrategy correlationIdGenerator) { }
-        public EasyNetQ.IMessage DeserializeMessage(EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body) { }
+        public EasyNetQ.IMessage DeserializeMessage(EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
         public EasyNetQ.SerializedMessage SerializeMessage(EasyNetQ.IMessage message) { }
     }
     public class DefaultPubSub : EasyNetQ.IPubSub
@@ -239,8 +239,10 @@ namespace EasyNetQ
     public sealed class EventBus : EasyNetQ.IEventBus
     {
         public EventBus() { }
-        public void Publish<TEvent>(TEvent @event) { }
-        public System.IDisposable Subscribe<TEvent>(System.Action<TEvent> handler) { }
+        public void Publish<TEvent>(in TEvent @event)
+            where TEvent :  struct { }
+        public System.IDisposable Subscribe<TEvent>(EasyNetQ.TEventHandler<TEvent> eventHandler)
+            where TEvent :  struct { }
     }
     public static class ExchangeDeclareConfigurationExtensions
     {
@@ -268,8 +270,8 @@ namespace EasyNetQ
         System.Threading.Tasks.Task<EasyNetQ.Topology.Binding<EasyNetQ.Topology.Exchange>> BindAsync(EasyNetQ.Topology.Exchange source, EasyNetQ.Topology.Exchange destination, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments, System.Threading.CancellationToken cancellationToken = default);
         void Connect();
         System.IDisposable Consume(System.Action<EasyNetQ.IConsumeConfiguration> configure);
-        EasyNetQ.IPullingConsumer<EasyNetQ.PullResult> CreatePullingConsumer(EasyNetQ.Topology.Queue queue, bool autoAck = true);
-        EasyNetQ.IPullingConsumer<EasyNetQ.PullResult<T>> CreatePullingConsumer<T>(EasyNetQ.Topology.Queue queue, bool autoAck = true);
+        EasyNetQ.IPullingConsumer<EasyNetQ.PullResult> CreatePullingConsumer(in EasyNetQ.Topology.Queue queue, bool autoAck = true);
+        EasyNetQ.IPullingConsumer<EasyNetQ.PullResult<T>> CreatePullingConsumer<T>(in EasyNetQ.Topology.Queue queue, bool autoAck = true);
         System.Threading.Tasks.Task<EasyNetQ.Topology.Exchange> ExchangeDeclareAsync(string name, System.Action<EasyNetQ.IExchangeDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task ExchangeDeclarePassiveAsync(string name, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task ExchangeDeleteAsync(EasyNetQ.Topology.Exchange exchange, bool ifUnused = false, System.Threading.CancellationToken cancellationToken = default);
@@ -295,8 +297,8 @@ namespace EasyNetQ
     }
     public interface IConsumeConfiguration
     {
-        EasyNetQ.IConsumeConfiguration ForQueue(EasyNetQ.Topology.Queue queue, EasyNetQ.Consumer.MessageHandler handler, System.Action<EasyNetQ.IPerQueueConsumeConfiguration> configure);
-        EasyNetQ.IConsumeConfiguration ForQueue(EasyNetQ.Topology.Queue queue, System.Action<EasyNetQ.Consumer.IHandlerRegistration> register, System.Action<EasyNetQ.IPerQueueConsumeConfiguration> configure);
+        EasyNetQ.IConsumeConfiguration ForQueue(in EasyNetQ.Topology.Queue queue, EasyNetQ.Consumer.MessageHandler handler, System.Action<EasyNetQ.IPerQueueConsumeConfiguration> configure);
+        EasyNetQ.IConsumeConfiguration ForQueue(in EasyNetQ.Topology.Queue queue, System.Action<EasyNetQ.Consumer.IHandlerRegistration> register, System.Action<EasyNetQ.IPerQueueConsumeConfiguration> configure);
         EasyNetQ.IConsumeConfiguration WithPrefetchCount(ushort prefetchCount);
     }
     public interface IConventions
@@ -319,8 +321,10 @@ namespace EasyNetQ
     }
     public interface IEventBus
     {
-        void Publish<TEvent>(TEvent @event);
-        System.IDisposable Subscribe<TEvent>(System.Action<TEvent> handler);
+        void Publish<TEvent>(in TEvent @event)
+            where TEvent :  struct;
+        System.IDisposable Subscribe<TEvent>(EasyNetQ.TEventHandler<TEvent> eventHandler)
+            where TEvent :  struct;
     }
     public interface IExchangeDeclareConfiguration
     {
@@ -346,7 +350,7 @@ namespace EasyNetQ
     }
     public interface IMessageSerializationStrategy
     {
-        EasyNetQ.IMessage DeserializeMessage(EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body);
+        EasyNetQ.IMessage DeserializeMessage(EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body);
         EasyNetQ.SerializedMessage SerializeMessage(EasyNetQ.IMessage message);
     }
     public interface IMessage<out T> : EasyNetQ.IMessage
@@ -384,8 +388,8 @@ namespace EasyNetQ
     }
     public interface IPullingConsumerFactory
     {
-        EasyNetQ.IPullingConsumer<EasyNetQ.PullResult> CreateConsumer(EasyNetQ.Topology.Queue queue, EasyNetQ.PullingConsumerOptions options);
-        EasyNetQ.IPullingConsumer<EasyNetQ.PullResult<T>> CreateConsumer<T>(EasyNetQ.Topology.Queue queue, EasyNetQ.PullingConsumerOptions options);
+        EasyNetQ.IPullingConsumer<EasyNetQ.PullResult> CreateConsumer(in EasyNetQ.Topology.Queue queue, in EasyNetQ.PullingConsumerOptions options);
+        EasyNetQ.IPullingConsumer<EasyNetQ.PullResult<T>> CreateConsumer<T>(in EasyNetQ.Topology.Queue queue, in EasyNetQ.PullingConsumerOptions options);
     }
     public interface IPullingConsumer<TPullResult> : System.IDisposable
         where TPullResult : EasyNetQ.IPullResult
@@ -567,12 +571,12 @@ namespace EasyNetQ
     }
     public class MessageReturnedEventArgs : System.EventArgs
     {
-        public MessageReturnedEventArgs(System.ReadOnlyMemory<byte> messageBody, EasyNetQ.MessageProperties messageProperties, EasyNetQ.MessageReturnedInfo messageReturnedInfo) { }
+        public MessageReturnedEventArgs(in System.ReadOnlyMemory<byte> messageBody, EasyNetQ.MessageProperties messageProperties, in EasyNetQ.MessageReturnedInfo messageReturnedInfo) { }
         public System.ReadOnlyMemory<byte> MessageBody { get; }
         public EasyNetQ.MessageProperties MessageProperties { get; }
         public EasyNetQ.MessageReturnedInfo MessageReturnedInfo { get; }
     }
-    public class MessageReturnedInfo
+    public readonly struct MessageReturnedInfo
     {
         public MessageReturnedInfo(string exchange, string routingKey, string returnReason) { }
         public string Exchange { get; }
@@ -635,7 +639,7 @@ namespace EasyNetQ
     }
     public readonly struct ProducedMessage
     {
-        public ProducedMessage(EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body) { }
+        public ProducedMessage(EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
         public System.ReadOnlyMemory<byte> Body { get; }
         public EasyNetQ.MessageProperties Properties { get; }
     }
@@ -671,7 +675,7 @@ namespace EasyNetQ
         public EasyNetQ.MessageReceivedInfo ReceivedInfo { get; }
         public static EasyNetQ.PullResult NotAvailable { get; }
         public void Dispose() { }
-        public static EasyNetQ.PullResult Available(ulong messagesCount, EasyNetQ.MessageReceivedInfo receivedInfo, EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body, System.IDisposable disposable) { }
+        public static EasyNetQ.PullResult Available(ulong messagesCount, EasyNetQ.MessageReceivedInfo receivedInfo, EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body, System.IDisposable disposable) { }
     }
     public readonly struct PullResult<T> : EasyNetQ.IPullResult, System.IDisposable
     {
@@ -685,7 +689,7 @@ namespace EasyNetQ
     }
     public class PullingConsumer : EasyNetQ.IPullingConsumer<EasyNetQ.PullResult>, System.IDisposable
     {
-        public PullingConsumer(EasyNetQ.PullingConsumerOptions options, EasyNetQ.Topology.Queue queue, EasyNetQ.Producer.IPersistentChannel channel, EasyNetQ.Interception.IProduceConsumeInterceptor interceptor) { }
+        public PullingConsumer(in EasyNetQ.PullingConsumerOptions options, in EasyNetQ.Topology.Queue queue, EasyNetQ.Producer.IPersistentChannel channel, EasyNetQ.Interception.IProduceConsumeInterceptor interceptor) { }
         public System.Threading.Tasks.Task AckAsync(ulong deliveryTag, bool multiple, System.Threading.CancellationToken cancellationToken = default) { }
         public void Dispose() { }
         public System.Threading.Tasks.Task<EasyNetQ.PullResult> PullAsync(System.Threading.CancellationToken cancellationToken = default) { }
@@ -707,8 +711,8 @@ namespace EasyNetQ
     public class PullingConsumerFactory : EasyNetQ.IPullingConsumerFactory
     {
         public PullingConsumerFactory(EasyNetQ.Producer.IPersistentChannelFactory channelFactory, EasyNetQ.Interception.IProduceConsumeInterceptor produceConsumeInterceptor, EasyNetQ.IMessageSerializationStrategy messageSerializationStrategy) { }
-        public EasyNetQ.IPullingConsumer<EasyNetQ.PullResult> CreateConsumer(EasyNetQ.Topology.Queue queue, EasyNetQ.PullingConsumerOptions options) { }
-        public EasyNetQ.IPullingConsumer<EasyNetQ.PullResult<T>> CreateConsumer<T>(EasyNetQ.Topology.Queue queue, EasyNetQ.PullingConsumerOptions options) { }
+        public EasyNetQ.IPullingConsumer<EasyNetQ.PullResult> CreateConsumer(in EasyNetQ.Topology.Queue queue, in EasyNetQ.PullingConsumerOptions options) { }
+        public EasyNetQ.IPullingConsumer<EasyNetQ.PullResult<T>> CreateConsumer<T>(in EasyNetQ.Topology.Queue queue, in EasyNetQ.PullingConsumerOptions options) { }
     }
     public readonly struct PullingConsumerOptions
     {
@@ -778,8 +782,8 @@ namespace EasyNetQ
         public System.Threading.Tasks.Task<EasyNetQ.Topology.Binding<EasyNetQ.Topology.Exchange>> BindAsync(EasyNetQ.Topology.Exchange source, EasyNetQ.Topology.Exchange destination, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments, System.Threading.CancellationToken cancellationToken) { }
         public void Connect() { }
         public System.IDisposable Consume(System.Action<EasyNetQ.IConsumeConfiguration> configure) { }
-        public EasyNetQ.IPullingConsumer<EasyNetQ.PullResult> CreatePullingConsumer(EasyNetQ.Topology.Queue queue, bool autoAck = true) { }
-        public EasyNetQ.IPullingConsumer<EasyNetQ.PullResult<T>> CreatePullingConsumer<T>(EasyNetQ.Topology.Queue queue, bool autoAck = true) { }
+        public EasyNetQ.IPullingConsumer<EasyNetQ.PullResult> CreatePullingConsumer(in EasyNetQ.Topology.Queue queue, bool autoAck = true) { }
+        public EasyNetQ.IPullingConsumer<EasyNetQ.PullResult<T>> CreatePullingConsumer<T>(in EasyNetQ.Topology.Queue queue, bool autoAck = true) { }
         public virtual void Dispose() { }
         public System.Threading.Tasks.Task<EasyNetQ.Topology.Exchange> ExchangeDeclareAsync(string name, System.Action<EasyNetQ.IExchangeDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task ExchangeDeclarePassiveAsync(string name, System.Threading.CancellationToken cancellationToken = default) { }
@@ -885,11 +889,12 @@ namespace EasyNetQ
     }
     public readonly struct SubscriptionResult : System.IDisposable
     {
-        public SubscriptionResult(EasyNetQ.Topology.Exchange exchange, EasyNetQ.Topology.Queue queue, System.IDisposable consumerCancellation) { }
+        public SubscriptionResult(in EasyNetQ.Topology.Exchange exchange, in EasyNetQ.Topology.Queue queue, System.IDisposable consumerCancellation) { }
         public EasyNetQ.Topology.Exchange Exchange { get; }
         public EasyNetQ.Topology.Queue Queue { get; }
         public void Dispose() { }
     }
+    public delegate void TEventHandler<TEvent>(in TEvent @event);
     public delegate string TopicNameConvention(System.Type messageType);
 }
 namespace EasyNetQ.AutoSubscribe
@@ -1020,7 +1025,7 @@ namespace EasyNetQ.Consumer
     }
     public readonly struct ConsumerExecutionContext
     {
-        public ConsumerExecutionContext(EasyNetQ.Consumer.MessageHandler handler, EasyNetQ.MessageReceivedInfo receivedInfo, EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body) { }
+        public ConsumerExecutionContext(EasyNetQ.Consumer.MessageHandler handler, EasyNetQ.MessageReceivedInfo receivedInfo, EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
         public System.ReadOnlyMemory<byte> Body { get; }
         public EasyNetQ.Consumer.MessageHandler Handler { get; }
         public EasyNetQ.MessageProperties Properties { get; }
@@ -1056,12 +1061,12 @@ namespace EasyNetQ.Consumer
     public class HandlerCollectionFactory : EasyNetQ.Consumer.IHandlerCollectionFactory
     {
         public HandlerCollectionFactory() { }
-        public EasyNetQ.Consumer.IHandlerCollection CreateHandlerCollection(EasyNetQ.Topology.Queue queue) { }
+        public EasyNetQ.Consumer.IHandlerCollection CreateHandlerCollection(in EasyNetQ.Topology.Queue queue) { }
     }
     public class HandlerCollectionPerQueueFactory : EasyNetQ.Consumer.IHandlerCollectionFactory
     {
         public HandlerCollectionPerQueueFactory() { }
-        public EasyNetQ.Consumer.IHandlerCollection CreateHandlerCollection(EasyNetQ.Topology.Queue queue) { }
+        public EasyNetQ.Consumer.IHandlerCollection CreateHandlerCollection(in EasyNetQ.Topology.Queue queue) { }
     }
     public static class HandlerRegistrationExtensions
     {
@@ -1102,7 +1107,7 @@ namespace EasyNetQ.Consumer
     }
     public interface IHandlerCollectionFactory
     {
-        EasyNetQ.Consumer.IHandlerCollection CreateHandlerCollection(EasyNetQ.Topology.Queue queue);
+        EasyNetQ.Consumer.IHandlerCollection CreateHandlerCollection(in EasyNetQ.Topology.Queue queue);
     }
     public interface IHandlerRegistration
     {
@@ -1135,7 +1140,7 @@ namespace EasyNetQ.Consumer
     }
     public class InternalConsumerCancelledEventArgs : System.EventArgs
     {
-        public InternalConsumerCancelledEventArgs(EasyNetQ.Topology.Queue cancelled, System.Collections.Generic.IReadOnlyCollection<EasyNetQ.Topology.Queue> active) { }
+        public InternalConsumerCancelledEventArgs(in EasyNetQ.Topology.Queue cancelled, System.Collections.Generic.IReadOnlyCollection<EasyNetQ.Topology.Queue> active) { }
         public System.Collections.Generic.IReadOnlyCollection<EasyNetQ.Topology.Queue> Active { get; }
         public EasyNetQ.Topology.Queue Cancelled { get; }
     }
@@ -1209,9 +1214,9 @@ namespace EasyNetQ.DI
 }
 namespace EasyNetQ.Events
 {
-    public class AckEvent
+    public readonly struct AckEvent
     {
-        public AckEvent(EasyNetQ.MessageReceivedInfo info, EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body, EasyNetQ.Events.AckResult ackResult) { }
+        public AckEvent(EasyNetQ.MessageReceivedInfo info, EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body, EasyNetQ.Events.AckResult ackResult) { }
         public EasyNetQ.Events.AckResult AckResult { get; }
         public System.ReadOnlyMemory<byte> Body { get; }
         public EasyNetQ.MessageProperties Properties { get; }
@@ -1223,56 +1228,52 @@ namespace EasyNetQ.Events
         Nack = 1,
         Exception = 2,
     }
-    public class ChannelRecoveredEvent
+    public readonly struct ChannelRecoveredEvent
     {
         public ChannelRecoveredEvent(RabbitMQ.Client.IModel channel) { }
         public RabbitMQ.Client.IModel Channel { get; }
     }
-    public class ChannelShutdownEvent
+    public readonly struct ChannelShutdownEvent
     {
         public ChannelShutdownEvent(RabbitMQ.Client.IModel channel) { }
         public RabbitMQ.Client.IModel Channel { get; }
     }
-    public class ConnectionBlockedEvent
+    public readonly struct ConnectionBlockedEvent
     {
         public ConnectionBlockedEvent(string reason) { }
         public string Reason { get; }
     }
-    public class ConnectionCreatedEvent
+    public readonly struct ConnectionCreatedEvent
     {
         public ConnectionCreatedEvent(RabbitMQ.Client.AmqpTcpEndpoint endpoint) { }
         public RabbitMQ.Client.AmqpTcpEndpoint Endpoint { get; }
     }
-    public class ConnectionDisconnectedEvent
+    public readonly struct ConnectionDisconnectedEvent
     {
         public ConnectionDisconnectedEvent(RabbitMQ.Client.AmqpTcpEndpoint endpoint, string reason) { }
         public RabbitMQ.Client.AmqpTcpEndpoint Endpoint { get; }
         public string Reason { get; }
     }
-    public class ConnectionRecoveredEvent
+    public readonly struct ConnectionRecoveredEvent
     {
         public ConnectionRecoveredEvent(RabbitMQ.Client.AmqpTcpEndpoint endpoint) { }
         public RabbitMQ.Client.AmqpTcpEndpoint Endpoint { get; }
     }
-    public class ConnectionUnblockedEvent
-    {
-        public ConnectionUnblockedEvent() { }
-    }
-    public class ConsumerModelDisposedEvent
+    public readonly struct ConnectionUnblockedEvent { }
+    public readonly struct ConsumerModelDisposedEvent
     {
         public ConsumerModelDisposedEvent(string[] consumerTags) { }
         public System.Collections.Generic.IReadOnlyCollection<string> ConsumerTags { get; }
     }
-    public class DeliveredMessageEvent
+    public readonly struct DeliveredMessageEvent
     {
-        public DeliveredMessageEvent(EasyNetQ.MessageReceivedInfo info, EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body) { }
+        public DeliveredMessageEvent(EasyNetQ.MessageReceivedInfo info, EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
         public System.ReadOnlyMemory<byte> Body { get; }
         public EasyNetQ.MessageProperties Properties { get; }
         public EasyNetQ.MessageReceivedInfo ReceivedInfo { get; }
     }
-    public class MessageConfirmationEvent
+    public readonly struct MessageConfirmationEvent
     {
-        public MessageConfirmationEvent() { }
         public RabbitMQ.Client.IModel Channel { get; }
         public ulong DeliveryTag { get; }
         public bool IsNack { get; }
@@ -1280,35 +1281,35 @@ namespace EasyNetQ.Events
         public static EasyNetQ.Events.MessageConfirmationEvent Ack(RabbitMQ.Client.IModel channel, ulong deliveryTag, bool multiple) { }
         public static EasyNetQ.Events.MessageConfirmationEvent Nack(RabbitMQ.Client.IModel channel, ulong deliveryTag, bool multiple) { }
     }
-    public class PublishedMessageEvent
+    public readonly struct PublishedMessageEvent
     {
-        public PublishedMessageEvent(string exchangeName, string routingKey, EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body) { }
+        public PublishedMessageEvent(in EasyNetQ.Topology.Exchange exchange, string routingKey, EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
         public System.ReadOnlyMemory<byte> Body { get; }
-        public string ExchangeName { get; }
+        public EasyNetQ.Topology.Exchange Exchange { get; }
         public EasyNetQ.MessageProperties Properties { get; }
         public string RoutingKey { get; }
     }
-    public class ReturnedMessageEvent
+    public readonly struct ReturnedMessageEvent
     {
-        public ReturnedMessageEvent(RabbitMQ.Client.IModel channel, System.ReadOnlyMemory<byte> body, EasyNetQ.MessageProperties properties, EasyNetQ.MessageReturnedInfo info) { }
+        public ReturnedMessageEvent(RabbitMQ.Client.IModel channel, in System.ReadOnlyMemory<byte> body, EasyNetQ.MessageProperties properties, in EasyNetQ.MessageReturnedInfo info) { }
         public System.ReadOnlyMemory<byte> Body { get; }
         public RabbitMQ.Client.IModel Channel { get; }
         public EasyNetQ.MessageReturnedInfo Info { get; }
         public EasyNetQ.MessageProperties Properties { get; }
     }
-    public class StartConsumingFailedEvent
+    public readonly struct StartConsumingFailedEvent
     {
-        public StartConsumingFailedEvent(EasyNetQ.Consumer.IConsumer consumer, EasyNetQ.Topology.Queue queue) { }
+        public StartConsumingFailedEvent(EasyNetQ.Consumer.IConsumer consumer, in EasyNetQ.Topology.Queue queue) { }
         public EasyNetQ.Consumer.IConsumer Consumer { get; }
         public EasyNetQ.Topology.Queue Queue { get; }
     }
-    public class StartConsumingSucceededEvent
+    public readonly struct StartConsumingSucceededEvent
     {
-        public StartConsumingSucceededEvent(EasyNetQ.Consumer.IConsumer consumer, EasyNetQ.Topology.Queue queue) { }
+        public StartConsumingSucceededEvent(EasyNetQ.Consumer.IConsumer consumer, in EasyNetQ.Topology.Queue queue) { }
         public EasyNetQ.Consumer.IConsumer Consumer { get; }
         public EasyNetQ.Topology.Queue Queue { get; }
     }
-    public class StoppedConsumingEvent
+    public readonly struct StoppedConsumingEvent
     {
         public StoppedConsumingEvent(EasyNetQ.Consumer.IConsumer consumer) { }
         public EasyNetQ.Consumer.IConsumer Consumer { get; }
@@ -1451,7 +1452,7 @@ namespace EasyNetQ.Internals
     }
     public sealed class ReadOnlyMemoryStream : System.IO.Stream
     {
-        public ReadOnlyMemoryStream(System.ReadOnlyMemory<byte> content) { }
+        public ReadOnlyMemoryStream(in System.ReadOnlyMemory<byte> content) { }
         public override bool CanRead { get; }
         public override bool CanSeek { get; }
         public override bool CanWrite { get; }
@@ -1629,7 +1630,7 @@ namespace EasyNetQ.MessageVersioning
     public class VersionedMessageSerializationStrategy : EasyNetQ.IMessageSerializationStrategy
     {
         public VersionedMessageSerializationStrategy(EasyNetQ.ITypeNameSerializer typeNameSerializer, EasyNetQ.ISerializer serializer, EasyNetQ.ICorrelationIdGenerationStrategy correlationIdGenerator) { }
-        public EasyNetQ.IMessage DeserializeMessage(EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body) { }
+        public EasyNetQ.IMessage DeserializeMessage(EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
         public EasyNetQ.SerializedMessage SerializeMessage(EasyNetQ.IMessage message) { }
     }
 }
@@ -1674,7 +1675,7 @@ namespace EasyNetQ.Producer
     }
     public interface IPersistentChannelFactory
     {
-        EasyNetQ.Producer.IPersistentChannel CreatePersistentChannel(EasyNetQ.Producer.PersistentChannelOptions options);
+        EasyNetQ.Producer.IPersistentChannel CreatePersistentChannel(in EasyNetQ.Producer.PersistentChannelOptions options);
     }
     public interface IPublishConfirmationListener : System.IDisposable
     {
@@ -1694,14 +1695,14 @@ namespace EasyNetQ.Producer
     }
     public class PersistentChannel : EasyNetQ.Producer.IPersistentChannel, System.IDisposable
     {
-        public PersistentChannel(EasyNetQ.Producer.PersistentChannelOptions options, EasyNetQ.IPersistentConnection connection, EasyNetQ.IEventBus eventBus) { }
+        public PersistentChannel(in EasyNetQ.Producer.PersistentChannelOptions options, EasyNetQ.IPersistentConnection connection, EasyNetQ.IEventBus eventBus) { }
         public void Dispose() { }
         public System.Threading.Tasks.Task<T> InvokeChannelActionAsync<T>(System.Func<RabbitMQ.Client.IModel, T> channelAction, System.Threading.CancellationToken cancellationToken) { }
     }
     public class PersistentChannelFactory : EasyNetQ.Producer.IPersistentChannelFactory
     {
         public PersistentChannelFactory(EasyNetQ.IPersistentConnection connection, EasyNetQ.IEventBus eventBus) { }
-        public EasyNetQ.Producer.IPersistentChannel CreatePersistentChannel(EasyNetQ.Producer.PersistentChannelOptions options) { }
+        public EasyNetQ.Producer.IPersistentChannel CreatePersistentChannel(in EasyNetQ.Producer.PersistentChannelOptions options) { }
     }
     public readonly struct PersistentChannelOptions
     {
@@ -1764,7 +1765,7 @@ namespace EasyNetQ.Topology
     public readonly struct Binding<TBindable>
         where TBindable :  struct, EasyNetQ.Topology.IBindable
     {
-        public Binding(EasyNetQ.Topology.Exchange source, TBindable destination, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments = null) { }
+        public Binding(in EasyNetQ.Topology.Exchange source, in TBindable destination, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments = null) { }
         public System.Collections.Generic.IDictionary<string, object> Arguments { get; }
         public TBindable Destination { get; }
         public string RoutingKey { get; }

--- a/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
@@ -77,8 +77,8 @@ namespace EasyNetQ.Tests.ConsumeTests
 
             var waiter = new CountdownEvent(2);
 
-            MockBuilder.EventBus.Subscribe<DeliveredMessageEvent>(_ => waiter.Signal());
-            MockBuilder.EventBus.Subscribe<AckEvent>(_ => waiter.Signal());
+            MockBuilder.EventBus.Subscribe((in DeliveredMessageEvent _) => waiter.Signal());
+            MockBuilder.EventBus.Subscribe((in AckEvent _) => waiter.Signal());
 
             MockBuilder.Consumers[0].HandleBasicDeliver(
                 ConsumerTag,

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_by_the_broker.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_by_the_broker.cs
@@ -1,4 +1,4 @@
-﻿// ReSharper disable InconsistentNaming
+// ReSharper disable InconsistentNaming
 
 using System;
 using System.Threading;

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_by_the_broker.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_by_the_broker.cs
@@ -1,4 +1,4 @@
-// ReSharper disable InconsistentNaming
+﻿// ReSharper disable InconsistentNaming
 
 using System;
 using System.Threading;
@@ -28,7 +28,7 @@ namespace EasyNetQ.Tests.ConsumeTests
             );
 
             var are = new AutoResetEvent(false);
-            mockBuilder.EventBus.Subscribe<ConsumerModelDisposedEvent>(_ => are.Set());
+            mockBuilder.EventBus.Subscribe((in ConsumerModelDisposedEvent _) => are.Set());
 
             mockBuilder.Consumers[0].HandleBasicCancel("consumer_tag").GetAwaiter().GetResult();
 

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_by_the_user.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_by_the_user.cs
@@ -1,4 +1,4 @@
-﻿// ReSharper disable InconsistentNaming
+// ReSharper disable InconsistentNaming
 
 using System;
 using System.Threading;

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_by_the_user.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_by_the_user.cs
@@ -1,4 +1,4 @@
-// ReSharper disable InconsistentNaming
+﻿// ReSharper disable InconsistentNaming
 
 using System;
 using System.Threading;
@@ -25,7 +25,7 @@ namespace EasyNetQ.Tests.ConsumeTests
                 .Consume(queue, (_, _, _) => Task.Run(() => { }));
 
             var are = new AutoResetEvent(false);
-            mockBuilder.EventBus.Subscribe<ConsumerModelDisposedEvent>(_ => are.Set());
+            mockBuilder.EventBus.Subscribe((in ConsumerModelDisposedEvent _) => are.Set());
 
             cancelSubscription.Dispose();
 

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_received.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_received.cs
@@ -1,4 +1,4 @@
-﻿// ReSharper disable InconsistentNaming
+// ReSharper disable InconsistentNaming
 using System;
 using System.Text;
 using System.Threading;

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_received.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_received.cs
@@ -1,4 +1,4 @@
-// ReSharper disable InconsistentNaming
+﻿// ReSharper disable InconsistentNaming
 using System;
 using System.Text;
 using System.Threading;
@@ -60,7 +60,7 @@ namespace EasyNetQ.Tests.ConsumeTests
             var body = Encoding.UTF8.GetBytes(message);
 
             var autoResetEvent = new AutoResetEvent(false);
-            mockBuilder.EventBus.Subscribe<AckEvent>(_ => autoResetEvent.Set());
+            mockBuilder.EventBus.Subscribe((in AckEvent _) => autoResetEvent.Set());
             mockBuilder.Consumers[0].HandleBasicDeliver(
                 "consumer tag",
                 0,

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
@@ -61,12 +61,12 @@ namespace EasyNetQ.Tests.ConsumeTests
             var serializedMessage = serializer.MessageToBytes(typeof(RpcRequest), request);
 
             var waiter = new CountdownEvent(2);
-            mockBuilder.EventBus.Subscribe<PublishedMessageEvent>(x =>
+            mockBuilder.EventBus.Subscribe((in PublishedMessageEvent x) =>
             {
                 publishedMessage = x;
                 waiter.Signal();
             });
-            mockBuilder.EventBus.Subscribe<AckEvent>(x =>
+            mockBuilder.EventBus.Subscribe((in AckEvent x) =>
             {
                 ackEvent = x;
                 waiter.Signal();

--- a/Source/EasyNetQ.Tests/EventBusTests.cs
+++ b/Source/EasyNetQ.Tests/EventBusTests.cs
@@ -1,4 +1,4 @@
-﻿// ReSharper disable InconsistentNaming
+// ReSharper disable InconsistentNaming
 
 using System;
 using System.Collections.Generic;

--- a/Source/EasyNetQ.Tests/EventBusTests.cs
+++ b/Source/EasyNetQ.Tests/EventBusTests.cs
@@ -1,4 +1,4 @@
-// ReSharper disable InconsistentNaming
+﻿// ReSharper disable InconsistentNaming
 
 using System;
 using System.Collections.Generic;
@@ -9,7 +9,7 @@ namespace EasyNetQ.Tests
 {
     public class EventBusTests
     {
-        private IEventBus eventBus;
+        private readonly IEventBus eventBus;
 
         public EventBusTests()
         {
@@ -19,9 +19,9 @@ namespace EasyNetQ.Tests
         [Fact]
         public void Should_be_able_to_get_subscribed_to_events()
         {
-            Event1 capturedEvent = null;
+            Event1? capturedEvent = null;
 
-            eventBus.Subscribe<Event1>(@event => capturedEvent = @event);
+            eventBus.Subscribe((in Event1 @event) => capturedEvent = @event);
 
             var publishedEvent = new Event1
             {
@@ -30,16 +30,15 @@ namespace EasyNetQ.Tests
 
             eventBus.Publish(publishedEvent);
 
-            capturedEvent.Should().NotBeNull();
-            capturedEvent.Should().BeSameAs(publishedEvent);
+            capturedEvent.Should().Be(publishedEvent);
         }
 
         [Fact]
         public void Should_not_get_events_not_subscribed_to()
         {
-            Event1 capturedEvent = null;
+            Event1? capturedEvent = null;
 
-            eventBus.Subscribe<Event1>(@event => capturedEvent = @event);
+            eventBus.Subscribe((in Event1 @event) => capturedEvent = @event);
 
             var publishedEvent = new Event2
             {
@@ -54,30 +53,31 @@ namespace EasyNetQ.Tests
         [Fact]
         public void Should_be_able_to_cancel_an_event()
         {
-            var stringsPublished = new List<string>();
+            var published = new List<Event1>();
 
-            var subscription = eventBus.Subscribe<string>(stringsPublished.Add);
+            var subscription = eventBus.Subscribe((in Event1 s) => published.Add(s));
             subscription.Should().NotBeNull();
 
-            eventBus.Publish("Before cancellation");
+            var publishedEvent = new Event1 { Text = "Before cancellation" };
+            eventBus.Publish(publishedEvent);
 
             subscription.Dispose();
 
-            eventBus.Publish("Hello World");
+            eventBus.Publish(new Event1 { Text = "Hello World" });
 
-            stringsPublished.Count.Should().Be(1);
-            stringsPublished[0].Should().Be("Before cancellation");
+            published.Count.Should().Be(1);
+            published[0].Should().Be(publishedEvent);
         }
 
         [Fact]
         public void Should_handle_resubscription_from_handler()
         {
-            Event1 eventFromSubscription = null;
+            Event1? eventFromSubscription = null;
 
-            eventBus.Subscribe<Event1>(@event =>
+            eventBus.Subscribe((in Event1 @event) =>
                 {
                     eventFromSubscription = @event;
-                    eventBus.Subscribe<Event1>(_ => { });
+                    eventBus.Subscribe((in Event1 _) => { });
                 });
 
             var publishedEvent1 = new Event1
@@ -93,11 +93,11 @@ namespace EasyNetQ.Tests
         [Fact]
         public void Should_handle_cancelation_from_handler()
         {
-            Event1 eventFromSubscription = null;
+            Event1? eventFromSubscription = null;
 
             IDisposable subscription = null;
 
-            subscription = eventBus.Subscribe<Event1>(@event =>
+            subscription = eventBus.Subscribe((in Event1 @event) =>
             {
                 subscription.Dispose();
                 eventFromSubscription = @event;
@@ -113,12 +113,12 @@ namespace EasyNetQ.Tests
             eventFromSubscription.Should().NotBeNull();
         }
 
-        private class Event1
+        private struct Event1
         {
             public string Text { get; set; }
         }
 
-        private class Event2
+        private struct Event2
         {
             public string Text { get; set; }
         }

--- a/Source/EasyNetQ.Tests/ModelCleanupTests.cs
+++ b/Source/EasyNetQ.Tests/ModelCleanupTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading;
 using EasyNetQ.Events;
 using EasyNetQ.Tests.Mocking;
@@ -23,7 +23,7 @@ namespace EasyNetQ.Tests
         private AutoResetEvent WaitForConsumerModelDisposedMessage()
         {
             var are = new AutoResetEvent(false);
-            mockBuilder.EventBus.Subscribe<ConsumerModelDisposedEvent>(_ => are.Set());
+            mockBuilder.EventBus.Subscribe((in ConsumerModelDisposedEvent _) => are.Set());
             return are;
         }
 
@@ -41,8 +41,8 @@ namespace EasyNetQ.Tests
         {
             var waiter = new CountdownEvent(2);
 
-            mockBuilder.EventBus.Subscribe<PublishedMessageEvent>(_ => waiter.Signal());
-            mockBuilder.EventBus.Subscribe<StartConsumingSucceededEvent>(_ => waiter.Signal());
+            mockBuilder.EventBus.Subscribe((in PublishedMessageEvent _) => waiter.Signal());
+            mockBuilder.EventBus.Subscribe((in StartConsumingSucceededEvent _) => waiter.Signal());
 
             bus.Rpc.RequestAsync<TestRequestMessage, TestResponseMessage>(new TestRequestMessage());
             if (!waiter.Wait(5000))
@@ -63,7 +63,7 @@ namespace EasyNetQ.Tests
         public void Should_cleanup_respond_model()
         {
             var waiter = new CountdownEvent(1);
-            mockBuilder.EventBus.Subscribe<StartConsumingSucceededEvent>(_ => waiter.Signal());
+            mockBuilder.EventBus.Subscribe((in StartConsumingSucceededEvent _) => waiter.Signal());
 
             bus.Rpc.Respond<TestRequestMessage, TestResponseMessage>(_ => (TestResponseMessage)null);
             if (!waiter.Wait(5000))

--- a/Source/EasyNetQ.Tests/ModelCleanupTests.cs
+++ b/Source/EasyNetQ.Tests/ModelCleanupTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using EasyNetQ.Events;
 using EasyNetQ.Tests.Mocking;

--- a/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent.cs
+++ b/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent.cs
@@ -26,8 +26,8 @@ namespace EasyNetQ.Tests.ProducerTests
 
             var waiter = new CountdownEvent(2);
 
-            mockBuilder.EventBus.Subscribe<PublishedMessageEvent>(_ => waiter.Signal());
-            mockBuilder.EventBus.Subscribe<StartConsumingSucceededEvent>(_ => waiter.Signal());
+            mockBuilder.EventBus.Subscribe((in PublishedMessageEvent _) => waiter.Signal());
+            mockBuilder.EventBus.Subscribe((in StartConsumingSucceededEvent _) => waiter.Signal());
 
             var task = mockBuilder.Rpc.RequestAsync<TestRequestMessage, TestResponseMessage>(new TestRequestMessage());
             if (!waiter.Wait(5000))

--- a/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent_but_an_exception_is_thrown_by_responder.cs
+++ b/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent_but_an_exception_is_thrown_by_responder.cs
@@ -40,8 +40,8 @@ namespace EasyNetQ.Tests.ProducerTests
             {
                 var waiter = new CountdownEvent(2);
 
-                mockBuilder.EventBus.Subscribe<PublishedMessageEvent>(_ => waiter.Signal());
-                mockBuilder.EventBus.Subscribe<StartConsumingSucceededEvent>(_ => waiter.Signal());
+                mockBuilder.EventBus.Subscribe((in PublishedMessageEvent _) => waiter.Signal());
+                mockBuilder.EventBus.Subscribe((in StartConsumingSucceededEvent _) => waiter.Signal());
 
                 var task = mockBuilder.Rpc.RequestAsync<TestRequestMessage, TestResponseMessage>(requestMessage);
                 if (!waiter.Wait(5000))
@@ -59,8 +59,8 @@ namespace EasyNetQ.Tests.ProducerTests
             {
                 var waiter = new CountdownEvent(2);
 
-                mockBuilder.EventBus.Subscribe<PublishedMessageEvent>(_ => waiter.Signal());
-                mockBuilder.EventBus.Subscribe<StartConsumingSucceededEvent>(_ => waiter.Signal());
+                mockBuilder.EventBus.Subscribe((in PublishedMessageEvent _) => waiter.Signal());
+                mockBuilder.EventBus.Subscribe((in StartConsumingSucceededEvent _) => waiter.Signal());
 
                 var task = mockBuilder.Rpc.RequestAsync<TestRequestMessage, TestResponseMessage>(requestMessage);
                 if (!waiter.Wait(5000))

--- a/Source/EasyNetQ.Tests/PublishTests.cs
+++ b/Source/EasyNetQ.Tests/PublishTests.cs
@@ -38,7 +38,7 @@ namespace EasyNetQ.Tests
         private void WaitForMessageToPublish()
         {
             var autoResetEvent = new AutoResetEvent(false);
-            mockBuilder.EventBus.Subscribe<PublishedMessageEvent>(_ => autoResetEvent.Set());
+            mockBuilder.EventBus.Subscribe((in PublishedMessageEvent _) => autoResetEvent.Set());
             autoResetEvent.WaitOne(1000);
         }
 
@@ -101,7 +101,7 @@ namespace EasyNetQ.Tests
         private void WaitForMessageToPublish()
         {
             var autoResetEvent = new AutoResetEvent(false);
-            mockBuilder.EventBus.Subscribe<PublishedMessageEvent>(_ => autoResetEvent.Set());
+            mockBuilder.EventBus.Subscribe((in PublishedMessageEvent _) => autoResetEvent.Set());
             autoResetEvent.WaitOne(1000);
         }
 

--- a/Source/EasyNetQ.Tests/SubscribeTests.cs
+++ b/Source/EasyNetQ.Tests/SubscribeTests.cs
@@ -1,4 +1,4 @@
-﻿// ReSharper disable InconsistentNaming
+// ReSharper disable InconsistentNaming
 
 using System;
 using System.Collections.Generic;

--- a/Source/EasyNetQ.Tests/SubscribeTests.cs
+++ b/Source/EasyNetQ.Tests/SubscribeTests.cs
@@ -1,4 +1,4 @@
-// ReSharper disable InconsistentNaming
+﻿// ReSharper disable InconsistentNaming
 
 using System;
 using System.Collections.Generic;
@@ -242,7 +242,7 @@ namespace EasyNetQ.Tests
             mockBuilder = new MockBuilder(x => x.Register<IConventions>(conventions));
 
             var autoResetEvent = new AutoResetEvent(false);
-            mockBuilder.EventBus.Subscribe<AckEvent>(_ => autoResetEvent.Set());
+            mockBuilder.EventBus.Subscribe((in AckEvent _) => autoResetEvent.Set());
 
             mockBuilder.PubSub.Subscribe<MyMessage>(subscriptionId, message => { deliveredMessage = message; });
 
@@ -355,7 +355,7 @@ namespace EasyNetQ.Tests
 
             // wait for the subscription thread to handle the message ...
             var autoResetEvent = new AutoResetEvent(false);
-            mockBuilder.EventBus.Subscribe<AckEvent>(_ => autoResetEvent.Set());
+            mockBuilder.EventBus.Subscribe((in AckEvent _) => autoResetEvent.Set());
             autoResetEvent.WaitOne(1000);
         }
 
@@ -409,7 +409,7 @@ namespace EasyNetQ.Tests
             mockBuilder = new MockBuilder(x => x.Register<IConventions>(conventions));
             var subscriptionResult = mockBuilder.PubSub.Subscribe<MyMessage>(subscriptionId, _ => { });
             var are = new AutoResetEvent(false);
-            mockBuilder.EventBus.Subscribe<ConsumerModelDisposedEvent>(_ => are.Set());
+            mockBuilder.EventBus.Subscribe((in ConsumerModelDisposedEvent _) => are.Set());
             subscriptionResult.Dispose();
             are.WaitOne(500);
         }

--- a/Source/EasyNetQ/ConsumeConfiguration.cs
+++ b/Source/EasyNetQ/ConsumeConfiguration.cs
@@ -35,13 +35,13 @@ namespace EasyNetQ
 
     internal class ConsumeConfiguration : IConsumeConfiguration
     {
-        private readonly Func<Queue, IHandlerCollection> createHandlerCollection;
+        private readonly IHandlerCollectionFactory handlerCollectionFactory;
 
         public ConsumeConfiguration(
-            ushort defaultPrefetchCount, Func<Queue, IHandlerCollection> createHandlerCollection
+            ushort defaultPrefetchCount, IHandlerCollectionFactory handlerCollectionFactory
         )
         {
-            this.createHandlerCollection = createHandlerCollection;
+            this.handlerCollectionFactory = handlerCollectionFactory;
             PrefetchCount = defaultPrefetchCount;
             PerQueueConsumeConfigurations = new List<Tuple<Queue, MessageHandler, PerQueueConsumeConfiguration>>();
             PerQueueTypedConsumeConfigurations =
@@ -63,7 +63,7 @@ namespace EasyNetQ
         }
 
         public IConsumeConfiguration ForQueue(
-            Queue queue, MessageHandler handler, Action<IPerQueueConsumeConfiguration> configure
+            in Queue queue, MessageHandler handler, Action<IPerQueueConsumeConfiguration> configure
         )
         {
             var perQueueConsumeConfiguration = new PerQueueConsumeConfiguration();
@@ -73,10 +73,10 @@ namespace EasyNetQ
         }
 
         public IConsumeConfiguration ForQueue(
-            Queue queue, Action<IHandlerRegistration> register, Action<IPerQueueConsumeConfiguration> configure
+            in Queue queue, Action<IHandlerRegistration> register, Action<IPerQueueConsumeConfiguration> configure
         )
         {
-            var handlerCollection = createHandlerCollection(queue);
+            var handlerCollection = handlerCollectionFactory.CreateHandlerCollection(queue);
             register(handlerCollection);
             var perQueueConsumeConfiguration = new PerQueueConsumeConfiguration();
             configure(perQueueConsumeConfiguration);
@@ -135,7 +135,7 @@ namespace EasyNetQ
         /// </summary>
         /// <returns>IConsumeConfiguration</returns>
         IConsumeConfiguration ForQueue(
-            Queue queue, MessageHandler handler, Action<IPerQueueConsumeConfiguration> configure
+            in Queue queue, MessageHandler handler, Action<IPerQueueConsumeConfiguration> configure
         );
 
         /// <summary>
@@ -143,7 +143,7 @@ namespace EasyNetQ
         /// </summary>
         /// <returns>IConsumeConfiguration</returns>
         IConsumeConfiguration ForQueue(
-            Queue queue, Action<IHandlerRegistration> register, Action<IPerQueueConsumeConfiguration> configure
+            in Queue queue, Action<IHandlerRegistration> register, Action<IPerQueueConsumeConfiguration> configure
         );
     }
 

--- a/Source/EasyNetQ/ConsumeConfigurationExtensions.cs
+++ b/Source/EasyNetQ/ConsumeConfigurationExtensions.cs
@@ -51,7 +51,7 @@ namespace EasyNetQ
     {
         public static IConsumeConfiguration ForQueue(
             this IConsumeConfiguration configuration,
-            Queue queue,
+            in Queue queue,
             MessageHandler handler
         )
         {
@@ -61,7 +61,7 @@ namespace EasyNetQ
 
         public static IConsumeConfiguration ForQueue(
             this IConsumeConfiguration configuration,
-            Queue queue,
+            in Queue queue,
             Func<ReadOnlyMemory<byte>, MessageProperties, MessageReceivedInfo, CancellationToken, Task> handler
         )
         {
@@ -71,7 +71,7 @@ namespace EasyNetQ
 
         public static IConsumeConfiguration ForQueue(
             this IConsumeConfiguration configuration,
-            Queue queue,
+            in Queue queue,
             Func<ReadOnlyMemory<byte>, MessageProperties, MessageReceivedInfo, CancellationToken, Task> handler,
             Action<IPerQueueConsumeConfiguration> configure
         )
@@ -90,7 +90,7 @@ namespace EasyNetQ
 
         public static IConsumeConfiguration ForQueue<T>(
             this IConsumeConfiguration configuration,
-            Queue queue,
+            in Queue queue,
             IMessageHandler<T> handler
         )
         {
@@ -101,7 +101,7 @@ namespace EasyNetQ
 
         public static IConsumeConfiguration ForQueue<T>(
             this IConsumeConfiguration configuration,
-            Queue queue,
+            in Queue queue,
             IMessageHandler<T> handler,
             Action<IPerQueueConsumeConfiguration> configure
         )
@@ -113,7 +113,7 @@ namespace EasyNetQ
 
         public static IConsumeConfiguration ForQueue<T>(
             this IConsumeConfiguration configuration,
-            Queue queue,
+            in Queue queue,
             Func<IMessage<T>, MessageReceivedInfo, CancellationToken, Task> handler
         )
         {
@@ -124,7 +124,7 @@ namespace EasyNetQ
 
         public static IConsumeConfiguration ForQueue<T>(
             this IConsumeConfiguration configuration,
-            Queue queue,
+            in Queue queue,
             Func<IMessage<T>, MessageReceivedInfo, CancellationToken, Task> handler,
             Action<IPerQueueConsumeConfiguration> configure
         )
@@ -136,7 +136,7 @@ namespace EasyNetQ
 
         public static IConsumeConfiguration ForQueue<T>(
             this IConsumeConfiguration configuration,
-            Queue queue,
+            in Queue queue,
             Action<IMessage<T>, MessageReceivedInfo> handler
         )
         {
@@ -147,7 +147,7 @@ namespace EasyNetQ
 
         public static IConsumeConfiguration ForQueue<T>(
             this IConsumeConfiguration configuration,
-            Queue queue,
+            in Queue queue,
             Action<IMessage<T>, MessageReceivedInfo> handler,
             Action<IPerQueueConsumeConfiguration> configure
         )

--- a/Source/EasyNetQ/ConsumedMessage.cs
+++ b/Source/EasyNetQ/ConsumedMessage.cs
@@ -13,7 +13,7 @@ namespace EasyNetQ
         /// <param name="receivedInfo">The received info</param>
         /// <param name="properties">The properties</param>
         /// <param name="body">The body</param>
-        public ConsumedMessage(MessageReceivedInfo receivedInfo, MessageProperties properties, ReadOnlyMemory<byte> body)
+        public ConsumedMessage(MessageReceivedInfo receivedInfo, MessageProperties properties, in ReadOnlyMemory<byte> body)
         {
             ReceivedInfo = receivedInfo;
             Properties = properties;

--- a/Source/EasyNetQ/Consumer/AsyncBasicConsumer.cs
+++ b/Source/EasyNetQ/Consumer/AsyncBasicConsumer.cs
@@ -24,7 +24,7 @@ namespace EasyNetQ.Consumer
 
         public AsyncBasicConsumer(
             IModel model,
-            Queue queue,
+            in Queue queue,
             IEventBus eventBus,
             IHandlerRunner handlerRunner,
             MessageHandler messageHandler

--- a/Source/EasyNetQ/Consumer/Consumer.cs
+++ b/Source/EasyNetQ/Consumer/Consumer.cs
@@ -176,12 +176,12 @@ namespace EasyNetQ.Consumer
                 Dispose();
         }
 
-        private void OnConnectionDisconnected(ConnectionDisconnectedEvent _)
+        private void OnConnectionDisconnected(in ConnectionDisconnectedEvent _)
         {
             consumer?.StopConsuming();
         }
 
-        private void OnConnectionRecovered(ConnectionRecoveredEvent _)
+        private void OnConnectionRecovered(in ConnectionRecoveredEvent _)
         {
             var consumerToRestart = consumer;
             if (consumerToRestart == null)

--- a/Source/EasyNetQ/Consumer/ConsumerExecutionContext.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerExecutionContext.cs
@@ -34,7 +34,7 @@ namespace EasyNetQ.Consumer
             MessageHandler handler,
             MessageReceivedInfo receivedInfo,
             MessageProperties properties,
-            ReadOnlyMemory<byte> body
+            in ReadOnlyMemory<byte> body
         )
         {
             Preconditions.CheckNotNull(handler, nameof(handler));

--- a/Source/EasyNetQ/Consumer/ConsumerFactory.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerFactory.cs
@@ -34,8 +34,8 @@ namespace EasyNetQ.Consumer
             this.internalConsumerFactory = internalConsumerFactory;
             this.eventBus = eventBus;
 
-            unsubscribeFromStoppedConsumerEvent = eventBus.Subscribe<StoppedConsumingEvent>(
-                @event => consumers.Remove(@event.Consumer.Id)
+            unsubscribeFromStoppedConsumerEvent = eventBus.Subscribe(
+                (in StoppedConsumingEvent @event) => consumers.Remove(@event.Consumer.Id)
             );
         }
 

--- a/Source/EasyNetQ/Consumer/HandlerCollectionFactory.cs
+++ b/Source/EasyNetQ/Consumer/HandlerCollectionFactory.cs
@@ -5,7 +5,7 @@ namespace EasyNetQ.Consumer
     public class HandlerCollectionFactory : IHandlerCollectionFactory
     {
         /// <inheritdoc />
-        public IHandlerCollection CreateHandlerCollection(Queue queue)
+        public IHandlerCollection CreateHandlerCollection(in Queue queue)
         {
             return new HandlerCollection();
         }

--- a/Source/EasyNetQ/Consumer/HandlerCollectionPerQueueFactory.cs
+++ b/Source/EasyNetQ/Consumer/HandlerCollectionPerQueueFactory.cs
@@ -9,7 +9,7 @@ namespace EasyNetQ.Consumer
         private readonly ConcurrentDictionary<string, IHandlerCollection> handlerCollections = new();
 
         /// <inheritdoc />
-        public IHandlerCollection CreateHandlerCollection(Queue queue)
+        public IHandlerCollection CreateHandlerCollection(in Queue queue)
         {
             return handlerCollections.GetOrAdd(queue.Name, _ => new HandlerCollection());
         }

--- a/Source/EasyNetQ/Consumer/IHandlerCollectionFactory.cs
+++ b/Source/EasyNetQ/Consumer/IHandlerCollectionFactory.cs
@@ -4,6 +4,6 @@ namespace EasyNetQ.Consumer
 {
     public interface IHandlerCollectionFactory
     {
-        IHandlerCollection CreateHandlerCollection(Queue queue);
+        IHandlerCollection CreateHandlerCollection(in Queue queue);
     }
 }

--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -42,7 +42,7 @@ namespace EasyNetQ.Consumer
     public class InternalConsumerCancelledEventArgs : EventArgs
     {
         /// <inheritdoc />
-        public InternalConsumerCancelledEventArgs(Queue cancelled, IReadOnlyCollection<Queue> active)
+        public InternalConsumerCancelledEventArgs(in Queue cancelled, IReadOnlyCollection<Queue> active)
         {
             Cancelled = cancelled;
             Active = active;

--- a/Source/EasyNetQ/DefaultMessageSerializationStrategy.cs
+++ b/Source/EasyNetQ/DefaultMessageSerializationStrategy.cs
@@ -41,7 +41,7 @@ namespace EasyNetQ
         }
 
         /// <inheritdoc />
-        public IMessage DeserializeMessage(MessageProperties properties, ReadOnlyMemory<byte> body)
+        public IMessage DeserializeMessage(MessageProperties properties, in ReadOnlyMemory<byte> body)
         {
             var messageType = typeNameSerializer.DeSerialize(properties.Type);
             var messageBody = serializer.BytesToMessage(messageType, body);

--- a/Source/EasyNetQ/DefaultRpc.cs
+++ b/Source/EasyNetQ/DefaultRpc.cs
@@ -123,7 +123,7 @@ namespace EasyNetQ
                 responseSubscription.Unsubscribe();
         }
 
-        private void OnConnectionRecovered(ConnectionRecoveredEvent @event)
+        private void OnConnectionRecovered(in ConnectionRecoveredEvent @event)
         {
             var responseActionsValues = responseActions.Values;
             var responseSubscriptionsValues = responseSubscriptions.Values;

--- a/Source/EasyNetQ/Events/AckEvent.cs
+++ b/Source/EasyNetQ/Events/AckEvent.cs
@@ -2,14 +2,35 @@ using System;
 
 namespace EasyNetQ.Events
 {
-    public class AckEvent
+    /// <summary>
+    ///     This event is raised after a message is acked
+    /// </summary>
+    public readonly struct AckEvent
     {
+        /// <summary>
+        ///     Acked message received info
+        /// </summary>
         public MessageReceivedInfo ReceivedInfo { get; }
+
+        /// <summary>
+        ///     Acked message properties
+        /// </summary>
         public MessageProperties Properties { get; }
+
+        /// <summary>
+        ///     Acked message body
+        /// </summary>
         public ReadOnlyMemory<byte> Body { get; }
+
+        /// <summary>
+        ///     Ack result of message
+        /// </summary>
         public AckResult AckResult { get; }
 
-        public AckEvent(MessageReceivedInfo info, MessageProperties properties, ReadOnlyMemory<byte> body, AckResult ackResult)
+        /// <summary>
+        ///     Creates AckEvent
+        /// </summary>
+        public AckEvent(MessageReceivedInfo info, MessageProperties properties, in ReadOnlyMemory<byte> body, AckResult ackResult)
         {
             ReceivedInfo = info;
             Properties = properties;
@@ -18,10 +39,25 @@ namespace EasyNetQ.Events
         }
     }
 
+
+    /// <summary>
+    ///     Represents various ack results
+    /// </summary>
     public enum AckResult
     {
+        /// <summary>
+        ///     Message is acknowledged
+        /// </summary>
         Ack,
+
+        /// <summary>
+        ///     Message is rejected
+        /// </summary>
         Nack,
+
+        /// <summary>
+        ///     Message is failed to process
+        /// </summary>
         Exception
     }
 }

--- a/Source/EasyNetQ/Events/ChannelRecoveredEvent.cs
+++ b/Source/EasyNetQ/Events/ChannelRecoveredEvent.cs
@@ -5,7 +5,7 @@ namespace EasyNetQ.Events
     /// <summary>
     ///     This event is raised after a successful recovery of the channel
     /// </summary>
-    public class ChannelRecoveredEvent
+    public readonly struct ChannelRecoveredEvent
     {
         /// <summary>
         ///     The recovered channel

--- a/Source/EasyNetQ/Events/ChannelShutdownEvent.cs
+++ b/Source/EasyNetQ/Events/ChannelShutdownEvent.cs
@@ -5,7 +5,7 @@ namespace EasyNetQ.Events
     /// <summary>
     ///     This event which is raised after a shutdown of the channel
     /// </summary>
-    public class ChannelShutdownEvent
+    public readonly struct ChannelShutdownEvent
     {
         /// <summary>
         ///     The closed channel

--- a/Source/EasyNetQ/Events/ConnectionBlockedEvent.cs
+++ b/Source/EasyNetQ/Events/ConnectionBlockedEvent.cs
@@ -3,7 +3,7 @@ namespace EasyNetQ.Events
     /// <summary>
     ///     This event is raised after a block of the connection
     /// </summary>
-    public class ConnectionBlockedEvent
+    public readonly struct ConnectionBlockedEvent
     {
         /// <summary>
         ///     The reason of a block

--- a/Source/EasyNetQ/Events/ConnectionCreatedEvent.cs
+++ b/Source/EasyNetQ/Events/ConnectionCreatedEvent.cs
@@ -5,7 +5,7 @@ namespace EasyNetQ.Events
     /// <summary>
     ///     This event is raised after an initial connection to the endpoint
     /// </summary>
-    public class ConnectionCreatedEvent
+    public readonly struct ConnectionCreatedEvent
     {
         /// <summary>
         ///     The endpoint a connection is connected to

--- a/Source/EasyNetQ/Events/ConnectionDisconnectedEvent.cs
+++ b/Source/EasyNetQ/Events/ConnectionDisconnectedEvent.cs
@@ -5,7 +5,7 @@ namespace EasyNetQ.Events
     /// <summary>
     ///     This event is raised after a successful connection to the endpoint
     /// </summary>
-    public class ConnectionDisconnectedEvent
+    public readonly struct ConnectionDisconnectedEvent
     {
         /// <summary>
         ///     The endpoint a connection is disconnected from

--- a/Source/EasyNetQ/Events/ConnectionRecoveredEvent.cs
+++ b/Source/EasyNetQ/Events/ConnectionRecoveredEvent.cs
@@ -5,7 +5,7 @@ namespace EasyNetQ.Events
     /// <summary>
     ///     This event is raised after a recovery of the connection to the endpoint
     /// </summary>
-    public class ConnectionRecoveredEvent
+    public readonly struct ConnectionRecoveredEvent
     {
         /// <summary>
         ///     The endpoint a connection is connected to

--- a/Source/EasyNetQ/Events/ConnectionUnblockedEvent.cs
+++ b/Source/EasyNetQ/Events/ConnectionUnblockedEvent.cs
@@ -3,7 +3,7 @@ namespace EasyNetQ.Events
     /// <summary>
     ///     This event is raised after an unblock of the connection
     /// </summary>
-    public class ConnectionUnblockedEvent
+    public readonly struct ConnectionUnblockedEvent
     {
     }
 }

--- a/Source/EasyNetQ/Events/ConsumerModelDisposedEvent.cs
+++ b/Source/EasyNetQ/Events/ConsumerModelDisposedEvent.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace EasyNetQ.Events
 {
-    public class ConsumerModelDisposedEvent
+    public readonly struct ConsumerModelDisposedEvent
     {
         public IReadOnlyCollection<string> ConsumerTags { get; }
 

--- a/Source/EasyNetQ/Events/DeliveredMessageEvent.cs
+++ b/Source/EasyNetQ/Events/DeliveredMessageEvent.cs
@@ -2,13 +2,13 @@ using System;
 
 namespace EasyNetQ.Events
 {
-    public class DeliveredMessageEvent
+    public readonly struct DeliveredMessageEvent
     {
         public MessageReceivedInfo ReceivedInfo { get; }
         public MessageProperties Properties { get; }
         public ReadOnlyMemory<byte> Body { get; }
 
-        public DeliveredMessageEvent(MessageReceivedInfo info, MessageProperties properties, ReadOnlyMemory<byte> body)
+        public DeliveredMessageEvent(MessageReceivedInfo info, MessageProperties properties, in ReadOnlyMemory<byte> body)
         {
             ReceivedInfo = info;
             Properties = properties;

--- a/Source/EasyNetQ/Events/MessageConfirmationEvent.cs
+++ b/Source/EasyNetQ/Events/MessageConfirmationEvent.cs
@@ -5,27 +5,27 @@ namespace EasyNetQ.Events
     /// <summary>
     ///     This event is raised after a message is acked or nacked
     /// </summary>
-    public class MessageConfirmationEvent
+    public readonly struct MessageConfirmationEvent
     {
         /// <summary>
         ///     The channel
         /// </summary>
-        public IModel Channel { get; private set; }
+        public IModel Channel { get; }
 
         /// <summary>
         ///     Delivery tag of the message
         /// </summary>
-        public ulong DeliveryTag { get; private set; }
+        public ulong DeliveryTag { get; }
 
         /// <summary>
         ///     True if a confirmation affects all previous messages
         /// </summary>
-        public bool Multiple { get; private set; }
+        public bool Multiple { get; }
 
         /// <summary>
         ///     True if a message is rejected
         /// </summary>
-        public bool IsNack { get; private set; }
+        public bool IsNack { get; }
 
         /// <summary>
         ///     Creates ack event
@@ -36,13 +36,7 @@ namespace EasyNetQ.Events
         /// <returns></returns>
         public static MessageConfirmationEvent Ack(IModel channel, ulong deliveryTag, bool multiple)
         {
-            return new MessageConfirmationEvent
-            {
-                Channel = channel,
-                IsNack = false,
-                DeliveryTag = deliveryTag,
-                Multiple = multiple
-            };
+            return new MessageConfirmationEvent(channel, deliveryTag, multiple, false);
         }
 
         /// <summary>
@@ -54,13 +48,15 @@ namespace EasyNetQ.Events
         /// <returns></returns>
         public static MessageConfirmationEvent Nack(IModel channel, ulong deliveryTag, bool multiple)
         {
-            return new MessageConfirmationEvent
-            {
-                Channel = channel,
-                IsNack = true,
-                DeliveryTag = deliveryTag,
-                Multiple = multiple
-            };
+            return new MessageConfirmationEvent(channel, deliveryTag, multiple, true);
+        }
+
+        private MessageConfirmationEvent(IModel channel, ulong deliveryTag, bool multiple, bool isNack)
+        {
+            Channel = channel;
+            DeliveryTag = deliveryTag;
+            Multiple = multiple;
+            IsNack = isNack;
         }
     }
 }

--- a/Source/EasyNetQ/Events/PublishedMessageEvent.cs
+++ b/Source/EasyNetQ/Events/PublishedMessageEvent.cs
@@ -1,22 +1,23 @@
 using System;
+using EasyNetQ.Topology;
 
 namespace EasyNetQ.Events
 {
     /// <summary>
     ///     This event is raised after a message is published
     /// </summary>
-    public class PublishedMessageEvent
+    public readonly struct PublishedMessageEvent
     {
         /// <summary>
         ///     Creates PublishedMessageEvent
         /// </summary>
-        /// <param name="exchangeName">The exchange name</param>
+        /// <param name="exchange">The exchange</param>
         /// <param name="routingKey">The routing key</param>
         /// <param name="properties">The properties</param>
         /// <param name="body">The body</param>
-        public PublishedMessageEvent(string exchangeName, string routingKey, MessageProperties properties, ReadOnlyMemory<byte> body)
+        public PublishedMessageEvent(in Exchange exchange, string routingKey, MessageProperties properties, in ReadOnlyMemory<byte> body)
         {
-            ExchangeName = exchangeName;
+            Exchange = exchange;
             RoutingKey = routingKey;
             Properties = properties;
             Body = body;
@@ -25,7 +26,7 @@ namespace EasyNetQ.Events
         /// <summary>
         ///     The exchange name
         /// </summary>
-        public string ExchangeName { get; }
+        public Exchange Exchange { get; }
 
         /// <summary>
         ///     The routing key

--- a/Source/EasyNetQ/Events/ReturnedMessageEvent.cs
+++ b/Source/EasyNetQ/Events/ReturnedMessageEvent.cs
@@ -6,7 +6,7 @@ namespace EasyNetQ.Events
     /// <summary>
     ///     This event is raised after a message is returned because it couldn't be routed
     /// </summary>
-    public class ReturnedMessageEvent
+    public readonly struct ReturnedMessageEvent
     {
         /// <summary>
         ///     Creates ReturnedMessageEvent
@@ -15,7 +15,7 @@ namespace EasyNetQ.Events
         /// <param name="body">The message body</param>
         /// <param name="properties">The message properties</param>
         /// <param name="info">The returned message info</param>
-        public ReturnedMessageEvent(IModel channel, ReadOnlyMemory<byte> body, MessageProperties properties, MessageReturnedInfo info)
+        public ReturnedMessageEvent(IModel channel, in ReadOnlyMemory<byte> body, MessageProperties properties, in MessageReturnedInfo info)
         {
             Channel = channel;
             Body = body;

--- a/Source/EasyNetQ/Events/StartConsumingFailedEvent.cs
+++ b/Source/EasyNetQ/Events/StartConsumingFailedEvent.cs
@@ -6,13 +6,13 @@ namespace EasyNetQ.Events
     /// <summary>
     /// This event is fired when the consumer cannot start consuming successfully.
     /// </summary>
-    public class StartConsumingFailedEvent
+    public readonly struct StartConsumingFailedEvent
     {
         public IConsumer Consumer { get; }
 
         public Queue Queue { get; }
 
-        public StartConsumingFailedEvent(IConsumer consumer, Queue queue)
+        public StartConsumingFailedEvent(IConsumer consumer, in Queue queue)
         {
             Consumer = consumer;
             Queue = queue;

--- a/Source/EasyNetQ/Events/StartConsumingSucceededEvent.cs
+++ b/Source/EasyNetQ/Events/StartConsumingSucceededEvent.cs
@@ -6,13 +6,13 @@ namespace EasyNetQ.Events
     /// <summary>
     /// This event is fired when the consumer starts consuming successfully.
     /// </summary>
-    public class StartConsumingSucceededEvent
+    public readonly struct StartConsumingSucceededEvent
     {
         public IConsumer Consumer { get; }
 
         public Queue Queue { get; }
 
-        public StartConsumingSucceededEvent(IConsumer consumer, Queue queue)
+        public StartConsumingSucceededEvent(IConsumer consumer, in Queue queue)
         {
             Consumer = consumer;
             Queue = queue;

--- a/Source/EasyNetQ/Events/StoppedConsumingEvent.cs
+++ b/Source/EasyNetQ/Events/StoppedConsumingEvent.cs
@@ -8,7 +8,7 @@ namespace EasyNetQ.Events
     /// This is _not_ fired when a connection interruption causes EasyNetQ to re-create
     /// a PersistentConsumer.
     /// </summary>
-    public class StoppedConsumingEvent
+    public readonly struct StoppedConsumingEvent
     {
         /// <summary>
         ///     The stopped consumer

--- a/Source/EasyNetQ/IAdvancedBus.cs
+++ b/Source/EasyNetQ/IAdvancedBus.cs
@@ -241,7 +241,7 @@ namespace EasyNetQ
         /// <param name="queue">The queue</param>
         /// <param name="autoAck"></param>
         /// <returns></returns>
-        IPullingConsumer<PullResult> CreatePullingConsumer(Queue queue, bool autoAck = true);
+        IPullingConsumer<PullResult> CreatePullingConsumer(in Queue queue, bool autoAck = true);
 
         /// <summary>
         ///     Creates a new pulling consumer
@@ -249,7 +249,7 @@ namespace EasyNetQ
         /// <param name="queue">The queue</param>
         /// <param name="autoAck"></param>
         /// <returns></returns>
-        IPullingConsumer<PullResult<T>> CreatePullingConsumer<T>(Queue queue, bool autoAck = true);
+        IPullingConsumer<PullResult<T>> CreatePullingConsumer<T>(in Queue queue, bool autoAck = true);
 
         /// <summary>
         /// Event fires when the bus has connected to a RabbitMQ broker.

--- a/Source/EasyNetQ/IEventBus.cs
+++ b/Source/EasyNetQ/IEventBus.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using EasyNetQ.Logging;

--- a/Source/EasyNetQ/IEventBus.cs
+++ b/Source/EasyNetQ/IEventBus.cs
@@ -1,10 +1,13 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using EasyNetQ.Logging;
 
 namespace EasyNetQ
 {
+    /// <inheritdoc />
+    public delegate void TEventHandler<TEvent>(in TEvent @event) where TEvent : struct;
+
     /// <summary>
     ///     An internal pub-sub bus to distribute events within EasyNetQ
     /// </summary>
@@ -15,15 +18,15 @@ namespace EasyNetQ
         /// </summary>
         /// <param name="event">The event</param>
         /// <typeparam name="TEvent">The event type</typeparam>
-        void Publish<TEvent>(TEvent @event);
+        void Publish<TEvent>(in TEvent @event) where TEvent : struct;
 
         /// <summary>
         ///     Subscribes to the event type
         /// </summary>
-        /// <param name="handler">The event handler</param>
+        /// <param name="eventHandler">The event handler</param>
         /// <typeparam name="TEvent">The event type</typeparam>
         /// <returns>Unsubscription disposable</returns>
-        IDisposable Subscribe<TEvent>(Action<TEvent> handler);
+        IDisposable Subscribe<TEvent>(TEventHandler<TEvent> eventHandler) where TEvent : struct;
     }
 
     /// <inheritdoc />
@@ -32,7 +35,7 @@ namespace EasyNetQ
         private readonly ConcurrentDictionary<Type, object> subscriptions = new();
 
         /// <inheritdoc />
-        public void Publish<TEvent>(TEvent @event)
+        public void Publish<TEvent>(in TEvent @event) where TEvent : struct
         {
             if (!subscriptions.TryGetValue(typeof(TEvent), out var handlers))
                 return;
@@ -41,46 +44,46 @@ namespace EasyNetQ
         }
 
         /// <inheritdoc />
-        public IDisposable Subscribe<TEvent>(Action<TEvent> handler)
+        public IDisposable Subscribe<TEvent>(TEventHandler<TEvent> eventHandler) where TEvent : struct
         {
             var handlers = (Handlers<TEvent>)subscriptions.GetOrAdd(typeof(TEvent), _ => new Handlers<TEvent>());
-            handlers.Add(handler);
-            return new Subscription<TEvent>(handlers, handler);
+            handlers.Add(eventHandler);
+            return new Subscription<TEvent>(handlers, eventHandler);
         }
 
-        private sealed class Handlers<TEvent>
+        private sealed class Handlers<TEvent> where TEvent : struct
         {
             private readonly ILog log = LogProvider.For<Handlers<TEvent>>();
             private readonly object mutex = new();
-            private volatile List<Action<TEvent>> handlers = new();
+            private volatile List<TEventHandler<TEvent>> handlers = new();
 
-            public void Add(Action<TEvent> handler)
+            public void Add(TEventHandler<TEvent> eventHandler)
             {
                 lock (mutex)
                 {
-                    var newHandlers = new List<Action<TEvent>>(handlers);
-                    newHandlers.Add(handler);
+                    var newHandlers = new List<TEventHandler<TEvent>>(handlers);
+                    newHandlers.Add(eventHandler);
                     handlers = newHandlers;
                 }
             }
 
-            public void Remove(Action<TEvent> handler)
+            public void Remove(TEventHandler<TEvent> eventHandler)
             {
                 lock (mutex)
                 {
-                    var newHandlers = new List<Action<TEvent>>(handlers);
-                    newHandlers.Remove(handler);
+                    var newHandlers = new List<TEventHandler<TEvent>>(handlers);
+                    newHandlers.Remove(eventHandler);
                     handlers = newHandlers;
                 }
             }
 
-            public void Handle(TEvent @event)
+            public void Handle(in TEvent @event)
             {
                 // ReSharper disable once InconsistentlySynchronizedField
                 foreach (var handler in handlers)
                     try
                     {
-                        handler(@event);
+                        handler(in @event);
                     }
                     catch (Exception exception)
                     {
@@ -89,18 +92,18 @@ namespace EasyNetQ
             }
         }
 
-        private sealed class Subscription<TEvent> : IDisposable
+        private sealed class Subscription<TEvent> : IDisposable where TEvent : struct
         {
             private readonly Handlers<TEvent> handlers;
-            private readonly Action<TEvent> handler;
+            private readonly TEventHandler<TEvent> eventHandler;
 
-            public Subscription(Handlers<TEvent> handlers, Action<TEvent> handler)
+            public Subscription(Handlers<TEvent> handlers, TEventHandler<TEvent> eventHandler)
             {
                 this.handlers = handlers;
-                this.handler = handler;
+                this.eventHandler = eventHandler;
             }
 
-            public void Dispose() => handlers.Remove(handler);
+            public void Dispose() => handlers.Remove(eventHandler);
         }
     }
 }

--- a/Source/EasyNetQ/IMessageSerializationStrategy.cs
+++ b/Source/EasyNetQ/IMessageSerializationStrategy.cs
@@ -21,7 +21,7 @@ namespace EasyNetQ
         /// <param name="properties">The properties</param>
         /// <param name="body">The body</param>
         /// <returns></returns>
-        IMessage DeserializeMessage(MessageProperties properties, ReadOnlyMemory<byte> body);
+        IMessage DeserializeMessage(MessageProperties properties, in ReadOnlyMemory<byte> body);
     }
 
     /// <summary>

--- a/Source/EasyNetQ/Internals/ReadOnlyMemoryStream.cs
+++ b/Source/EasyNetQ/Internals/ReadOnlyMemoryStream.cs
@@ -16,7 +16,7 @@ namespace EasyNetQ.Internals
         private int position;
 
         /// <inheritdoc />
-        public ReadOnlyMemoryStream(ReadOnlyMemory<byte> content)
+        public ReadOnlyMemoryStream(in ReadOnlyMemory<byte> content)
         {
             this.content = content;
         }

--- a/Source/EasyNetQ/MessageReturnedEventArgs.cs
+++ b/Source/EasyNetQ/MessageReturnedEventArgs.cs
@@ -8,7 +8,7 @@ namespace EasyNetQ
         public MessageProperties MessageProperties { get; }
         public MessageReturnedInfo MessageReturnedInfo { get; }
 
-        public MessageReturnedEventArgs(ReadOnlyMemory<byte> messageBody, MessageProperties messageProperties, MessageReturnedInfo messageReturnedInfo)
+        public MessageReturnedEventArgs(in ReadOnlyMemory<byte> messageBody, MessageProperties messageProperties, in MessageReturnedInfo messageReturnedInfo)
         {
             Preconditions.CheckNotNull(messageProperties, nameof(messageProperties));
             Preconditions.CheckNotNull(messageReturnedInfo, nameof(messageReturnedInfo));

--- a/Source/EasyNetQ/MessageReturnedInfo.cs
+++ b/Source/EasyNetQ/MessageReturnedInfo.cs
@@ -1,11 +1,28 @@
 namespace EasyNetQ
 {
-    public class MessageReturnedInfo
+    /// <summary>
+    /// Contains an information about a message returned from broker
+    /// </summary>
+    public readonly struct MessageReturnedInfo
     {
+        /// <summary>
+        ///     The exchange the returned message was original published to
+        /// </summary>
         public string Exchange { get; }
+
+        /// <summary>
+        ///     The routing key used when the message was originally published
+        /// </summary>
         public string RoutingKey { get; }
+
+        /// <summary>
+        ///     Human-readable text from the broker describing the reason for the return
+        /// </summary>
         public string ReturnReason { get; }
 
+        /// <summary>
+        ///     Creates MessageReturnedInfo
+        /// </summary>
         public MessageReturnedInfo(
             string exchange,
             string routingKey,

--- a/Source/EasyNetQ/MessageVersioning/VersionedMessageSerializationStrategy.cs
+++ b/Source/EasyNetQ/MessageVersioning/VersionedMessageSerializationStrategy.cs
@@ -12,7 +12,9 @@ namespace EasyNetQ.MessageVersioning
         /// <summary>
         ///     Creates VersionedMessageSerializationStrategy
         /// </summary>
-        public VersionedMessageSerializationStrategy(ITypeNameSerializer typeNameSerializer, ISerializer serializer, ICorrelationIdGenerationStrategy correlationIdGenerator)
+        public VersionedMessageSerializationStrategy(
+            ITypeNameSerializer typeNameSerializer, ISerializer serializer, ICorrelationIdGenerationStrategy correlationIdGenerator
+        )
         {
             this.typeNameSerializer = typeNameSerializer;
             this.serializer = serializer;
@@ -32,7 +34,7 @@ namespace EasyNetQ.MessageVersioning
         }
 
         /// <inheritdoc />
-        public IMessage DeserializeMessage(MessageProperties properties, ReadOnlyMemory<byte> body)
+        public IMessage DeserializeMessage(MessageProperties properties, in ReadOnlyMemory<byte> body)
         {
             var messageTypeProperty = MessageTypeProperty.ExtractFromProperties(properties, typeNameSerializer);
             var messageType = messageTypeProperty.GetMessageType();

--- a/Source/EasyNetQ/ProducedMessage.cs
+++ b/Source/EasyNetQ/ProducedMessage.cs
@@ -12,7 +12,7 @@ namespace EasyNetQ
         /// </summary>
         /// <param name="properties">The properties</param>
         /// <param name="body">The body</param>
-        public ProducedMessage(MessageProperties properties, ReadOnlyMemory<byte> body)
+        public ProducedMessage(MessageProperties properties, in ReadOnlyMemory<byte> body)
         {
             Properties = properties;
             Body = body;

--- a/Source/EasyNetQ/Producer/IPersistentChannelFactory.cs
+++ b/Source/EasyNetQ/Producer/IPersistentChannelFactory.cs
@@ -30,7 +30,7 @@ namespace EasyNetQ.Producer
         /// </summary>
         /// <param name="options">The channel options</param>
         /// <returns>New PersistentChannel</returns>
-        IPersistentChannel CreatePersistentChannel(PersistentChannelOptions options);
+        IPersistentChannel CreatePersistentChannel(in PersistentChannelOptions options);
     }
 
     /// <inheritdoc />
@@ -54,7 +54,7 @@ namespace EasyNetQ.Producer
         }
 
         /// <inheritdoc />
-        public IPersistentChannel CreatePersistentChannel(PersistentChannelOptions options)
+        public IPersistentChannel CreatePersistentChannel(in PersistentChannelOptions options)
         {
             return new PersistentChannel(options, connection, eventBus);
         }

--- a/Source/EasyNetQ/Producer/PersistentChannel.cs
+++ b/Source/EasyNetQ/Producer/PersistentChannel.cs
@@ -32,7 +32,7 @@ namespace EasyNetQ.Producer
         /// <param name="options">The channel options</param>
         /// <param name="connection">The connection</param>
         /// <param name="eventBus">The event bus</param>
-        public PersistentChannel(PersistentChannelOptions options, IPersistentConnection connection, IEventBus eventBus)
+        public PersistentChannel(in PersistentChannelOptions options, IPersistentConnection connection, IEventBus eventBus)
         {
             Preconditions.CheckNotNull(connection, nameof(connection));
             Preconditions.CheckNotNull(eventBus, nameof(eventBus));

--- a/Source/EasyNetQ/Producer/PublishConfirmationListener.cs
+++ b/Source/EasyNetQ/Producer/PublishConfirmationListener.cs
@@ -60,7 +60,7 @@ namespace EasyNetQ.Producer
             InterruptAllUnconfirmedRequests(true);
         }
 
-        private void OnMessageConfirmation(MessageConfirmationEvent @event)
+        private void OnMessageConfirmation(in MessageConfirmationEvent @event)
         {
             if (!unconfirmedChannelRequests.TryGetValue(@event.Channel.ChannelNumber, out var requests))
                 return;
@@ -78,7 +78,7 @@ namespace EasyNetQ.Producer
                 Confirm(confirmation, deliveryTag, type);
         }
 
-        private void OnChannelRecovered(ChannelRecoveredEvent @event)
+        private void OnChannelRecovered(in ChannelRecoveredEvent @event)
         {
             if (@event.Channel.NextPublishSeqNo == 0)
                 return;
@@ -86,7 +86,7 @@ namespace EasyNetQ.Producer
             InterruptUnconfirmedRequests(@event.Channel.ChannelNumber);
         }
 
-        private void OnChannelShutdown(ChannelShutdownEvent @event)
+        private void OnChannelShutdown(in ChannelShutdownEvent @event)
         {
             if (@event.Channel.NextPublishSeqNo == 0)
                 return;
@@ -95,7 +95,7 @@ namespace EasyNetQ.Producer
         }
 
 
-        private void OnReturnedMessage(ReturnedMessageEvent @event)
+        private void OnReturnedMessage(in ReturnedMessageEvent @event)
         {
             if (@event.Channel.NextPublishSeqNo == 0)
                 return;

--- a/Source/EasyNetQ/PullingConsumer.cs
+++ b/Source/EasyNetQ/PullingConsumer.cs
@@ -55,7 +55,7 @@ namespace EasyNetQ
             ulong messagesCount,
             MessageReceivedInfo receivedInfo,
             MessageProperties properties,
-            ReadOnlyMemory<byte> body,
+            in ReadOnlyMemory<byte> body,
             IDisposable disposable
         )
         {
@@ -67,7 +67,7 @@ namespace EasyNetQ
             ulong messagesCount,
             MessageReceivedInfo receivedInfo,
             MessageProperties properties,
-            ReadOnlyMemory<byte> body,
+            in ReadOnlyMemory<byte> body,
             IDisposable disposable
         )
         {
@@ -321,8 +321,8 @@ namespace EasyNetQ
         /// <param name="channel">The channel</param>
         /// <param name="interceptor">The produce-consumer interceptor</param>
         public PullingConsumer(
-            PullingConsumerOptions options,
-            Queue queue,
+            in PullingConsumerOptions options,
+            in Queue queue,
             IPersistentChannel channel,
             IProduceConsumeInterceptor interceptor
         )

--- a/Source/EasyNetQ/PullingConsumerFactory.cs
+++ b/Source/EasyNetQ/PullingConsumerFactory.cs
@@ -15,7 +15,7 @@ namespace EasyNetQ
         /// <param name="queue">The queue</param>
         /// <param name="options">The options</param>
         /// <returns></returns>
-        IPullingConsumer<PullResult> CreateConsumer(Queue queue, PullingConsumerOptions options);
+        IPullingConsumer<PullResult> CreateConsumer(in Queue queue, in PullingConsumerOptions options);
 
         /// <summary>
         ///     Creates a pulling consumer
@@ -23,7 +23,7 @@ namespace EasyNetQ
         /// <param name="queue">The queue</param>
         /// <param name="options">The options</param>
         /// <returns></returns>
-        IPullingConsumer<PullResult<T>> CreateConsumer<T>(Queue queue, PullingConsumerOptions options);
+        IPullingConsumer<PullResult<T>> CreateConsumer<T>(in Queue queue, in PullingConsumerOptions options);
     }
 
     /// <inheritdoc />
@@ -51,14 +51,14 @@ namespace EasyNetQ
         }
 
         /// <inheritdoc />
-        public IPullingConsumer<PullResult> CreateConsumer(Queue queue, PullingConsumerOptions options)
+        public IPullingConsumer<PullResult> CreateConsumer(in Queue queue, in PullingConsumerOptions options)
         {
             var channel = channelFactory.CreatePersistentChannel(new PersistentChannelOptions());
             return new PullingConsumer(options, queue, channel, produceConsumeInterceptor);
         }
 
         /// <inheritdoc />
-        public IPullingConsumer<PullResult<T>> CreateConsumer<T>(Queue queue, PullingConsumerOptions options)
+        public IPullingConsumer<PullResult<T>> CreateConsumer<T>(in Queue queue, in PullingConsumerOptions options)
         {
             var consumer = CreateConsumer(queue, options);
             return new PullingConsumer<T>(consumer, messageSerializationStrategy);

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -110,7 +110,7 @@ namespace EasyNetQ
             Preconditions.CheckNotNull(configure, nameof(configure));
 
             var consumeConfiguration = new ConsumeConfiguration(
-                configuration.PrefetchCount, handlerCollectionFactory.CreateHandlerCollection
+                configuration.PrefetchCount, handlerCollectionFactory
             );
             configure(consumeConfiguration);
 
@@ -184,14 +184,14 @@ namespace EasyNetQ
         }
 
         /// <inheritdoc />
-        public IPullingConsumer<PullResult> CreatePullingConsumer(Queue queue, bool autoAck = true)
+        public IPullingConsumer<PullResult> CreatePullingConsumer(in Queue queue, bool autoAck = true)
         {
             var options = new PullingConsumerOptions(autoAck, configuration.Timeout);
             return pullingConsumerFactory.CreateConsumer(queue, options);
         }
 
         /// <inheritdoc />
-        public IPullingConsumer<PullResult<T>> CreatePullingConsumer<T>(Queue queue, bool autoAck = true)
+        public IPullingConsumer<PullResult<T>> CreatePullingConsumer<T>(in Queue queue, bool autoAck = true)
         {
             var options = new PullingConsumerOptions(autoAck, configuration.Timeout);
             return pullingConsumerFactory.CreateConsumer<T>(queue, options);
@@ -235,34 +235,34 @@ namespace EasyNetQ
             MessageReturned -= advancedBusEventHandlers.MessageReturned;
         }
 
-        private void OnConnectionCreated(ConnectionCreatedEvent @event)
+        private void OnConnectionCreated(in ConnectionCreatedEvent @event)
         {
             Connected?.Invoke(this, new ConnectedEventArgs(@event.Endpoint.HostName, @event.Endpoint.Port));
         }
 
-        private void OnConnectionRecovered(ConnectionRecoveredEvent @event)
+        private void OnConnectionRecovered(in ConnectionRecoveredEvent @event)
         {
             Connected?.Invoke(this, new ConnectedEventArgs(@event.Endpoint.HostName, @event.Endpoint.Port));
         }
 
-        private void OnConnectionDisconnected(ConnectionDisconnectedEvent @event)
+        private void OnConnectionDisconnected(in ConnectionDisconnectedEvent @event)
         {
             Disconnected?.Invoke(
                 this, new DisconnectedEventArgs(@event.Endpoint.HostName, @event.Endpoint.Port, @event.Reason)
             );
         }
 
-        private void OnConnectionBlocked(ConnectionBlockedEvent @event)
+        private void OnConnectionBlocked(in ConnectionBlockedEvent @event)
         {
             Blocked?.Invoke(this, new BlockedEventArgs(@event.Reason));
         }
 
-        private void OnConnectionUnblocked(ConnectionUnblockedEvent @event)
+        private void OnConnectionUnblocked(in ConnectionUnblockedEvent @event)
         {
             Unblocked?.Invoke(this, EventArgs.Empty);
         }
 
-        private void OnMessageReturned(ReturnedMessageEvent @event)
+        private void OnMessageReturned(in ReturnedMessageEvent @event)
         {
             MessageReturned?.Invoke(this, new MessageReturnedEventArgs(@event.Body, @event.Properties, @event.Info));
         }
@@ -368,7 +368,7 @@ namespace EasyNetQ
             }
 
             eventBus.Publish(
-                new PublishedMessageEvent(exchange.Name, routingKey, rawMessage.Properties, rawMessage.Body)
+                new PublishedMessageEvent(exchange, routingKey, rawMessage.Properties, rawMessage.Body)
             );
 
             if (logger.IsDebugEnabled())

--- a/Source/EasyNetQ/RabbitHutch.cs
+++ b/Source/EasyNetQ/RabbitHutch.cs
@@ -179,7 +179,7 @@ namespace EasyNetQ
             registerServices(serviceRegister);
         }
 
-        private class BusWithCustomDisposer : IBus
+        private sealed class BusWithCustomDisposer : IBus
         {
             private readonly IBus bus;
             private readonly Action disposer;

--- a/Source/EasyNetQ/SubscriptionResult.cs
+++ b/Source/EasyNetQ/SubscriptionResult.cs
@@ -13,7 +13,7 @@ namespace EasyNetQ
         /// <summary>
         /// The <see cref="IConsumer"/> cancellation, which can be disposed to cancel the subscription.
         /// </summary>
-        public SubscriptionResult(Exchange exchange, Queue queue, IDisposable consumerCancellation)
+        public SubscriptionResult(in Exchange exchange, in Queue queue, IDisposable consumerCancellation)
         {
             Preconditions.CheckNotNull(consumerCancellation, nameof(consumerCancellation));
 

--- a/Source/EasyNetQ/Topology/Binding.cs
+++ b/Source/EasyNetQ/Topology/Binding.cs
@@ -10,7 +10,7 @@ namespace EasyNetQ.Topology
         /// <summary>
         ///     Creates Binding
         /// </summary>
-        public Binding(Exchange source, TBindable destination, string routingKey, IDictionary<string, object> arguments = null)
+        public Binding(in Exchange source, in TBindable destination, string routingKey, IDictionary<string, object> arguments = null)
         {
             Preconditions.CheckNotNull(routingKey, nameof(routingKey));
 


### PR DESCRIPTION
It allows to not allocate, even in pretty often cases such as publish/consume of messages.