### PR TITLE
[routing fix] broadcast exchange routing key skip for empty TopicAttr

### DIFF
--- a/Source/EasyNetQ/AutoSubscribe/AutoSubscriber.cs
+++ b/Source/EasyNetQ/AutoSubscribe/AutoSubscriber.cs
@@ -167,19 +167,20 @@ namespace EasyNetQ.AutoSubscribe
             return sc =>
                 {
                     ConfigureSubscriptionConfiguration(sc);
-                    TopicInfo(subscriptionInfo)(sc);
+                    TopicAttributeInfo(subscriptionInfo)(sc);
                     AutoSubscriberConsumerInfo(subscriptionInfo)(sc);
                 };
         }
 
-        private static Action<ISubscriptionConfiguration> TopicInfo(AutoSubscriberConsumerInfo subscriptionInfo)
+        private static Action<ISubscriptionConfiguration> TopicAttributeInfo(AutoSubscriberConsumerInfo subscriptionInfo)
         {
             var topics = GetTopAttributeValues(subscriptionInfo);
             if (topics.Length != 0)
             {
                 return GenerateConfigurationFromTopics(topics);
             }
-            return configuration => configuration.WithTopic("#");
+
+            return configuration => configuration.WithTopic(string.Empty);
         }
 
         private static Action<ISubscriptionConfiguration> GenerateConfigurationFromTopics(string[] topics)

--- a/Source/EasyNetQ/AutoSubscribe/AutoSubscriber.cs
+++ b/Source/EasyNetQ/AutoSubscribe/AutoSubscriber.cs
@@ -27,6 +27,12 @@ namespace EasyNetQ.AutoSubscribe
         public string SubscriptionIdPrefix { get; }
 
         /// <summary>
+        /// Used when no topic is set.
+        /// By default topic uses broadcast sign
+        /// </summary>
+        public static string DefaultTopicName { get; set; } = "#";
+
+        /// <summary>
         /// Responsible for consuming a message with the relevant message consumer.
         /// </summary>
         public IAutoSubscriberMessageDispatcher AutoSubscriberMessageDispatcher { get; set; }
@@ -175,12 +181,11 @@ namespace EasyNetQ.AutoSubscribe
         private static Action<ISubscriptionConfiguration> TopicAttributeInfo(AutoSubscriberConsumerInfo subscriptionInfo)
         {
             var topics = GetTopAttributeValues(subscriptionInfo);
-            if (topics.Length != 0)
-            {
-                return GenerateConfigurationFromTopics(topics);
-            }
 
-            return configuration => configuration.WithTopic(string.Empty);
+            if (topics.Length != 0)
+                return GenerateConfigurationFromTopics(topics);
+
+            return configuration => configuration.WithTopic(DefaultTopicName ?? string.Empty);
         }
 
         private static Action<ISubscriptionConfiguration> GenerateConfigurationFromTopics(string[] topics)

--- a/Source/EasyNetQ/SubscriptionConfiguration.cs
+++ b/Source/EasyNetQ/SubscriptionConfiguration.cs
@@ -130,7 +130,8 @@ namespace EasyNetQ
 
         public ISubscriptionConfiguration WithTopic(string topic)
         {
-            Topics.Add(topic);
+            if (!string.IsNullOrWhiteSpace(topic))
+                Topics.Add(topic);
             return this;
         }
 


### PR DESCRIPTION
If no topic attribute set to IConsumeAsync method a broadcast routing key # will not be added for message broadcasting