### PR TITLE
Make IConsumerErrorStrategy methods async

### DIFF
--- a/Source/EasyNetQ.Tests/ConsumeTests/DefaultConsumerErrorStrategyTests.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/DefaultConsumerErrorStrategyTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using EasyNetQ.Consumer;
 using NSubstitute;
 using RabbitMQ.Client;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace EasyNetQ.Tests.ConsumeTests
@@ -10,7 +11,7 @@ namespace EasyNetQ.Tests.ConsumeTests
     public class DefaultConsumerErrorStrategyTests
     {
         [Fact]
-        public void Should_enable_publisher_confirm_when_configured_and_return_ack_when_confirm_received()
+        public async Task Should_enable_publisher_confirm_when_configured_and_return_ack_when_confirm_received()
         {
             var persistedConnectionMock = Substitute.For<IPersistentConnection>();
             var modelMock = Substitute.For<IModel>();
@@ -18,7 +19,7 @@ namespace EasyNetQ.Tests.ConsumeTests
             persistedConnectionMock.CreateModel().Returns(modelMock);
             var consumerErrorStrategy = CreateConsumerErrorStrategy(persistedConnectionMock, true);
 
-            var ackStrategy = consumerErrorStrategy.HandleConsumerError(CreateConsumerExcutionContext(CreateOriginalMessage()), new Exception("I just threw!"));
+            var ackStrategy = await consumerErrorStrategy.HandleConsumerErrorAsync(CreateConsumerExcutionContext(CreateOriginalMessage()), new Exception("I just threw!"), default);
 
             Assert.Equal(AckStrategies.Ack, ackStrategy);
             modelMock.Received().WaitForConfirms(Arg.Any<TimeSpan>());
@@ -26,7 +27,7 @@ namespace EasyNetQ.Tests.ConsumeTests
         }
 
         [Fact]
-        public void
+        public async Task
             Should_enable_publisher_confirm_when_configured_and_return_nack_with_requeue_when_no_confirm_received()
         {
             var persistedConnectionMock = Substitute.For<IPersistentConnection>();
@@ -35,7 +36,7 @@ namespace EasyNetQ.Tests.ConsumeTests
             persistedConnectionMock.CreateModel().Returns(modelMock);
             var consumerErrorStrategy = CreateConsumerErrorStrategy(persistedConnectionMock, true);
 
-            var ackStrategy = consumerErrorStrategy.HandleConsumerError(CreateConsumerExcutionContext(CreateOriginalMessage()), new Exception("I just threw!"));
+            var ackStrategy = await consumerErrorStrategy.HandleConsumerErrorAsync(CreateConsumerExcutionContext(CreateOriginalMessage()), new Exception("I just threw!"), default);
 
             Assert.Equal(AckStrategies.NackWithRequeue, ackStrategy);
             modelMock.Received().WaitForConfirms(Arg.Any<TimeSpan>());
@@ -43,7 +44,7 @@ namespace EasyNetQ.Tests.ConsumeTests
         }
 
         [Fact]
-        public void Should_not_enable_publisher_confirm_when_not_configured_and_return_ack_when_no_confirm_received()
+        public async Task Should_not_enable_publisher_confirm_when_not_configured_and_return_ack_when_no_confirm_received()
         {
             var persistedConnectionMock = Substitute.For<IPersistentConnection>();
             var modelMock = Substitute.For<IModel>();
@@ -51,7 +52,7 @@ namespace EasyNetQ.Tests.ConsumeTests
             persistedConnectionMock.CreateModel().Returns(modelMock);
             var consumerErrorStrategy = CreateConsumerErrorStrategy(persistedConnectionMock);
 
-            var ackStrategy = consumerErrorStrategy.HandleConsumerError(CreateConsumerExcutionContext(CreateOriginalMessage()), new Exception("I just threw!"));
+            var ackStrategy = await consumerErrorStrategy.HandleConsumerErrorAsync(CreateConsumerExcutionContext(CreateOriginalMessage()), new Exception("I just threw!"), default);
 
             Assert.Equal(AckStrategies.Ack, ackStrategy);
             modelMock.DidNotReceive().WaitForConfirms(Arg.Any<TimeSpan>());

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_cancelled.cs
@@ -25,7 +25,7 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
         public When_a_user_handler_is_cancelled()
         {
             consumerErrorStrategy = Substitute.For<IConsumerErrorStrategy>();
-            consumerErrorStrategy.HandleConsumerCancelled(default).ReturnsForAnyArgs(AckStrategies.Ack);
+            consumerErrorStrategy.HandleConsumerCancelledAsync(default).ReturnsForAnyArgs(Task.FromResult(AckStrategies.Ack));
 
             var handlerRunner = new HandlerRunner(consumerErrorStrategy);
 
@@ -34,7 +34,7 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
             consumer.Model.Returns(channel);
 
             context = new ConsumerExecutionContext(
-                async (body, properties, info, cancellation) => throw new OperationCanceledException(),
+                (body, properties, info, cancellation) => Task.FromException<AckStrategy>(new OperationCanceledException()),
                 messageInfo,
                 messageProperties,
                 messageBody
@@ -55,9 +55,9 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
         }
 
         [Fact]
-        public void Should_handle_consumer_cancelled()
+        public async Task Should_handle_consumer_cancelled()
         {
-            consumerErrorStrategy.Received().HandleConsumerCancelled(context);
+            await consumerErrorStrategy.Received().HandleConsumerCancelledAsync(context);
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_executed.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_executed.cs
@@ -23,12 +23,12 @@ namespace EasyNetQ.Tests.HandlerRunnerTests
             consumer.Model.Returns(channel);
 
             var context = new ConsumerExecutionContext(
-                async (body, properties, info, cancellation) =>
+                (body, properties, info, cancellation) =>
                 {
                     deliveredBody = body;
                     deliveredProperties = properties;
                     deliveredInfo = info;
-                    return AckStrategies.Ack;
+                    return Task.FromResult(AckStrategies.Ack);
                 },
                 messageInfo,
                 messageProperties,

--- a/Source/EasyNetQ.Tests/SubscribeTests.cs
+++ b/Source/EasyNetQ.Tests/SubscribeTests.cs
@@ -9,6 +9,7 @@ using EasyNetQ.Tests.Mocking;
 using FluentAssertions;
 using NSubstitute;
 using RabbitMQ.Client;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace EasyNetQ.Tests
@@ -115,9 +116,6 @@ namespace EasyNetQ.Tests
         [Fact]
         public void Should_return_non_null_and_with_expected_values_result()
         {
-            Assert.NotNull(subscriptionResult);
-            Assert.NotNull(subscriptionResult.Exchange);
-            Assert.NotNull(subscriptionResult.Queue);
             Assert.True(subscriptionResult.Exchange.Name == typeName);
             Assert.True(subscriptionResult.Queue.Name == queueName);
         }
@@ -320,12 +318,12 @@ namespace EasyNetQ.Tests
             };
 
             consumerErrorStrategy = Substitute.For<IConsumerErrorStrategy>();
-            consumerErrorStrategy.HandleConsumerError(default, null)
+            consumerErrorStrategy.HandleConsumerErrorAsync(default, null)
                 .ReturnsForAnyArgs(i =>
                 {
                     basicDeliverEventArgs = (ConsumerExecutionContext)i[0];
                     raisedException = (Exception)i[1];
-                    return AckStrategies.Ack;
+                    return Task.FromResult(AckStrategies.Ack);
                 });
 
             mockBuilder = new MockBuilder(x => x
@@ -376,7 +374,7 @@ namespace EasyNetQ.Tests
         public void Should_invoke_the_consumer_error_strategy()
         {
             consumerErrorStrategy.Received()
-                .HandleConsumerError(Arg.Any<ConsumerExecutionContext>(), Arg.Any<Exception>());
+                .HandleConsumerErrorAsync(Arg.Any<ConsumerExecutionContext>(), Arg.Any<Exception>(), Arg.Any<CancellationToken>());
         }
 
         [Fact]

--- a/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
+++ b/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
@@ -4,7 +4,6 @@ using System;
 using System.Text;
 using System.Threading.Tasks;
 using EasyNetQ.Consumer;
-using EasyNetQ.Internals;
 using EasyNetQ.Tests.Mocking;
 using NSubstitute;
 using RabbitMQ.Client;
@@ -39,7 +38,7 @@ namespace EasyNetQ.Tests
             const string originalMessage = "";
             var originalMessageBody = Encoding.UTF8.GetBytes(originalMessage);
 
-            var context = new ConsumerExecutionContext(
+            consumerExecutionContext = new ConsumerExecutionContext(
                 (bytes, properties, info, cancellation) => Task.FromResult(AckStrategies.Ack),
                 new MessageReceivedInfo("consumerTag", 0, false, "orginalExchange", "originalRoutingKey", "queue"),
                 new MessageProperties
@@ -49,44 +48,41 @@ namespace EasyNetQ.Tests
                 },
                 originalMessageBody
             );
-
-            try
-            {
-                errorAckStrategy = errorStrategy.HandleConsumerError(context, new Exception());
-                cancelAckStrategy = errorStrategy.HandleConsumerCancelled(context);
-            }
-            catch (Exception)
-            {
-                // swallow
-            }
         }
 
         private DefaultConsumerErrorStrategy errorStrategy;
         private MockBuilder mockBuilder;
-        private AckStrategy errorAckStrategy;
-        private AckStrategy cancelAckStrategy;
+        private ConsumerExecutionContext consumerExecutionContext;
 
         [Fact]
-        public void Should_Ack_canceled_message()
+        public async Task Should_Ack_canceled_message()
         {
+            var cancelAckStrategy = await errorStrategy.HandleConsumerCancelledAsync(consumerExecutionContext, default);
+
             Assert.Same(AckStrategies.NackWithRequeue, cancelAckStrategy);
         }
 
         [Fact]
-        public void Should_Ack_failed_message()
+        public async Task Should_Ack_failed_message()
         {
+            var errorAckStrategy = await errorStrategy.HandleConsumerErrorAsync(consumerExecutionContext, new Exception(), default);
+
             Assert.Same(AckStrategies.Ack, errorAckStrategy);
         }
 
         [Fact]
-        public void Should_use_exchange_name_from_custom_names_provider()
+        public async Task Should_use_exchange_name_from_custom_names_provider()
         {
+            await errorStrategy.HandleConsumerErrorAsync(consumerExecutionContext, new Exception(), default);
+
             mockBuilder.Channels[0].Received().ExchangeDeclare("CustomErrorExchangePrefixName.originalRoutingKey", "direct", true);
         }
 
         [Fact]
-        public void Should_use_queue_name_from_custom_names_provider()
+        public async Task Should_use_queue_name_from_custom_names_provider()
         {
+            await errorStrategy.HandleConsumerErrorAsync(consumerExecutionContext, new Exception(), default);
+
             mockBuilder.Channels[0].Received().QueueDeclare("CustomEasyNetQErrorQueueName", true, false, false, null);
         }
     }

--- a/Source/EasyNetQ/Consumer/HandlerRunner.cs
+++ b/Source/EasyNetQ/Consumer/HandlerRunner.cs
@@ -86,11 +86,15 @@ namespace EasyNetQ.Consumer
                 }
                 catch (OperationCanceledException)
                 {
-                    return consumerErrorStrategy.HandleConsumerCancelled(context);
+                    return await consumerErrorStrategy.HandleConsumerCancelledAsync(
+                        context, cancellationToken
+                    ).ConfigureAwait(false);
                 }
                 catch (Exception exception)
                 {
-                    return consumerErrorStrategy.HandleConsumerError(context, exception);
+                    return await consumerErrorStrategy.HandleConsumerErrorAsync(
+                        context, exception, cancellationToken
+                    ).ConfigureAwait(false);
                 }
             }
             catch (Exception exception)

--- a/Source/EasyNetQ/Consumer/IConsumerErrorStrategy.cs
+++ b/Source/EasyNetQ/Consumer/IConsumerErrorStrategy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/Source/EasyNetQ/Consumer/IConsumerErrorStrategy.cs
+++ b/Source/EasyNetQ/Consumer/IConsumerErrorStrategy.cs
@@ -1,4 +1,6 @@
-using System;
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace EasyNetQ.Consumer
 {
@@ -10,15 +12,17 @@ namespace EasyNetQ.Consumer
         /// </summary>
         /// <param name="context">The consumer execution context.</param>
         /// <param name="exception">The exception</param>
+        /// <param name="cancellationToken"></param>
         /// <returns><see cref="AckStrategy"/> for processing the original failed message</returns>
-        AckStrategy HandleConsumerError(ConsumerExecutionContext context, Exception exception);
+        Task<AckStrategy> HandleConsumerErrorAsync(ConsumerExecutionContext context, Exception exception, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// This method is fired when the task returned from the UserHandler is cancelled.
         /// Implement a strategy for handling the cancellation here.
         /// </summary>
         /// <param name="context">The consumer execution context.</param>
+        /// <param name="cancellationToken"></param>
         /// <returns><see cref="AckStrategy"/> for processing the original cancelled message</returns>
-        AckStrategy HandleConsumerCancelled(ConsumerExecutionContext context);
+        Task<AckStrategy> HandleConsumerCancelledAsync(ConsumerExecutionContext context, CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
Hello,

I would like to create a custom `IConsumerErrorStrategy` with `await work(cancellationToken);`

Now it is possible only over `work().ConfigureAwait(false).GetAwaiter().GetResult()`.