### PR TITLE
Max channel handling support

### DIFF
--- a/Source/EasyNetQ/ConnectionConfiguration.cs
+++ b/Source/EasyNetQ/ConnectionConfiguration.cs
@@ -32,7 +32,8 @@ namespace EasyNetQ
             PublisherConfirms = false;
             PersistentMessages = true;
             ConnectIntervalAttempt = TimeSpan.FromSeconds(5);
-            MandatoryPublish = false;
+            RequestedChannelMax = 2047;
+            MandatoryPublish = false;             
 
             // prefetchCount determines how many messages will be allowed in the local in-memory queue
             // setting to zero makes this infinite, but risks an out-of-memory exception.
@@ -136,6 +137,11 @@ namespace EasyNetQ
         ///     Enables mandatory flag for publish (default is false)
         /// </summary>
         public bool MandatoryPublish { get; set; }
+
+        /// <summary>
+        ///     Maximum channel number per connection (default is 2047)
+        /// </summary>
+        public ushort RequestedChannelMax { get; set; }
     }
 
     /// <summary>

--- a/Source/EasyNetQ/DI/ConnectionFactoryFactory.cs
+++ b/Source/EasyNetQ/DI/ConnectionFactoryFactory.cs
@@ -23,7 +23,8 @@ namespace EasyNetQ.DI
                 NetworkRecoveryInterval = configuration.ConnectIntervalAttempt,
                 ContinuationTimeout = configuration.Timeout,
                 DispatchConsumersAsync = true,
-                ConsumerDispatchConcurrency = configuration.PrefetchCount
+                ConsumerDispatchConcurrency = configuration.PrefetchCount,
+                RequestedChannelMax = configuration.RequestedChannelMax
             };
             return connectionFactory;
         }

--- a/hall_of_fame.md
+++ b/hall_of_fame.md
@@ -68,3 +68,4 @@ No particular order. Don't forget to add your name with your pull request.
 * Marcus Hellsten
 * Thomas Mutton
 * Ivan Maximov
+* Jens Willmer


### PR DESCRIPTION
I implemented max channel handling support to solve my problem I described in #1224 

User can set max supported channels by client and limit the creation of new channels like this:
```
var rabbitConfig = new ConnectionConfiguration
{
    ...
    RequestedChannelMax = 1
    ..
};

RabbitHutch.CreateBus(rabbitConfig, sr => { });
```

**How it works:**

If max supported channel limit is reached EasyNetQ returns the last created channel for any new requested channel. 

**Potential problems/side effects**
This can potentially create problems when developers are not aware that multiple queues can be connected to the same channel. However the current solution is also not perfect since when the limit is reached it stops creating new queues silently. So I believe we trade one side effect with another in this edge case.