### PR TITLE
Fix missing unescape in AmqpConnectionStringParser

### DIFF
--- a/Source/EasyNetQ.Tests/ConnectionString/AmqpConnectionStringParserTests.cs
+++ b/Source/EasyNetQ.Tests/ConnectionString/AmqpConnectionStringParserTests.cs
@@ -25,7 +25,17 @@ namespace EasyNetQ.Tests.ConnectionString
             {
                 return new[] { new AmqpSpecification(uri, configuration) };
             }
-
+            yield return Spec(
+               "amqp://user%2f:P%40ssword@host:10000/v%2fhost?name=unit%2ftest",
+               new ConnectionConfiguration
+               {
+                   Hosts = new[] { new HostConfiguration { Host = "host", Port = 10000 } },
+                   VirtualHost = "v/host",
+                   UserName = "user/",
+                   Password = "P@ssword",
+                   Name = "unit/test",
+               }
+           );
             yield return Spec(
                 "amqp://user:pass@host:10000/vhost",
                 new ConnectionConfiguration

--- a/Source/EasyNetQ/ConnectionString/AmqpConnectionStringParser.cs
+++ b/Source/EasyNetQ/ConnectionString/AmqpConnectionStringParser.cs
@@ -61,14 +61,14 @@ namespace EasyNetQ.ConnectionString
                 if (userPass.Length > 2)
                     throw new ArgumentException($"Bad user info in AMQP URI: {userInfo}");
 
-                configuration.UserName = Uri.EscapeUriString(userPass[0]);
-                if (userPass.Length == 2) configuration.Password = Uri.EscapeUriString(userPass[1]);
+                configuration.UserName = Uri.UnescapeDataString(userPass[0]);
+                if (userPass.Length == 2) configuration.Password = Uri.UnescapeDataString(userPass[1]);
             }
 
             if (uri.Segments.Length > 2)
                 throw new ArgumentException($"Multiple segments in path of AMQP URI: {string.Join(", ", uri.Segments)}");
 
-            if (uri.Segments.Length == 2) configuration.VirtualHost = Uri.EscapeUriString(uri.Segments[1]);
+            if (uri.Segments.Length == 2) configuration.VirtualHost = Uri.UnescapeDataString(uri.Segments[1]);
 
             var query = uri.ParseQuery();
             return Parsers.Aggregate(configuration, (current, parser) => parser(current, query));


### PR DESCRIPTION
Fixing problem when connection string contains special characters.