### PR TITLE
Improve quorum queues implementation

### DIFF
--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_queue_type.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_queue_type.cs
@@ -25,7 +25,7 @@ namespace EasyNetQ.IntegrationTests.PubSub
             bus.Dispose();
         }
 
-        private const int MessagesCount = 1;
+        private const int MessagesCount = 10;
 
         private readonly IBus bus;
 

--- a/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_queue_type.cs
+++ b/Source/EasyNetQ.IntegrationTests/PubSub/When_publish_and_subscribe_with_queue_type.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EasyNetQ.IntegrationTests.Utils;
+using FluentAssertions;
+using Xunit;
+
+namespace EasyNetQ.IntegrationTests.PubSub
+{
+    [Collection("RabbitMQ")]
+    public class When_publish_and_subscribe_with_queue_type : IDisposable
+    {
+        private readonly RabbitMQFixture rmqFixture;
+
+        public When_publish_and_subscribe_with_queue_type(RabbitMQFixture rmqFixture)
+        {
+            this.rmqFixture = rmqFixture;
+            bus = RabbitHutch.CreateBus($"host={rmqFixture.Host};prefetchCount=1;timeout=-1");
+        }
+
+        public void Dispose()
+        {
+            bus.Dispose();
+        }
+
+        private const int MessagesCount = 1;
+
+        private readonly IBus bus;
+
+        [Fact]
+        public async Task Should_publish_and_consume()
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+            var subscriptionId = Guid.NewGuid().ToString();
+            var messagesSink = new MessagesSink(MessagesCount);
+            var messages = CreateMessages(MessagesCount);
+
+            using (await bus.PubSub.SubscribeAsync<QuorumQueueMessage>(subscriptionId, messagesSink.Receive))
+            {
+                await bus.PubSub.PublishBatchAsync(messages, cts.Token);
+
+                await messagesSink.WaitAllReceivedAsync(cts.Token);
+                messagesSink.ReceivedMessages.Should().Equal(messages);
+            }
+        }
+
+        private static List<QuorumQueueMessage> CreateMessages(int count)
+        {
+            var result = new List<QuorumQueueMessage>();
+            for (int i = 0; i < count; i++)
+                result.Add(new QuorumQueueMessage(i));
+            return result;
+        }
+    }
+
+    [Queue("QuorumQueue", QueueType = QueueType.Quorum)]
+    public class QuorumQueueMessage : Message
+    {
+        public QuorumQueueMessage(int id) : base(id)
+        {
+        }
+    }
+}

--- a/Source/EasyNetQ.Tests/ConventionsTests.cs
+++ b/Source/EasyNetQ.Tests/ConventionsTests.cs
@@ -95,6 +95,15 @@ namespace EasyNetQ.Tests
         }
 
         [Theory]
+        [InlineData(typeof(QuorumQueueTestMessage))]
+        [InlineData(typeof(IQuorumQueueTestMessage))]
+        public void The_queue_type_convention_should_use_attribute_QueueType(Type messageType)
+        {
+            var result = conventions.QueueTypeConvention(messageType);
+            result.Should().Be(QueueType.Quorum);
+        }
+
+        [Theory]
         [InlineData(typeof(AnnotatedTestMessage))]
         [InlineData(typeof(IAnnotatedTestMessage))]
         public void The_queue_naming_convention_should_use_attribute_queueName_then_an_underscore_then_the_subscription_id(Type messageType)

--- a/Source/EasyNetQ.Tests/SubscribeTests.cs
+++ b/Source/EasyNetQ.Tests/SubscribeTests.cs
@@ -90,7 +90,7 @@ namespace EasyNetQ.Tests
         public void Should_set_configured_prefetch_count()
         {
             var connectionConfiguration = new ConnectionConfiguration();
-            mockBuilder.Channels[1].Received().BasicQos(0, connectionConfiguration.PrefetchCount, true);
+            mockBuilder.Channels[1].Received().BasicQos(0, connectionConfiguration.PrefetchCount, false);
         }
 
         [Fact]
@@ -210,7 +210,7 @@ namespace EasyNetQ.Tests
             );
 
             // Assert that QoS got configured correctly
-            mockBuilder.Channels[1].Received().BasicQos(0, prefetchCount, true);
+            mockBuilder.Channels[1].Received().BasicQos(0, prefetchCount, false);
 
             // Assert that binding got configured correctly
             mockBuilder.Channels[0].Received().QueueBind(

--- a/Source/EasyNetQ.Tests/TestMessage.cs
+++ b/Source/EasyNetQ.Tests/TestMessage.cs
@@ -4,6 +4,16 @@ namespace EasyNetQ.Tests
     {
     }
 
+    [Queue("MyQueue", QueueType = QueueType.Quorum)]
+    public class QuorumQueueTestMessage
+    {
+    }
+
+    [Queue("MyQueue", QueueType = QueueType.Quorum)]
+    public interface IQuorumQueueTestMessage
+    {
+    }
+
     [Queue("MyQueue", ExchangeName = "MyExchange")]
     public class AnnotatedTestMessage
     {

--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -128,7 +128,7 @@ namespace EasyNetQ.Consumer
                 try
                 {
                     model = connection.CreateModel();
-                    model.BasicQos(0, configuration.PrefetchCount, true);
+                    model.BasicQos(0, configuration.PrefetchCount, false);
                 }
                 catch (Exception exception)
                 {

--- a/Source/EasyNetQ/Conventions.cs
+++ b/Source/EasyNetQ/Conventions.cs
@@ -19,6 +19,11 @@ namespace EasyNetQ
     public delegate string QueueNameConvention(Type messageType, string subscriberId);
 
     /// <summary>
+    ///     Convention for queue type
+    /// </summary>
+    public delegate string QueueTypeConvention(Type messageType);
+
+    /// <summary>
     ///     Convention for error queue routing key naming
     /// </summary>
     public delegate string ErrorQueueNameConvention(MessageReceivedInfo receivedInfo);
@@ -67,6 +72,11 @@ namespace EasyNetQ
         ///     Convention for queue naming
         /// </summary>
         QueueNameConvention QueueNamingConvention { get; }
+
+        /// <summary>
+        ///     Convention for queue type
+        /// </summary>
+        QueueTypeConvention QueueTypeConvention { get; }
 
         /// <summary>
         ///     Convention for RPC routing key naming
@@ -123,6 +133,15 @@ namespace EasyNetQ
                     : attr.ExchangeName;
             };
 
+            QueueTypeConvention = type =>
+            {
+                var attr = GetQueueAttribute(type);
+
+                return string.IsNullOrEmpty(attr.QueueType)
+                    ? null
+                    : attr.QueueType;
+            };
+
             TopicNamingConvention = type => "";
 
             QueueNamingConvention = (type, subscriptionId) =>
@@ -166,6 +185,9 @@ namespace EasyNetQ
 
         /// <inheritdoc />
         public QueueNameConvention QueueNamingConvention { get; set; }
+
+        /// <inheritdoc />
+        public QueueTypeConvention QueueTypeConvention { get; set; }
 
         /// <inheritdoc />
         public RpcRoutingKeyNamingConvention RpcRoutingKeyNamingConvention { get; set; }

--- a/Source/EasyNetQ/DefaultPubSub.cs
+++ b/Source/EasyNetQ/DefaultPubSub.cs
@@ -103,6 +103,10 @@ namespace EasyNetQ
 
             var queueName = subscriptionConfiguration.QueueName ?? conventions.QueueNamingConvention(typeof(T), subscriptionId);
             var exchangeName = conventions.ExchangeNamingConvention(typeof(T));
+            var queueType = conventions.QueueTypeConvention(typeof(T));
+
+            if (!string.IsNullOrEmpty(queueType))
+                subscriptionConfiguration.WithQueueType(queueType);
 
             var queue = await advancedBus.QueueDeclareAsync(
                 queueName,

--- a/Source/EasyNetQ/QueueAttribute.cs
+++ b/Source/EasyNetQ/QueueAttribute.cs
@@ -15,5 +15,7 @@ namespace EasyNetQ
         public string QueueName { get; }
 
         public string ExchangeName { get; set; }
+
+        public string QueueType { get; set; }
     }
 }


### PR DESCRIPTION
Hello,
Based on my previous issue (https://github.com/EasyNetQ/EasyNetQ/issues/1241),

This is my first pull request to this repository, I'd like to start using EasyNetQ but currently the project doesn't have fully implemented quorum queues, so I decided to contribute finishing implementing them :)

Important change note:
Currently, it's not possible to **use** quorum queues with the actual implementation existent on EasyNetQ source code, it's only possible to **create** them, but not subscribe. The reason for that is, in the InternalConsumer the prefetch configuration is set to global = true and it's impossible to use quorum queues with that configuration (reference: https://www.rabbitmq.com/consumer-prefetch.html) then I changed to global = false, which according to rabbitMq documentation is the default in most APIs and should not impact current implementation: "Note that the default value for the global flag is false in most APIs."(reference: https://www.rabbitmq.com/consumer-prefetch.html)

I also added some Unit and Integration tests to improve this implementation.

Tried to do my best to follow current patterns and project structure, but I'm open to any modification, suggestions or something I missed.
