### PR TITLE
In case of internal errors reopen a channel and try again

### DIFF
--- a/Source/EasyNetQ/Producer/AmqpErrorCodes.cs
+++ b/Source/EasyNetQ/Producer/AmqpErrorCodes.cs
@@ -7,5 +7,6 @@ namespace EasyNetQ.Producer
         public const ushort NotFound = 404;
         public const ushort ResourceLocked = 405;
         public const ushort PreconditionFailed = 406;
+        public const ushort InternalErrors = 541;
     }
 }

--- a/Source/EasyNetQ/Producer/PersistentChannel.cs
+++ b/Source/EasyNetQ/Producer/PersistentChannel.cs
@@ -189,6 +189,7 @@ namespace EasyNetQ.Producer
                         AmqpErrorCodes.NotFound => ExceptionVerdict.ThrowAndCloseChannel,
                         AmqpErrorCodes.ResourceLocked => ExceptionVerdict.ThrowAndCloseChannel,
                         AmqpErrorCodes.PreconditionFailed => ExceptionVerdict.ThrowAndCloseChannel,
+                        AmqpErrorCodes.InternalErrors => ExceptionVerdict.SuppressAndCloseChannel,
                         _ => ExceptionVerdict.Throw
                     };
                 case NotSupportedException e:
@@ -196,7 +197,7 @@ namespace EasyNetQ.Producer
                     return isRequestPipeliningForbiddenException
                         ? ExceptionVerdict.SuppressAndCloseChannel
                         : ExceptionVerdict.Throw;
-                case EasyNetQException _:
+                case EasyNetQException:
                     return ExceptionVerdict.Suppress;
                 default:
                     return ExceptionVerdict.Throw;


### PR DESCRIPTION
Fixes #1249, #1248.

It doesn't look like we are able to do something with connection disruptions, but we are able to handle these events gracefully.