### PR TITLE
Fix connection close logging

### DIFF
--- a/Source/EasyNetQ/PersistentConnection.cs
+++ b/Source/EasyNetQ/PersistentConnection.cs
@@ -62,7 +62,7 @@ namespace EasyNetQ
 
 
         /// <inheritdoc />
-        public bool IsConnected => initializedConnection is { IsOpen: true };
+        public bool IsConnected => initializedConnection is {IsOpen: true};
 
         /// <inheritdoc />
         public void Connect()
@@ -148,17 +148,14 @@ namespace EasyNetQ
         {
             var connection = Interlocked.Exchange(ref initializedConnection, null);
             if (connection == null) return;
-
-            connection.RecoverySucceeded -= OnConnectionRecovered;
-            connection.ConnectionUnblocked -= OnConnectionUnblocked;
-            connection.ConnectionBlocked -= OnConnectionBlocked;
-            connection.ConnectionShutdown -= OnConnectionShutdown;
+            
             connection.Dispose();
+            connection.RecoverySucceeded -= OnConnectionRecovered;
         }
 
         private void OnConnectionRecovered(object sender, EventArgs e)
         {
-            var connection = (IConnection)sender;
+            var connection = (IConnection) sender;
             logger.InfoFormat(
                 "Reconnected to broker {host}:{port}",
                 connection.Endpoint.HostName,
@@ -169,7 +166,7 @@ namespace EasyNetQ
 
         private void OnConnectionShutdown(object sender, ShutdownEventArgs e)
         {
-            var connection = (IConnection)sender;
+            var connection = (IConnection) sender;
             logger.InfoFormat(
                 "Disconnected from broker {host}:{port} because of {reason}",
                 connection.Endpoint.HostName,

--- a/Source/EasyNetQ/PersistentConnection.cs
+++ b/Source/EasyNetQ/PersistentConnection.cs
@@ -62,7 +62,7 @@ namespace EasyNetQ
 
 
         /// <inheritdoc />
-        public bool IsConnected => initializedConnection is {IsOpen: true};
+        public bool IsConnected => initializedConnection is { IsOpen: true };
 
         /// <inheritdoc />
         public void Connect()
@@ -148,14 +148,14 @@ namespace EasyNetQ
         {
             var connection = Interlocked.Exchange(ref initializedConnection, null);
             if (connection == null) return;
-            
+
             connection.Dispose();
             connection.RecoverySucceeded -= OnConnectionRecovered;
         }
 
         private void OnConnectionRecovered(object sender, EventArgs e)
         {
-            var connection = (IConnection) sender;
+            var connection = (IConnection)sender;
             logger.InfoFormat(
                 "Reconnected to broker {host}:{port}",
                 connection.Endpoint.HostName,
@@ -166,7 +166,7 @@ namespace EasyNetQ
 
         private void OnConnectionShutdown(object sender, ShutdownEventArgs e)
         {
-            var connection = (IConnection) sender;
+            var connection = (IConnection)sender;
             logger.InfoFormat(
                 "Disconnected from broker {host}:{port} because of {reason}",
                 connection.Endpoint.HostName,


### PR DESCRIPTION
@micdenny found that in v7 EasyNetQ doesn't log anything on PersistentConnection dispose.

![image](https://user-images.githubusercontent.com/664889/133871288-3a054188-6729-41c2-abc6-4a86bfc65094.png)
![image](https://user-images.githubusercontent.com/664889/133871292-fcfef9f8-e0bb-4909-a40f-4f2c52811da0.png)


I've investigated and found that because of the unsubscription from events before calling Dispose this log is lost.

As a solution, we previously agreed to dispose firstly and then unsubscribe from events. These works only for `            connection.RecoverySucceeded -= OnConnectionRecovered;`, for other events it's prohibited to unsubscribe from them after a connection disposal.

```
Object name: 'RabbitMQ.Client.Framing.Impl.AutorecoveringConnection'.
   at RabbitMQ.Client.Framing.Impl.AutorecoveringConnection.remove_ConnectionUnblocked(EventHandler`1 value)
   at EasyNetQ.PersistentConnection.DisposeConnection() in /Users/yury.pliner/Sources/EasyNetQ/Source/EasyNetQ/PersistentConnection.cs:line 155
   at EasyNetQ.PersistentConnection.Dispose() in /Users/yury.pliner/Sources/EasyNetQ/Source/EasyNetQ/PersistentConnection.cs:line 99
   at EasyNetQ.LightInject.PerContainerLifetime.Dispose() in /Users/yury.pliner/Sources/EasyNetQ/Source/EasyNetQ/obj/Debug/netstandard2.0/NuGet/56E02254B6148CDA43C30E90DB662F722D3D6688/LightInject.Source/6.4.0/LightInject/LightInject.cs:line 6438
   at EasyNetQ.LightInject.ServiceContainer.Dispose() in /Users/yury.pliner/Sources/EasyNetQ/Source/EasyNetQ/obj/Debug/netstandard2.0/NuGet/56E02254B6148CDA43C30E90DB662
```

There are a good news though: these events handlers(except one mentioned) are nullified on `AutorecoveringConnection.Dispose`.

