### PR TITLE
Eliminate ROM.ToArray() heap allocation in GZipInterceptor and TripleDESInterceptor

### DIFF
--- a/Source/EasyNetQ/Interception/GZipInterceptor.cs
+++ b/Source/EasyNetQ/Interception/GZipInterceptor.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.IO;
 using System.IO.Compression;
 
@@ -11,25 +12,41 @@ namespace EasyNetQ.Interception
         /// <inheritdoc />
         public ProducedMessage OnProduce(in ProducedMessage message)
         {
-            var properties = message.Properties;
-            var body = message.Body.ToArray(); // TODO Do not copy here
-            using var output = new MemoryStream();
-            using (var compressingStream = new GZipStream(output, CompressionMode.Compress))
-                compressingStream.Write(body, 0, body.Length);
-            return new ProducedMessage(properties, output.ToArray());
+            var body = ArrayPool<byte>.Shared.Rent(message.Body.Length); // most likely rented array is larger than message.Body
+
+            try
+            {
+                message.Body.CopyTo(body);
+                using var output = new MemoryStream();
+                using (var compressingStream = new GZipStream(output, CompressionMode.Compress))
+                    compressingStream.Write(body, 0, message.Body.Length);
+                return new ProducedMessage(message.Properties, output.ToArray()); // TODO: think of a better memory management for interceptors
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(body);
+            }
         }
 
         /// <inheritdoc />
         public ConsumedMessage OnConsume(in ConsumedMessage message)
         {
-            var receivedInfo = message.ReceivedInfo;
-            var properties = message.Properties;
-            var body = message.Body;
-            using var output = new MemoryStream();
-            using (var compressedStream = new MemoryStream(body.ToArray())) // TODO Do not copy here
-            using (var decompressingStream = new GZipStream(compressedStream, CompressionMode.Decompress))
-                decompressingStream.CopyTo(output);
-            return new ConsumedMessage(receivedInfo, properties, output.ToArray());
+            var body = ArrayPool<byte>.Shared.Rent(message.Body.Length); // most likely rented array is larger than message.Body
+
+            try
+            {
+                message.Body.CopyTo(body);
+
+                using var output = new MemoryStream();
+                using (var compressedStream = new MemoryStream(body, 0, message.Body.Length))
+                using (var decompressingStream = new GZipStream(compressedStream, CompressionMode.Decompress))
+                    decompressingStream.CopyTo(output);
+                return new ConsumedMessage(message.ReceivedInfo, message.Properties, output.ToArray()); // TODO: think of better memory management for interceptors
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(body);
+            }
         }
     }
 }


### PR DESCRIPTION
This code was moved from #1277 to make review easier.