### PR TITLE
Fixed problem of extracting the original message type.

### DIFF
--- a/Source/EasyNetQ/DefaultPubSub.cs
+++ b/Source/EasyNetQ/DefaultPubSub.cs
@@ -57,7 +57,7 @@ namespace EasyNetQ
             var publishConfiguration = new PublishConfiguration(conventions.TopicNamingConvention(typeof(T)));
             configure(publishConfiguration);
 
-            var messageType = typeof(T);
+            var messageType = message.GetType();
             var advancedMessageProperties = new MessageProperties();
             if (publishConfiguration.Priority != null)
                 advancedMessageProperties.Priority = publishConfiguration.Priority.Value;


### PR DESCRIPTION
My case is when I have a method to which pass a variable of the `IMessage` type and a queue name of the appropriate type is created, but in this case I want to get `MessageA` or  `MessageB` that are inheritors of  `IMessage`

According to my case, is this a problem or am I using it incorrectly?