### PR TITLE
Recreate a model if it is closed due to a soft error

### DIFF
--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_via_soft_error.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_via_soft_error.cs
@@ -31,7 +31,7 @@ public class When_a_consumer_is_cancelled_via_soft_error : IDisposable
             new ShutdownEventArgs(ShutdownInitiator.Application, AmqpErrorCodes.PreconditionFailed, "Oops")
         );
         mockBuilder.Consumers[0].HandleBasicCancel("consumer_tag").GetAwaiter().GetResult();
-        // Wait for period consumer restart
+        // Wait for a periodic consumer restart
         Task.Delay(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
     }
 

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_via_soft_error.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_cancelled_via_soft_error.cs
@@ -1,0 +1,51 @@
+// ReSharper disable InconsistentNaming
+
+using System;
+using System.Threading.Tasks;
+using EasyNetQ.Persistent;
+using EasyNetQ.Tests.Mocking;
+using EasyNetQ.Topology;
+using NSubstitute;
+using RabbitMQ.Client;
+using Xunit;
+
+namespace EasyNetQ.Tests.ConsumeTests;
+
+public class When_a_consumer_is_cancelled_via_soft_error : IDisposable
+{
+    private readonly MockBuilder mockBuilder;
+
+    public When_a_consumer_is_cancelled_via_soft_error()
+    {
+        mockBuilder = new MockBuilder();
+
+        var queue = new Queue("my_queue", false);
+
+        mockBuilder.Bus.Advanced.Consume(
+            queue,
+            (_, _, _) => Task.Run(() => { }),
+            c => c.WithConsumerTag("consumer_tag")
+        );
+
+        mockBuilder.Consumers[0].Model.CloseReason.Returns(
+            new ShutdownEventArgs(ShutdownInitiator.Application, AmqpErrorCodes.PreconditionFailed, "Oops")
+        );
+        mockBuilder.Consumers[0].HandleBasicCancel("consumer_tag").GetAwaiter().GetResult();
+        // Wait for period consumer restart
+        Task.Delay(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
+    }
+
+    public void Dispose()
+    {
+        mockBuilder.Dispose();
+    }
+
+    [Fact]
+    public void Should_recreate_model_and_consumer()
+    {
+        mockBuilder.Consumers[0].Model.Received().Dispose();
+        mockBuilder.Consumers[1].Model.DidNotReceive().Dispose();
+    }
+}
+
+// ReSharper restore InconsistentNaming

--- a/Source/EasyNetQ/Consumer/Consumer.cs
+++ b/Source/EasyNetQ/Consumer/Consumer.cs
@@ -84,8 +84,10 @@ public class ConsumerConfiguration
     /// <summary>
     ///     Creates ConsumerConfiguration
     /// </summary>
-    public ConsumerConfiguration(ushort prefetchCount,
-        IReadOnlyDictionary<Queue, PerQueueConsumerConfiguration> perQueueConfigurations)
+    public ConsumerConfiguration(
+        ushort prefetchCount,
+        IReadOnlyDictionary<Queue, PerQueueConsumerConfiguration> perQueueConfigurations
+    )
     {
         PrefetchCount = prefetchCount;
         PerQueueConfigurations = perQueueConfigurations;

--- a/Source/EasyNetQ/Consumer/Consumer.cs
+++ b/Source/EasyNetQ/Consumer/Consumer.cs
@@ -107,7 +107,7 @@ public class ConsumerConfiguration
 /// <inheritdoc />
 public class Consumer : IConsumer
 {
-    private static readonly TimeSpan RestartConsumingPeriod = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan RestartConsumingPeriod = TimeSpan.FromSeconds(5);
 
     private readonly ConsumerConfiguration configuration;
     private readonly IEventBus eventBus;


### PR DESCRIPTION
#1326

1. Stop sending cancelled event if a consumer has been cancelled due to a soft error.
2. Recreate a model if it is closed due to a soft error.