### PR TITLE
Added QueueType Parameter on Send / Receive (ReceiveConfiguration) & Single Active Consumer for PubSub (SubscriptionConfiguration)

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -417,6 +417,7 @@ namespace EasyNetQ
         EasyNetQ.IReceiveConfiguration WithPrefetchCount(ushort prefetchCount);
         EasyNetQ.IReceiveConfiguration WithPriority(int priority);
         EasyNetQ.IReceiveConfiguration WithQueueMode(string queueMode = "default");
+        EasyNetQ.IReceiveConfiguration WithQueueType(string queueType = "classic");
         EasyNetQ.IReceiveConfiguration WithSingleActiveConsumer(bool singleActiveConsumer = true);
     }
     public interface IReceiveRegistration
@@ -486,6 +487,7 @@ namespace EasyNetQ
         EasyNetQ.ISubscriptionConfiguration WithQueueMode(string queueMode = "default");
         EasyNetQ.ISubscriptionConfiguration WithQueueName(string queueName);
         EasyNetQ.ISubscriptionConfiguration WithQueueType(string queueType = "classic");
+        EasyNetQ.ISubscriptionConfiguration WithSingleActiveConsumer(bool singleActiveConsumer = true);
         EasyNetQ.ISubscriptionConfiguration WithTopic(string topic);
     }
     public interface ITypeNameSerializer

--- a/Source/EasyNetQ/DefaultPubSub.cs
+++ b/Source/EasyNetQ/DefaultPubSub.cs
@@ -138,6 +138,8 @@ public class DefaultPubSub : IPubSub
                     c.WithQueueMode(subscriptionConfiguration.QueueMode);
                 if (!string.IsNullOrEmpty(subscriptionConfiguration.QueueType))
                     c.WithQueueType(subscriptionConfiguration.QueueType);
+                if (subscriptionConfiguration.SingleActiveConsumer)
+                    c.WithSingleActiveConsumer();
             },
             cts.Token
         ).ConfigureAwait(false);

--- a/Source/EasyNetQ/DefaultSendReceive.cs
+++ b/Source/EasyNetQ/DefaultSendReceive.cs
@@ -110,6 +110,8 @@ public class DefaultSendReceive : ISendReceive
                     c.WithMaxLengthBytes(receiveConfiguration.MaxLengthBytes.Value);
                 if (!string.IsNullOrEmpty(receiveConfiguration.QueueMode))
                     c.WithQueueMode(receiveConfiguration.QueueMode);
+                if (!string.IsNullOrEmpty(receiveConfiguration.QueueType))
+                    c.WithQueueType(receiveConfiguration.QueueType);
                 if (receiveConfiguration.SingleActiveConsumer)
                     c.WithSingleActiveConsumer();
             },

--- a/Source/EasyNetQ/ReceiveConfiguration.cs
+++ b/Source/EasyNetQ/ReceiveConfiguration.cs
@@ -87,6 +87,13 @@ public interface IReceiveConfiguration
     IReceiveConfiguration WithQueueMode(string queueMode = QueueMode.Default);
 
     /// <summary>
+    /// Sets the queue type. Valid types are "classic" and "quorum". Works with RabbitMQ version 3.8+.
+    /// </summary>
+    /// <param name="queueType">Desired queue type.</param>
+    /// <returns>Returns a reference to itself</returns>
+    IReceiveConfiguration WithQueueType(string queueType = QueueType.Classic);
+
+    /// <summary>
     /// Configure the queue as single active consumer. Single active consumer allows to have only one consumer at a time consuming from a queue and to fail over to another registered consumer in case the active one is cancelled or dies.
     /// </summary>
     /// <param name="singleActiveConsumer">Queue's single-active-consumer flag</param>
@@ -106,6 +113,7 @@ internal class ReceiveConfiguration : IReceiveConfiguration
     public int? MaxLength { get; private set; }
     public int? MaxLengthBytes { get; private set; }
     public string QueueMode { get; private set; }
+    public string QueueType { get; private set; }
     public bool SingleActiveConsumer { get; private set; }
 
     public ReceiveConfiguration(ushort defaultPrefetchCount)
@@ -176,6 +184,12 @@ internal class ReceiveConfiguration : IReceiveConfiguration
     public IReceiveConfiguration WithQueueMode(string queueMode)
     {
         QueueMode = queueMode;
+        return this;
+    }
+
+    public IReceiveConfiguration WithQueueType(string queueType)
+    {
+        QueueType = queueType;
         return this;
     }
 

--- a/Source/EasyNetQ/ReceiveConfiguration.cs
+++ b/Source/EasyNetQ/ReceiveConfiguration.cs
@@ -187,7 +187,7 @@ internal class ReceiveConfiguration : IReceiveConfiguration
         return this;
     }
 
-    public IReceiveConfiguration WithQueueType(string queueType)
+    public IReceiveConfiguration WithQueueType(string queueType = EasyNetQ.QueueType.Classic)
     {
         QueueType = queueType;
         return this;

--- a/Source/EasyNetQ/SubscriptionConfiguration.cs
+++ b/Source/EasyNetQ/SubscriptionConfiguration.cs
@@ -122,6 +122,13 @@ public interface ISubscriptionConfiguration
     /// <param name="alternateExchange">The alternate exchange to set</param>
     /// <returns>Returns a reference to itself</returns>
     ISubscriptionConfiguration WithAlternateExchange(string alternateExchange);
+
+    /// <summary>
+    /// Configure the queue as single active consumer. Single active consumer allows to have only one consumer at a time consuming from a queue and to fail over to another registered consumer in case the active one is cancelled or dies.
+    /// </summary>
+    /// <param name="singleActiveConsumer">Queue's single-active-consumer flag</param>
+    /// <returns>Returns a reference to itself</returns>
+    ISubscriptionConfiguration WithSingleActiveConsumer(bool singleActiveConsumer = true);
 }
 
 internal class SubscriptionConfiguration : ISubscriptionConfiguration
@@ -141,6 +148,7 @@ internal class SubscriptionConfiguration : ISubscriptionConfiguration
     public string QueueType { get; private set; }
     public string ExchangeType { get; private set; } = Topology.ExchangeType.Topic;
     public string AlternateExchange { get; private set; }
+    public bool SingleActiveConsumer { get; private set; }
 
     public SubscriptionConfiguration(ushort defaultPrefetchCount)
     {
@@ -150,6 +158,7 @@ internal class SubscriptionConfiguration : ISubscriptionConfiguration
         PrefetchCount = defaultPrefetchCount;
         IsExclusive = false;
         Durable = true;
+        SingleActiveConsumer = false;
     }
 
     public ISubscriptionConfiguration WithTopic(string topic)
@@ -241,6 +250,12 @@ internal class SubscriptionConfiguration : ISubscriptionConfiguration
     public ISubscriptionConfiguration WithAlternateExchange(string alternateExchange)
     {
         AlternateExchange = alternateExchange;
+        return this;
+    }
+
+    public ISubscriptionConfiguration WithSingleActiveConsumer(bool singleActiveConsumer = true)
+    {
+        SingleActiveConsumer = singleActiveConsumer;
         return this;
     }
 }

--- a/hall_of_fame.md
+++ b/hall_of_fame.md
@@ -69,3 +69,4 @@ No particular order. Don't forget to add your name with your pull request.
 * Thomas Mutton
 * Ivan Maximov
 * Jens Willmer
+* Pierre Malatre


### PR DESCRIPTION
I added the possibility to set "QueueType" parameter on Send Receive configuration.
In the process I also made the update to set the parameter "Single Active Consumer" (x-single-active-consumer) for PubSub (SubscriptionConfiguration) (as discussed in #1282 ).