### PR TITLE
Add possibility to delete a queue by name on AdvancedBus

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -49,6 +49,7 @@ namespace EasyNetQ
         public static System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(this EasyNetQ.IAdvancedBus bus, string name, bool durable, bool exclusive, bool autoDelete, System.Threading.CancellationToken cancellationToken = default) { }
         public static void QueueDeclarePassive(this EasyNetQ.IAdvancedBus bus, string name, System.Threading.CancellationToken cancellationToken = default) { }
         public static void QueueDelete(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Queue queue, bool ifUnused = false, bool ifEmpty = false, System.Threading.CancellationToken cancellationToken = default) { }
+        public static void QueueDelete(this EasyNetQ.IAdvancedBus bus, string name, bool ifUnused = false, bool ifEmpty = false, System.Threading.CancellationToken cancellationToken = default) { }
         public static void QueuePurge(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Queue queue, System.Threading.CancellationToken cancellationToken = default) { }
         public static void Unbind(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Binding<EasyNetQ.Topology.Exchange> binding, System.Threading.CancellationToken cancellationToken = default) { }
         public static void Unbind(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Binding<EasyNetQ.Topology.Queue> binding, System.Threading.CancellationToken cancellationToken = default) { }
@@ -286,6 +287,7 @@ namespace EasyNetQ
         System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(string name, System.Action<EasyNetQ.IQueueDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task QueueDeclarePassiveAsync(string name, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task QueueDeleteAsync(EasyNetQ.Topology.Queue queue, bool ifUnused = false, bool ifEmpty = false, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task QueueDeleteAsync(string name, bool ifUnused = false, bool ifEmpty = false, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task QueuePurgeAsync(EasyNetQ.Topology.Queue queue, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task UnbindAsync(EasyNetQ.Topology.Binding<EasyNetQ.Topology.Exchange> binding, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task UnbindAsync(EasyNetQ.Topology.Binding<EasyNetQ.Topology.Queue> binding, System.Threading.CancellationToken cancellationToken = default);
@@ -820,6 +822,7 @@ namespace EasyNetQ
         public System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(string name, System.Action<EasyNetQ.IQueueDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task QueueDeclarePassiveAsync(string name, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.Task QueueDeleteAsync(EasyNetQ.Topology.Queue queue, bool ifUnused = false, bool ifEmpty = false, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.Task QueueDeleteAsync(string name, bool ifUnused = false, bool ifEmpty = false, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.Task QueuePurgeAsync(EasyNetQ.Topology.Queue queue, System.Threading.CancellationToken cancellationToken) { }
         public virtual System.Threading.Tasks.Task UnbindAsync(EasyNetQ.Topology.Binding<EasyNetQ.Topology.Exchange> binding, System.Threading.CancellationToken cancellationToken) { }
         public virtual System.Threading.Tasks.Task UnbindAsync(EasyNetQ.Topology.Binding<EasyNetQ.Topology.Queue> binding, System.Threading.CancellationToken cancellationToken) { }

--- a/Source/EasyNetQ.IntegrationTests/Advanced/When_delete_a_queue_with_name.cs
+++ b/Source/EasyNetQ.IntegrationTests/Advanced/When_delete_a_queue_with_name.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using RabbitMQ.Client.Exceptions;
+using Xunit;
+
+namespace EasyNetQ.IntegrationTests.Advanced;
+
+[Collection("RabbitMQ")]
+public class When_delete_a_queue_with_name : IDisposable
+{
+    private readonly IBus bus;
+
+    public When_delete_a_queue_with_name(RabbitMQFixture rmqFixture)
+    {
+        bus = RabbitHutch.CreateBus($"host={rmqFixture.Host};prefetchCount=1;timeout=-1");
+    }
+
+    [Fact]
+    public async Task Should_delete_existing_queue()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var queueName = Guid.NewGuid().ToString();
+        var queue = await bus.Advanced.QueueDeclareAsync(queueName, cts.Token);
+
+        await bus.Advanced.QueueDeclarePassiveAsync(queueName, cts.Token);
+        await bus.Advanced.QueueDeleteAsync(queueName, cancellationToken: cts.Token);
+
+        var exception = Assert.Throws<OperationInterruptedException>(() => bus.Advanced.QueueDeclarePassive(queueName, cts.Token));
+        Assert.Equal(404, exception.ShutdownReason.ReplyCode);
+    }
+
+    public void Dispose() => bus.Dispose();
+}

--- a/Source/EasyNetQ.Tests/ExchangeQueueBindingTests.cs
+++ b/Source/EasyNetQ.Tests/ExchangeQueueBindingTests.cs
@@ -187,6 +187,29 @@ public class When_a_queue_is_deleted : IDisposable
     }
 }
 
+public class When_a_queue_is_deleted_with_name : IDisposable
+{
+    public When_a_queue_is_deleted_with_name()
+    {
+        mockBuilder = new MockBuilder();
+
+        mockBuilder.Bus.Advanced.QueueDelete("my_queue");
+    }
+
+    public void Dispose()
+    {
+        mockBuilder.Dispose();
+    }
+
+    private readonly MockBuilder mockBuilder;
+
+    [Fact]
+    public void Should_delete_the_queue()
+    {
+        mockBuilder.Channels[0].Received().QueueDelete("my_queue", false, false);
+    }
+}
+
 public class When_an_exchange_is_declared : IDisposable
 {
     public When_an_exchange_is_declared()

--- a/Source/EasyNetQ/AdvancedBusExtensions.cs
+++ b/Source/EasyNetQ/AdvancedBusExtensions.cs
@@ -952,6 +952,23 @@ public static class AdvancedBusExtensions
     }
 
     /// <summary>
+    /// Delete a queue using queue name
+    /// </summary>
+    /// <param name="bus">The bus instance</param>
+    /// <param name="name">The name of the queue to delete</param>
+    /// <param name="ifUnused">Only delete if unused</param>
+    /// <param name="ifEmpty">Only delete if empty</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    public static void QueueDelete(this IAdvancedBus bus, string name, bool ifUnused = false, bool ifEmpty = false, CancellationToken cancellationToken = default)
+    {
+        Preconditions.CheckNotNull(bus, "bus");
+
+        bus.QueueDeleteAsync(name, ifUnused, ifEmpty, cancellationToken)
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    /// <summary>
     /// Purges a queue
     /// </summary>
     /// <param name="bus">The bus instance</param>

--- a/Source/EasyNetQ/IAdvancedBus.cs
+++ b/Source/EasyNetQ/IAdvancedBus.cs
@@ -162,6 +162,15 @@ public interface IAdvancedBus : IDisposable
     );
 
     /// <summary>
+    /// Delete a queue using queue name
+    /// </summary>
+    /// <param name="name">The name of the queue to delete</param>
+    /// <param name="ifUnused">Only delete if unused</param>
+    /// <param name="ifEmpty">Only delete if empty</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    Task QueueDeleteAsync(string name, bool ifUnused = false, bool ifEmpty = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Purges a queue
     /// </summary>
     /// <param name="queue">The queue to purge</param>

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -445,18 +445,24 @@ public class RabbitAdvancedBus : IAdvancedBus
     public virtual async Task QueueDeleteAsync(
         Queue queue, bool ifUnused = false, bool ifEmpty = false, CancellationToken cancellationToken = default
     )
+        => await QueueDeleteAsync(queue.Name, ifUnused, ifEmpty, cancellationToken);
+
+    /// <inheritdoc />
+    public virtual async Task QueueDeleteAsync(string name, bool ifUnused = false, bool ifEmpty = false, CancellationToken cancellationToken = default)
     {
+        Preconditions.CheckNotNull(name, nameof(name));
+
         using var cts = cancellationToken.WithTimeout(configuration.Timeout);
 
         await channelDispatcher.InvokeAsync(
-            x => x.QueueDelete(queue.Name, ifUnused, ifEmpty),
+            x => x.QueueDelete(name, ifUnused, ifEmpty),
             ChannelDispatchOptions.ConsumerTopology,
             cts.Token
         ).ConfigureAwait(false);
 
         if (logger.IsDebugEnabled())
         {
-            logger.DebugFormat("Deleted queue {queue}", queue.Name);
+            logger.DebugFormat("Deleted queue {queue}", name);
         }
     }
 


### PR DESCRIPTION
It's add a simplified way to delete a queue using only its name. I actually need it in the eventuality I have not the actual 'exact' configuration of the queue (AutoDelete / SAC etc...) to declare it correctly before deletion.