### PR TITLE
Log the exception causing the connection shutdown

### DIFF
--- a/Source/EasyNetQ/Persistent/PersistentConnection.cs
+++ b/Source/EasyNetQ/Persistent/PersistentConnection.cs
@@ -156,8 +156,9 @@ public class PersistentConnection : IPersistentConnection
     private void OnConnectionShutdown(object sender, ShutdownEventArgs e)
     {
         var connection = (IConnection)sender;
-        logger.InfoFormat(
+        logger.InfoException(
             "Connection {type} disconnected from broker {host}:{port} because of {reason}",
+            e.Cause as Exception,
             type,
             connection.Endpoint.HostName,
             connection.Endpoint.Port,


### PR DESCRIPTION
When the underlying RabbitMQ client has an unhandled exception it wont get logged anywhere. The `e.ReplyText` will only contain "Unexpected Exception".
https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/08d441764a5b676a40e715ea97999915f536da0d/projects/RabbitMQ.Client/client/impl/Connection.Receive.cs#L61-L64

