### PR TITLE
Dispose if a consumer contains only exclusive queues

### DIFF
--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_started_on_exclusive_queue_and_connection_is_dropped.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_is_started_on_exclusive_queue_and_connection_is_dropped.cs
@@ -1,0 +1,52 @@
+// ReSharper disable InconsistentNaming
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EasyNetQ.Events;
+using EasyNetQ.Persistent;
+using EasyNetQ.Tests.Mocking;
+using EasyNetQ.Topology;
+using NSubstitute;
+using RabbitMQ.Client;
+using Xunit;
+
+namespace EasyNetQ.Tests.ConsumeTests;
+
+public class When_a_consumer_is_started_on_exclusive_queue_and_connection_is_dropped : IDisposable
+{
+    private readonly MockBuilder mockBuilder;
+
+    public When_a_consumer_is_started_on_exclusive_queue_and_connection_is_dropped()
+    {
+        mockBuilder = new MockBuilder();
+
+        var queue = new Queue("my_queue", false, true);
+        using var cancelSubscription = mockBuilder.Bus.Advanced
+            .Consume(queue, (_, _, _) => Task.Run(() => { }));
+
+        var stopped = new AutoResetEvent(false);
+        mockBuilder.EventBus.Subscribe((in StoppedConsumingEvent _) => stopped.Set());
+
+        mockBuilder.EventBus.Publish(new ConnectionDisconnectedEvent(PersistentConnectionType.Consumer, Substitute.For<AmqpTcpEndpoint>(), "Unknown"));
+        mockBuilder.EventBus.Publish(new ConnectionRecoveredEvent(PersistentConnectionType.Consumer, Substitute.For<AmqpTcpEndpoint>()));
+
+        if (!stopped.WaitOne(5000))
+        {
+            throw new TimeoutException();
+        }
+    }
+
+    public void Dispose()
+    {
+        mockBuilder.Dispose();
+    }
+
+    [Fact]
+    public void Should_dispose_the_model()
+    {
+        mockBuilder.Consumers[0].Model.Received().Dispose();
+    }
+}
+
+// ReSharper restore InconsistentNaming

--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -151,7 +151,10 @@ public class InternalConsumer : IInternalConsumer
             var perQueueConfiguration = kvp.Value;
 
             if (queue.IsExclusive && !firstStart)
+            {
+                failedQueues.Add(queue);
                 continue;
+            }
 
             if (consumers.ContainsKey(queue.Name))
                 continue;


### PR DESCRIPTION
After a connection recovery, a model is recovered, but no consumer could be started if all queues are exclusive, so it could lead to resources leakage.

PR disposes Consumer(and the model) if this sutiation happens.