### PR TITLE
Move references from props to csproj

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -1,5 +1,4 @@
 <Project>
-
   <PropertyGroup>
     <Authors>Mike Hadlow;Michael Denny;Yury Pliner;Wiebe Tijsma;Contributors (see GitHub repo)</Authors>
     <PackageProduct>EasyNetQ</PackageProduct>
@@ -23,11 +22,5 @@
   <ItemGroup Condition="'$(IsPackable)' == 'true'">
     <None Include="..\..\Assets\EasyNetQ.png" Pack="true" PackagePath="" />
     <None Include="..\..\licence.txt" Pack="true" PackagePath="" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="MinVer" Version="4.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
-
 </Project>

--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.ApprovalTests.csproj
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.ApprovalTests.csproj
@@ -1,6 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../Tests.props" />
-
   <PropertyGroup>
     <TargetFramework>net6</TargetFramework>
     <RootNamespace>EasyNetQ.Approval.Tests</RootNamespace>
@@ -8,6 +6,9 @@
 
   <ItemGroup>
     <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
+    <PackageReference Include="Shouldly" Version="4.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/EasyNetQ.DI.Autofac/EasyNetQ.DI.Autofac.csproj
+++ b/Source/EasyNetQ.DI.Autofac/EasyNetQ.DI.Autofac.csproj
@@ -9,5 +9,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.3" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="4.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/Source/EasyNetQ.DI.LightInject/EasyNetQ.DI.LightInject.csproj
+++ b/Source/EasyNetQ.DI.LightInject/EasyNetQ.DI.LightInject.csproj
@@ -9,5 +9,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="LightInject" Version="5.5.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="4.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/Source/EasyNetQ.DI.Microsoft/EasyNetQ.DI.Microsoft.csproj
+++ b/Source/EasyNetQ.DI.Microsoft/EasyNetQ.DI.Microsoft.csproj
@@ -9,5 +9,10 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EasyNetQ\EasyNetQ.csproj" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="4.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/Source/EasyNetQ.DI.Ninject/EasyNetQ.DI.Ninject.csproj
+++ b/Source/EasyNetQ.DI.Ninject/EasyNetQ.DI.Ninject.csproj
@@ -9,5 +9,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Ninject" Version="3.3.5" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="4.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/Source/EasyNetQ.DI.SimpleInjector/EasyNetQ.DI.SimpleInjector.csproj
+++ b/Source/EasyNetQ.DI.SimpleInjector/EasyNetQ.DI.SimpleInjector.csproj
@@ -11,5 +11,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SimpleInjector" Version="4.6.2" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="4.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/Source/EasyNetQ.DI.StructureMap/EasyNetQ.DI.StructureMap.csproj
+++ b/Source/EasyNetQ.DI.StructureMap/EasyNetQ.DI.StructureMap.csproj
@@ -9,5 +9,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="structuremap" Version="4.7.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="4.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
+++ b/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
@@ -1,6 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../Tests.props" />
-
   <PropertyGroup>
     <TargetFramework>net6</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -26,5 +24,7 @@
     <PackageReference Include="Castle.Windsor" Version="5.0.0" />
     <PackageReference Include="Ninject" Version="3.3.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/Source/EasyNetQ.DI.Windsor/EasyNetQ.DI.Windsor.csproj
+++ b/Source/EasyNetQ.DI.Windsor/EasyNetQ.DI.Windsor.csproj
@@ -10,5 +10,10 @@
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.1" />
     <PackageReference Include="Castle.Windsor" Version="5.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="4.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/Source/EasyNetQ.Hosepipe.Tests/EasyNetQ.Hosepipe.Tests.csproj
+++ b/Source/EasyNetQ.Hosepipe.Tests/EasyNetQ.Hosepipe.Tests.csproj
@@ -1,13 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../Tests.props"/>
-
   <PropertyGroup>
     <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EasyNetQ\EasyNetQ.csproj" />
     <ProjectReference Include="..\EasyNetQ.Hosepipe\EasyNetQ.Hosepipe.csproj" />

--- a/Source/EasyNetQ.Hosepipe/EasyNetQ.Hosepipe.csproj
+++ b/Source/EasyNetQ.Hosepipe/EasyNetQ.Hosepipe.csproj
@@ -8,8 +8,6 @@
   <ItemGroup>
     <PackageReference Include="RabbitMQ.Client" Version="[6.2.1,6.4.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EasyNetQ\EasyNetQ.csproj" />

--- a/Source/EasyNetQ.IntegrationTests/EasyNetQ.IntegrationTests.csproj
+++ b/Source/EasyNetQ.IntegrationTests/EasyNetQ.IntegrationTests.csproj
@@ -1,6 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../Tests.props" />
-
   <PropertyGroup>
     <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
@@ -17,6 +15,9 @@
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="docker.dotnet" Version="3.125.5" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="settings.json" />

--- a/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_inflight_during_shutdown.cs
+++ b/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_inflight_during_shutdown.cs
@@ -34,7 +34,9 @@ public class When_request_and_respond_in_flight_during_shutdown : IDisposable
         );
         var requestTask = bus.Rpc.RequestAsync<Request, Response>(new Request(42), cts.Token);
         requestArrived.Wait(cts.Token);
+#pragma warning disable CS4014
         Task.Run(() => responder.Dispose(), cts.Token);
+#pragma warning restore CS4014
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await requestTask);
         cts.IsCancellationRequested.Should().BeTrue();

--- a/Source/EasyNetQ.Logging.Microsoft/EasyNetQ.Logging.Microsoft.csproj
+++ b/Source/EasyNetQ.Logging.Microsoft/EasyNetQ.Logging.Microsoft.csproj
@@ -6,6 +6,11 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+      <PackageReference Include="MinVer" Version="4.0.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/EasyNetQ.Logging.Serilog/EasyNetQ.Logging.Serilog.csproj
+++ b/Source/EasyNetQ.Logging.Serilog/EasyNetQ.Logging.Serilog.csproj
@@ -10,6 +10,11 @@
 
     <ItemGroup>
       <PackageReference Include="Serilog" Version="2.8.0" />
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+      <PackageReference Include="MinVer" Version="4.0.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/Source/EasyNetQ.Serialization.NewtonsoftJson/EasyNetQ.Serialization.NewtonsoftJson.csproj
+++ b/Source/EasyNetQ.Serialization.NewtonsoftJson/EasyNetQ.Serialization.NewtonsoftJson.csproj
@@ -16,6 +16,11 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="4.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Source/EasyNetQ.Serialization.Tests/EasyNetQ.Serialization.Tests.csproj
+++ b/Source/EasyNetQ.Serialization.Tests/EasyNetQ.Serialization.Tests.csproj
@@ -1,6 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../Tests.props" />
-
   <PropertyGroup>
     <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
@@ -13,4 +11,9 @@
     <ProjectReference Include="..\EasyNetQ.Serialization.NewtonsoftJson\EasyNetQ.Serialization.NewtonsoftJson.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+  </ItemGroup>
 </Project>

--- a/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
+++ b/Source/EasyNetQ.Tests/EasyNetQ.Tests.csproj
@@ -1,6 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../Tests.props" />
-
   <PropertyGroup>
     <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
@@ -14,5 +12,8 @@
     <PackageReference Include="RabbitMQ.Client" Version="[6.2.1,6.4.0)" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/Source/EasyNetQ.Tests/Logging/MessageFormatterTests.cs
+++ b/Source/EasyNetQ.Tests/Logging/MessageFormatterTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Globalization;
 using EasyNetQ.Logging;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace EasyNetQ.Tests.Logging;
@@ -15,7 +15,7 @@ public class MessageFormatterTests
 
         var formattedMessage = MessageFormatter.SimulateStructuredLogging(MessageBuilder, new object[] { "arg0", "arg1", "arg2" })();
 
-        formattedMessage.ShouldBe("This is an arg0 and this another arg1 and a last one arg2.");
+        formattedMessage.Should().Be("This is an arg0 and this another arg1 and a last one arg2.");
     }
 
     [Fact]
@@ -25,7 +25,7 @@ public class MessageFormatterTests
 
         var formattedMessage = MessageFormatter.SimulateStructuredLogging(MessageBuilder, new object[] { "arg0", "arg1" })();
 
-        formattedMessage.ShouldBe("This is an arg0 and this an {escaped_argument}.");
+        formattedMessage.Should().Be("This is an arg0 and this an {escaped_argument}.");
     }
 
     [Fact]
@@ -36,8 +36,9 @@ public class MessageFormatterTests
 
         var formattedMessage = MessageFormatter.SimulateStructuredLogging(MessageBuilder, new object[] { date, date })();
 
-        formattedMessage.ShouldBe(
-            string.Format(CultureInfo.InvariantCulture, "Formatted {0:yyyy-MM-dd} and not formatted {1}.", date, date));
+        formattedMessage.Should().Be(
+            string.Format(CultureInfo.InvariantCulture, "Formatted {0:yyyy-MM-dd} and not formatted {1}.", date, date)
+        );
     }
 
     [Fact]
@@ -48,7 +49,7 @@ public class MessageFormatterTests
 
         var formattedMessage = MessageFormatter.SimulateStructuredLogging(MessageBuilder, new object[] { date, "arg0" })();
 
-        formattedMessage.ShouldBe(
+        formattedMessage.Should().Be(
             string.Format(CultureInfo.InvariantCulture, "{0:yyyy-MM-dd} {1} {0:yyyy}", date, "arg0")
         );
     }

--- a/Source/EasyNetQ.sln
+++ b/Source/EasyNetQ.sln
@@ -13,7 +13,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".Solution Items", ".Solutio
 		..\hall_of_fame.md = ..\hall_of_fame.md
 		..\licence.txt = ..\licence.txt
 		..\README.md = ..\README.md
-		Tests.props = Tests.props
 		Version.cs = Version.cs
 	EndProjectSection
 EndProject

--- a/Source/EasyNetQ/EasyNetQ.csproj
+++ b/Source/EasyNetQ/EasyNetQ.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <Description>A nice .NET API for RabbitMQ</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <DefineConstants>$(DefineConstants);LIBLOG_PUBLIC;LIBLOG_PORTABLE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="LightInject.Source" Version="6.4.1">

--- a/Source/EasyNetQ/Logging/MessageFormatters.cs
+++ b/Source/EasyNetQ/Logging/MessageFormatters.cs
@@ -10,18 +10,6 @@ internal static class MessageFormatter
 {
     private static readonly Regex Pattern = new(@"(?<!{){@?(?<arg>[^ :{}]+)(?<format>:[^}]+)?}", RegexOptions.Compiled);
 
-    /// <summary>
-    ///     Some logging frameworks support structured logging, such as serilog. This will allow you to add names to structured
-    ///     data in a format string:
-    ///     For example: Log("Log message to {user}", user). This only works with serilog, but as the user of LibLog, you don't
-    ///     know if serilog is actually
-    ///     used. So, this class simulates that. it will replace any text in {curly braces} with an index number.
-    ///     "Log {message} to {user}" would turn into => "Log {0} to {1}". Then the format parameters are handled using regular
-    ///     .net string.Format.
-    /// </summary>
-    /// <param name="messageBuilder">The message builder.</param>
-    /// <param name="formatParameters">The format parameters.</param>
-    /// <returns></returns>
     public static Func<string> SimulateStructuredLogging(Func<string> messageBuilder, object[] formatParameters)
     {
         if (formatParameters == null || formatParameters.Length == 0) return messageBuilder;

--- a/Source/EasyNetQ/PullingConsumerExtensions.cs
+++ b/Source/EasyNetQ/PullingConsumerExtensions.cs
@@ -49,7 +49,7 @@ public readonly struct PullBatchResult<TPullResult> : IDisposable where TPullRes
 }
 
 /// <summary>
-///     Various extensions for <see cref="IPullingConsumer"/>
+///     Various extensions for <see cref="IPullingConsumer{TPullResult}"/>
 /// </summary>
 public static class PullingConsumerExtensions
 {

--- a/Source/Tests.props
+++ b/Source/Tests.props
@@ -6,13 +6,5 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Shouldly" Version="4.0.3" />
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
To avoid:
1. Errors connected to multi referencing same package
2. Referencing a package when it is not needed