### PR TITLE
A simple consumer error strategy

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -1229,6 +1229,15 @@ namespace EasyNetQ.Consumer
         public EasyNetQ.Consumer.MessageHandler Handler { get; }
         public bool IsExclusive { get; }
     }
+    public class SimpleConsumerErrorStrategy : EasyNetQ.Consumer.IConsumerErrorStrategy, System.IDisposable
+    {
+        public static readonly EasyNetQ.Consumer.SimpleConsumerErrorStrategy Ack;
+        public static readonly EasyNetQ.Consumer.SimpleConsumerErrorStrategy NackWithRequeue;
+        public static readonly EasyNetQ.Consumer.SimpleConsumerErrorStrategy NackWithoutRequeue;
+        public void Dispose() { }
+        public System.Threading.Tasks.Task<EasyNetQ.Consumer.AckStrategy> HandleConsumerCancelledAsync(EasyNetQ.Consumer.ConsumerExecutionContext context, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<EasyNetQ.Consumer.AckStrategy> HandleConsumerErrorAsync(EasyNetQ.Consumer.ConsumerExecutionContext context, System.Exception exception, System.Threading.CancellationToken cancellationToken = default) { }
+    }
 }
 namespace EasyNetQ.DI
 {

--- a/Source/EasyNetQ/Consumer/SimpleConsumerErrorStrategy.cs
+++ b/Source/EasyNetQ/Consumer/SimpleConsumerErrorStrategy.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 namespace EasyNetQ.Consumer;
 
 /// <summary>
-///     ConsumerErrorStrategy based on AckStrategies
+///     A simple strategy which does nothing, only applies AckStrategies
 /// </summary>
 public class SimpleConsumerErrorStrategy : IConsumerErrorStrategy
 {

--- a/Source/EasyNetQ/Consumer/SimpleConsumerErrorStrategy.cs
+++ b/Source/EasyNetQ/Consumer/SimpleConsumerErrorStrategy.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EasyNetQ.Consumer;
+
+/// <summary>
+///     ConsumerErrorStrategy based on AckStrategies
+/// </summary>
+public class SimpleConsumerErrorStrategy : IConsumerErrorStrategy
+{
+    /// <summary>
+    ///     Acks a message in case of an error
+    /// </summary>
+    public static readonly SimpleConsumerErrorStrategy Ack = new(AckStrategies.Ack);
+
+    /// <summary>
+    ///     Nacks a message with requeue in case of an error
+    /// </summary>
+    public static readonly SimpleConsumerErrorStrategy NackWithRequeue = new(AckStrategies.NackWithRequeue);
+
+    /// <summary>
+    ///     Nacks a message without requeue in case of an error
+    /// </summary>
+    public static readonly SimpleConsumerErrorStrategy NackWithoutRequeue = new(AckStrategies.NackWithoutRequeue);
+
+    private readonly AckStrategy errorStrategy;
+
+    private SimpleConsumerErrorStrategy(AckStrategy errorStrategy)
+    {
+        this.errorStrategy = errorStrategy;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+    }
+
+    /// <inheritdoc />
+    public Task<AckStrategy> HandleConsumerErrorAsync(ConsumerExecutionContext context, Exception exception, CancellationToken cancellationToken = default) => Task.FromResult(errorStrategy);
+
+    /// <inheritdoc />
+    public Task<AckStrategy> HandleConsumerCancelledAsync(ConsumerExecutionContext context, CancellationToken cancellationToken = default) => Task.FromResult(AckStrategies.NackWithRequeue);
+}


### PR DESCRIPTION
It should nack with requeue not to lose messages in a case of cancellation.


PS I'm just trying to implement the following example:
```
using EasyNetQ;
using EasyNetQ.Consumer;
using EasyNetQ.Topology;
using EasyNetQ.DI;

// https://www.rabbitmq.com/quorum-queues.html#dead-lettering

var completionTcs = new TaskCompletionSource<bool>();
Console.CancelKeyPress += (_, _) => completionTcs.TrySetResult(true);

using var bus = RabbitHutch.CreateBus(
    "host=localhost",
    x => x.EnableConsoleLogger()
        .EnableNewtonsoftJson()
        .Register<IConsumerErrorStrategy>(SimpleConsumerErrorStrategy.NackWithoutRequeue)
);

await bus.Advanced.QueueDeclareAsync(
    "Events:Failed",
    c => c.WithQueueType(QueueType.Quorum)
        .WithDeadLetterExchange(Exchange.Default)
        .WithDeadLetterRoutingKey("Events")
        .WithMessageTtl(TimeSpan.FromSeconds(5))
        .WithOverflowType(OverflowType.RejectPublish)
        .WithDeadLetterStrategy(DeadLetterStrategy.AtLeastOnce)
);

var eventsQueue = await bus.Advanced.QueueDeclareAsync(
    "Events",
    c => c.WithQueueType(QueueType.Quorum)
        .WithDeadLetterExchange(Exchange.Default)
        .WithDeadLetterRoutingKey("Events:Failed")
        .WithOverflowType(OverflowType.RejectPublish)
        .WithDeadLetterStrategy(DeadLetterStrategy.AtLeastOnce)
);

using var eventsConsumer = bus.Advanced.Consume(eventsQueue, (_, _, _) => throw new Exception("Oops"));

await bus.Advanced.PublishAsync(Exchange.Default, "Events", true, new MessageProperties(), ReadOnlyMemory<byte>.Empty);

await completionTcs.Task;

```