### PR TITLE
Support of dead-letter-strategy

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -131,6 +131,11 @@ namespace EasyNetQ
         public DeadLetterExchangeAndMessageTtlScheduler(EasyNetQ.ConnectionConfiguration configuration, EasyNetQ.IAdvancedBus advancedBus, EasyNetQ.IConventions conventions, EasyNetQ.IMessageDeliveryModeStrategy messageDeliveryModeStrategy, EasyNetQ.Producer.IExchangeDeclareStrategy exchangeDeclareStrategy) { }
         public System.Threading.Tasks.Task FuturePublishAsync<T>(T message, System.TimeSpan delay, System.Action<EasyNetQ.IFuturePublishConfiguration> configure, System.Threading.CancellationToken cancellationToken = default) { }
     }
+    public static class DeadLetterStrategy
+    {
+        public const string AtLeastOnce = "at-least-once";
+        public const string AtMostOnce = "at-most-once";
+    }
     public class DefaultCorrelationIdGenerationStrategy : EasyNetQ.ICorrelationIdGenerationStrategy
     {
         public DefaultCorrelationIdGenerationStrategy() { }
@@ -630,7 +635,7 @@ namespace EasyNetQ
     }
     public static class OverflowType
     {
-        public const string Default = "drop-head";
+        public const string DropHead = "drop-head";
         public const string RejectPublish = "reject-publish";
         public const string RejectPublishDlx = "reject-publish-dlx";
     }
@@ -742,6 +747,7 @@ namespace EasyNetQ
     {
         public static EasyNetQ.IQueueDeclareConfiguration WithDeadLetterExchange(this EasyNetQ.IQueueDeclareConfiguration configuration, EasyNetQ.Topology.Exchange deadLetterExchange) { }
         public static EasyNetQ.IQueueDeclareConfiguration WithDeadLetterRoutingKey(this EasyNetQ.IQueueDeclareConfiguration configuration, string deadLetterRoutingKey) { }
+        public static EasyNetQ.IQueueDeclareConfiguration WithDeadLetterStrategy(this EasyNetQ.IQueueDeclareConfiguration configuration, string deadLetterStrategy) { }
         public static EasyNetQ.IQueueDeclareConfiguration WithExpires(this EasyNetQ.IQueueDeclareConfiguration configuration, System.TimeSpan expires) { }
         public static EasyNetQ.IQueueDeclareConfiguration WithMaxLength(this EasyNetQ.IQueueDeclareConfiguration configuration, int maxLength) { }
         public static EasyNetQ.IQueueDeclareConfiguration WithMaxLengthBytes(this EasyNetQ.IQueueDeclareConfiguration configuration, int maxLengthBytes) { }

--- a/Source/EasyNetQ/DeadLetterStrategy.cs
+++ b/Source/EasyNetQ/DeadLetterStrategy.cs
@@ -1,0 +1,19 @@
+namespace EasyNetQ;
+
+/// <summary>
+/// Represent dead letter strategies of a queue
+/// </summary>
+public static class DeadLetterStrategy
+{
+    /// <summary>
+    /// Default one for quorum queues.
+    /// Messages are removed from the original queue immediately after publishing to the DLX target queue.
+    /// This ensures that there is no chance of excessive message buildup that could exhaust broker resources, but messages can be lost if the target queue isn't available to accept messages.
+    /// </summary>
+    public const string AtMostOnce = "at-most-once";
+
+    /// <summary>
+    /// Messages are re-published with publisher confirms turned on internally.
+    /// </summary>
+    public const string AtLeastOnce = "at-least-once";
+}

--- a/Source/EasyNetQ/OverflowType.cs
+++ b/Source/EasyNetQ/OverflowType.cs
@@ -8,7 +8,7 @@ public static class OverflowType
     /// <summary>
     ///     Default queue overflow mode, the oldest messages will be deleted.
     /// </summary>
-    public const string Default = "drop-head";
+    public const string DropHead = "drop-head";
 
     /// <summary>
     ///     New messages will be rejected.

--- a/Source/EasyNetQ/QueueDeclareConfigurationExtensions.cs
+++ b/Source/EasyNetQ/QueueDeclareConfigurationExtensions.cs
@@ -58,7 +58,7 @@ public static class QueueDeclareConfigurationExtensions
     /// <param name="configuration">The configuration instance</param>
     /// <param name="overflowType">The overflow type to set</param>
     /// <returns>The same <paramref name="configuration"/></returns>
-    public static IQueueDeclareConfiguration WithOverflowType(this IQueueDeclareConfiguration configuration, string overflowType = OverflowType.Default)
+    public static IQueueDeclareConfiguration WithOverflowType(this IQueueDeclareConfiguration configuration, string overflowType = OverflowType.DropHead)
     {
         Preconditions.CheckNotNull(configuration, nameof(configuration));
 
@@ -177,4 +177,19 @@ public static class QueueDeclareConfigurationExtensions
 
         return configuration.WithArgument("x-queue-master-locator", queueMasterLocator);
     }
+
+    /// <summary>
+    ///     Sets dead letter strategy.
+    ///     Valid types are at-least-once and at-most-once, see <see cref="DeadLetterStrategy"/>.
+    /// </summary>
+    /// <param name="configuration">The configuration instance</param>
+    /// <param name="deadLetterStrategy">The dead letter strategy to set</param>
+    /// <returns>The same <paramref name="configuration"/></returns>
+    public static IQueueDeclareConfiguration WithDeadLetterStrategy(this IQueueDeclareConfiguration configuration, string deadLetterStrategy)
+    {
+        Preconditions.CheckNotNull(configuration, nameof(configuration));
+
+        return configuration.WithArgument("x-dead-letter-strategy", deadLetterStrategy);
+    }
+
 }


### PR DESCRIPTION
https://www.rabbitmq.com/quorum-queues.html#dead-lettering



PS I'm just trying to implement the following example:
```
using EasyNetQ;
using EasyNetQ.Consumer;
using EasyNetQ.Topology;
using EasyNetQ.DI;

// https://www.rabbitmq.com/quorum-queues.html#dead-lettering

var completionTcs = new TaskCompletionSource<bool>();
Console.CancelKeyPress += (_, _) => completionTcs.TrySetResult(true);

using var bus = RabbitHutch.CreateBus(
    "host=localhost",
    x => x.EnableConsoleLogger()
        .EnableNewtonsoftJson()
        .Register<IConsumerErrorStrategy>(SimpleConsumerErrorStrategy.NackWithoutRequeue)
);

await bus.Advanced.QueueDeclareAsync(
    "Events:Failed",
    c => c.WithQueueType(QueueType.Quorum)
        .WithDeadLetterExchange(Exchange.Default)
        .WithDeadLetterRoutingKey("Events")
        .WithMessageTtl(TimeSpan.FromSeconds(5))
        .WithOverflowType(OverflowType.RejectPublish)
        .WithDeadLetterStrategy(DeadLetterStrategy.AtLeastOnce)
);

var eventsQueue = await bus.Advanced.QueueDeclareAsync(
    "Events",
    c => c.WithQueueType(QueueType.Quorum)
        .WithDeadLetterExchange(Exchange.Default)
        .WithDeadLetterRoutingKey("Events:Failed")
        .WithOverflowType(OverflowType.RejectPublish)
        .WithDeadLetterStrategy(DeadLetterStrategy.AtLeastOnce)
);

using var eventsConsumer = bus.Advanced.Consume(eventsQueue, (_, _, _) => throw new Exception("Oops"));

await bus.Advanced.PublishAsync(Exchange.Default, "Events", true, new MessageProperties(), ReadOnlyMemory<byte>.Empty);

await completionTcs.Task;

```