### PR TITLE
Register only generic loggers

### DIFF
--- a/Source/EasyNetQ.Logging.Microsoft/ServiceRegisterExtensions.cs
+++ b/Source/EasyNetQ.Logging.Microsoft/ServiceRegisterExtensions.cs
@@ -17,8 +17,6 @@ public static class ServiceRegisterExtensions
     /// <param name="serviceRegister">The register</param>
     public static IServiceRegister EnableMicrosoftLogging(this IServiceRegister serviceRegister)
     {
-        return serviceRegister
-            .Register(typeof(ILogger), typeof(MicrosoftLoggerAdapter))
-            .Register(typeof(ILogger<>), typeof(MicrosoftLoggerAdapter<>));
+        return serviceRegister.Register(typeof(ILogger<>), typeof(MicrosoftLoggerAdapter<>));
     }
 }

--- a/Source/EasyNetQ.Logging.Serilog/ServiceRegisterExtensions.cs
+++ b/Source/EasyNetQ.Logging.Serilog/ServiceRegisterExtensions.cs
@@ -16,8 +16,6 @@ public static class ServiceRegisterExtensions
     /// <param name="serviceRegister">The register</param>
     public static IServiceRegister EnableSerilogLogging(this IServiceRegister serviceRegister)
     {
-        return serviceRegister
-            .Register(typeof(ILogger), typeof(SerilogLoggerAdapter))
-            .Register(typeof(ILogger<>), typeof(SerilogLoggerAdapter<>));
+        return serviceRegister.Register(typeof(ILogger<>), typeof(SerilogLoggerAdapter<>));
     }
 }

--- a/Source/EasyNetQ/ServiceRegisterExtensions.cs
+++ b/Source/EasyNetQ/ServiceRegisterExtensions.cs
@@ -156,9 +156,7 @@ public static class ServiceRegisterExtensions
     /// <param name="serviceRegister">The register</param>
     public static IServiceRegister EnableConsoleLogger(this IServiceRegister serviceRegister)
     {
-        return serviceRegister
-            .Register(typeof(ILogger), typeof(ConsoleLogger))
-            .Register(typeof(ILogger<>), typeof(ConsoleLogger<>));
+        return serviceRegister.Register(typeof(ILogger<>), typeof(ConsoleLogger<>));
     }
 
     /// <summary>


### PR DESCRIPTION
In very simple app it doesn't work.

```
using EasyNetQ;

var builder = WebApplication.CreateBuilder(args);
builder.Logging.AddSimpleConsole();
builder.Services.RegisterEasyNetQ("host=localhost", c => c.EnableMicrosoftLogging());
var app = builder.Build();

app.MapGet("/", () => "Hello World!");

app.Run();
```


```
Unhandled exception. System.AggregateException: Some services are not able to be constructed (Error while validating the service descriptor 'ServiceType: EasyNetQ.Logging.ILogger Lifetime: Singleton ImplementationType: EasyNetQ.Logging.Microsoft.MicrosoftLoggerAdapter': Unable to resolve service for type 'Microsoft.Extensions.Logging.ILogger' while attempting to activate 'EasyNetQ.Logging.Microsoft.MicrosoftLoggerAdapter'.)
 ---> System.InvalidOperationException: Error while validating the service descriptor 'ServiceType: EasyNetQ.Logging.ILogger Lifetime: Singleton ImplementationType: EasyNetQ.Logging.Microsoft.MicrosoftLoggerAdapter': Unable to resolve service for type 'Microsoft.Extensions.Logging.ILogger' while attempting to activate 'EasyNetQ.Logging.Microsoft.MicrosoftLoggerAdapter'.
 ---> System.InvalidOperationException: Unable to resolve service for type 'Microsoft.Extensions.Logging.ILogger' while attempting to activate 'EasyNetQ.Logging.Microsoft.MicrosoftLoggerAdapter'.
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateArgumentCallSites(Type implementationType, CallSiteChain callSiteChain, ParameterInfo[] parameters, Boolean throwIfCallSiteNotFound)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateConstructorCallSite(ResultCache lifetime, Type serviceType, Type implementationType, CallSiteChain callSiteChain)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.TryCreateExact(ServiceDescriptor descriptor, Type serviceType, CallSiteChain callSiteChain, Int32 slot)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.GetCallSite(ServiceDescriptor serviceDescriptor, CallSiteChain callSiteChain)
   at Microsoft.Extensions.DependencyInjection.ServiceProvider.ValidateService(ServiceDescriptor descriptor)
   --- End of inner exception stack trace ---
   at Microsoft.Extensions.DependencyInjection.ServiceProvider.ValidateService(ServiceDescriptor descriptor)
   at Microsoft.Extensions.DependencyInjection.ServiceProvider..ctor(ICollection`1 serviceDescriptors, ServiceProviderOptions options)
   --- End of inner exception stack trace ---
   at Microsoft.Extensions.DependencyInjection.ServiceProvider..ctor(ICollection`1 serviceDescriptors, ServiceProviderOptions options)
   at Microsoft.Extensions.DependencyInjection.ServiceCollectionContainerBuilderExtensions.BuildServiceProvider(IServiceCollection services, ServiceProviderOptions options)
   at Microsoft.Extensions.DependencyInjection.DefaultServiceProviderFactory.CreateServiceProvider(IServiceCollection containerBuilder)
   at Microsoft.Extensions.Hosting.Internal.ServiceFactoryAdapter`1.CreateServiceProvider(Object containerBuilder)
   at Microsoft.Extensions.Hosting.HostBuilder.CreateServiceProvider()
   at Microsoft.Extensions.Hosting.HostBuilder.Build()
   at Microsoft.AspNetCore.Builder.WebApplicationBuilder.Build()
   at Program.<Main>$(String[] args) in 
```

https://stackoverflow.com/questions/52921966/unable-to-resolve-ilogger-from-microsoft-extensions-logging