### PR TITLE
Rename QueueMasterLocatorType to QueueMasterLocator

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -767,7 +767,7 @@ namespace EasyNetQ
         public static EasyNetQ.IQueueDeclareConfiguration WithQueueType(this EasyNetQ.IQueueDeclareConfiguration configuration, string queueType = "classic") { }
         public static EasyNetQ.IQueueDeclareConfiguration WithSingleActiveConsumer(this EasyNetQ.IQueueDeclareConfiguration configuration) { }
     }
-    public static class QueueMasterLocatorType
+    public static class QueueMasterLocator
     {
         public const string ClientLocal = "client-local";
         public const string MinMasters = "min-masters";

--- a/Source/EasyNetQ/QueueDeclareConfigurationExtensions.cs
+++ b/Source/EasyNetQ/QueueDeclareConfigurationExtensions.cs
@@ -166,12 +166,12 @@ public static class QueueDeclareConfigurationExtensions
 
     /// <summary>
     ///     Sets queue master locator.
-    ///     Valid types are min-masters, client-local and random, see <see cref="QueueMasterLocatorType"/>.
+    ///     Valid types are min-masters, client-local and random, see <see cref="QueueMasterLocator"/>.
     /// </summary>
     /// <param name="configuration">The configuration instance</param>
     /// <param name="queueMasterLocator">The queue master locator to set</param>
     /// <returns>The same <paramref name="configuration"/></returns>
-    public static IQueueDeclareConfiguration WithQueueMasterLocator(this IQueueDeclareConfiguration configuration, string queueMasterLocator = QueueMasterLocatorType.MinMasters)
+    public static IQueueDeclareConfiguration WithQueueMasterLocator(this IQueueDeclareConfiguration configuration, string queueMasterLocator = QueueMasterLocator.MinMasters)
     {
         Preconditions.CheckNotNull(configuration, nameof(configuration));
 

--- a/Source/EasyNetQ/QueueMasterLocator.cs
+++ b/Source/EasyNetQ/QueueMasterLocator.cs
@@ -10,7 +10,7 @@ namespace EasyNetQ;
 ///     queue leader replicas and thus handling most of the load, queue leaders should be
 ///     reasonably evenly distributed across cluster nodes.
 /// </summary>
-public static class QueueMasterLocatorType
+public static class QueueMasterLocator
 {
     /// <summary>
     ///     Pick the node hosting the minimum number of leaders


### PR DESCRIPTION
We don't have a Type suffix nowhere in the codebase.