### PR TITLE
Rearrange code to eliminate the closure when consuming

### DIFF
--- a/Source/EasyNetQ/Consumer/HandlerRunner.cs
+++ b/Source/EasyNetQ/Consumer/HandlerRunner.cs
@@ -1,8 +1,5 @@
-using EasyNetQ.Events;
 using EasyNetQ.Logging;
-using RabbitMQ.Client.Exceptions;
 using System;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -39,66 +36,19 @@ public class HandlerRunner : IHandlerRunner
             logger.DebugFormat("Received message with receivedInfo={receivedInfo}", context.ReceivedInfo);
         }
 
-        var ackStrategy = await InvokeUserMessageHandlerInternalAsync(context, cancellationToken).ConfigureAwait(false);
-
-        return (model, tag) =>
-        {
-            try
-            {
-                return ackStrategy(model, tag);
-            }
-            catch (AlreadyClosedException alreadyClosedException)
-            {
-                logger.Info(
-                    alreadyClosedException,
-                    "Failed to ACK or NACK, message will be retried, receivedInfo={receivedInfo}",
-                    context.ReceivedInfo
-                );
-            }
-            catch (IOException ioException)
-            {
-                logger.Info(
-                    ioException,
-                    "Failed to ACK or NACK, message will be retried, receivedInfo={receivedInfo}",
-                    context.ReceivedInfo
-                );
-            }
-            catch (Exception exception)
-            {
-                logger.Error(
-                    exception,
-                    "Unexpected exception when attempting to ACK or NACK, receivedInfo={receivedInfo}",
-                    context.ReceivedInfo
-                );
-            }
-
-            return AckResult.Exception;
-        };
-    }
-
-    private async Task<AckStrategy> InvokeUserMessageHandlerInternalAsync(
-        ConsumerExecutionContext context, CancellationToken cancellationToken
-    )
-    {
         try
         {
             try
             {
-                return await context.Handler(
-                    context.Body, context.Properties, context.ReceivedInfo, cancellationToken
-                ).ConfigureAwait(false);
+                return await context.Handler(context.Body, context.Properties, context.ReceivedInfo, cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
-                return await consumerErrorStrategy.HandleConsumerCancelledAsync(
-                    context, cancellationToken
-                ).ConfigureAwait(false);
+                return await consumerErrorStrategy.HandleConsumerCancelledAsync(context, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
-                return await consumerErrorStrategy.HandleConsumerErrorAsync(
-                    context, exception, cancellationToken
-                ).ConfigureAwait(false);
+                return await consumerErrorStrategy.HandleConsumerErrorAsync(context, exception, cancellationToken).ConfigureAwait(false);
             }
         }
         catch (Exception exception)

--- a/Source/EasyNetQ/ServiceRegisterExtensions.cs
+++ b/Source/EasyNetQ/ServiceRegisterExtensions.cs
@@ -3,7 +3,6 @@ using EasyNetQ.ChannelDispatcher;
 using EasyNetQ.ConnectionString;
 using EasyNetQ.Consumer;
 using EasyNetQ.DI;
-using EasyNetQ.Interception;
 using EasyNetQ.Logging;
 using EasyNetQ.MessageVersioning;
 using EasyNetQ.MultipleExchange;


### PR DESCRIPTION
There is a closure allocation for every consumed message. It could be easily removed.

Measurements were taken by [Dynamic Program Analysis](https://www.jetbrains.com/help/rider/2022.1/Dynamic_Program_Analysis.html).

Before:

<img width="952" alt="image" src="https://user-images.githubusercontent.com/664889/175771933-c286eade-7e2e-4e53-8c15-e2d8ac01b155.png">

After:
<img width="838" alt="image" src="https://user-images.githubusercontent.com/664889/175772008-f044389a-6c3b-4746-b1e5-1375f610512a.png">
