### PR TITLE
AsyncLock Acquire should not allocate task on happy path

### DIFF
--- a/Source/EasyNetQ/Internals/AsyncLock.cs
+++ b/Source/EasyNetQ/Internals/AsyncLock.cs
@@ -39,7 +39,7 @@ public sealed class AsyncLock : IDisposable
         var acquireAsync = semaphore.WaitAsync(cancellationToken);
         return acquireAsync.Status == TaskStatus.RanToCompletion
             ? releaserTask
-            : WaitForAcquire(acquireAsync);
+            : WaitForAcquireAsync(acquireAsync);
     }
 
     /// <summary>
@@ -66,7 +66,7 @@ public sealed class AsyncLock : IDisposable
     public void Dispose() => semaphore.Dispose();
 
 
-    private async Task<IDisposable> WaitForAcquire(Task acquireAsync)
+    private async Task<IDisposable> WaitForAcquireAsync(Task acquireAsync)
     {
         await acquireAsync.ConfigureAwait(false);
         return releaser;


### PR DESCRIPTION
Continuation of #1418. AsyncLock.AcquireAsync allocates a task on happy path, but it could be easily fixed.

Measurements were taken by [Dynamic Program Analysis](https://www.jetbrains.com/help/rider/2022.1/Dynamic_Program_Analysis.html).

Before:

<img width="947" alt="image" src="https://user-images.githubusercontent.com/664889/175789464-cd6d3c3c-3b25-4f52-aff3-83ccddb354d4.png">

After:

<img width="968" alt="image" src="https://user-images.githubusercontent.com/664889/175789542-47720620-148a-47de-9055-11f46f71c45a.png">

