### PR TITLE
Register noop default consumer to prevent disconnection

### DIFF
--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -149,6 +149,7 @@ public class InternalConsumer : IInternalConsumer
             try
             {
                 model = connection.CreateModel();
+                model.DefaultConsumer = new NoopDefaultConsumer();
                 model.BasicQos(0, configuration.PrefetchCount, false);
             }
             catch (Exception exception)

--- a/Source/EasyNetQ/Consumer/NoopDefaultConsumer.cs
+++ b/Source/EasyNetQ/Consumer/NoopDefaultConsumer.cs
@@ -1,0 +1,72 @@
+#nullable disable
+
+using System;
+using System.Threading.Tasks;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace EasyNetQ.Consumer;
+
+internal sealed class NoopDefaultConsumer : IBasicConsumer, IAsyncBasicConsumer
+{
+    public IModel Model => null;
+
+    event AsyncEventHandler<ConsumerEventArgs> IAsyncBasicConsumer.ConsumerCancelled
+    {
+        add { }
+        remove { }
+    }
+
+    event EventHandler<ConsumerEventArgs> IBasicConsumer.ConsumerCancelled
+    {
+        add { }
+        remove { }
+    }
+
+    void IBasicConsumer.HandleBasicCancel(string consumerTag)
+    {
+    }
+
+    void IBasicConsumer.HandleBasicCancelOk(string consumerTag)
+    {
+    }
+
+    void IBasicConsumer.HandleBasicConsumeOk(string consumerTag)
+    {
+    }
+
+    void IBasicConsumer.HandleBasicDeliver(
+        string consumerTag,
+        ulong deliveryTag,
+        bool redelivered,
+        string exchange,
+        string routingKey,
+        IBasicProperties properties,
+        ReadOnlyMemory<byte> body
+    )
+    {
+    }
+
+
+    void IBasicConsumer.HandleModelShutdown(object model, ShutdownEventArgs reason)
+    {
+    }
+
+    Task IAsyncBasicConsumer.HandleBasicCancel(string consumerTag) => Task.CompletedTask;
+
+    Task IAsyncBasicConsumer.HandleBasicCancelOk(string consumerTag) => Task.CompletedTask;
+
+    Task IAsyncBasicConsumer.HandleBasicConsumeOk(string consumerTag) => Task.CompletedTask;
+
+    Task IAsyncBasicConsumer.HandleBasicDeliver(
+        string consumerTag,
+        ulong deliveryTag,
+        bool redelivered,
+        string exchange,
+        string routingKey,
+        IBasicProperties properties,
+        ReadOnlyMemory<byte> body
+    ) => Task.CompletedTask;
+
+    Task IAsyncBasicConsumer.HandleModelShutdown(object model, ShutdownEventArgs reason) => Task.CompletedTask;
+}


### PR DESCRIPTION
Fixes #1466

After a deep investigation of the issue, two things happening in parallel cause it:
1. BasicCancel/BasicCancelNoWait is called to "unsubscribe" a consumer from the queue.
2. There are a lot of messages in the queue and they are arriving because of large prefetch count.

This sample reproduces the issue from the first iteration in my environment.

```
using EasyNetQ;
using EasyNetQ.Topology;

var cts = new CancellationTokenSource();
Console.CancelKeyPress += (_, _) => cts.Cancel();

using var bus = RabbitHutch.CreateBus(
    "host=localhost;publisherConfirms=True",
    x => x.EnableNewtonsoftJson()
        .EnableAlwaysNackWithoutRequeueConsumerErrorStrategy()
        .EnableConsoleLogger()
);

var eventQueue = await bus.Advanced.QueueDeclareAsync(
    "Events",
    c => c.WithQueueType(QueueType.Quorum)
        .WithOverflowType(OverflowType.RejectPublish),
    cts.Token
);

for (var i = 0; i < 64; ++i)
{
    await bus.Advanced.PublishAsync(
        Exchange.Default,
        "Events",
        true,
        new MessageProperties(),
        ReadOnlyMemory<byte>.Empty,
        cts.Token
    );
}

while (!cts.IsCancellationRequested)
{
    var consumers = new List<IDisposable>();
    for(var i = 0; i < 8; ++i)
        consumers.Add(bus.Advanced.Consume(eventQueue, (_, _, _, c) => Task.Delay(-1, c), c => { }));

    foreach(var consumer in consumers)
        consumer.Dispose();

    await Task.Delay(5000);
}

```

Also, I've checked how RabbitMQ.Client v7(unreleased) handles this case: it registers `FallbackConsumer` by default and just emits warnings about these errors.

RabbitMQ.Client v6 handles this case by throwing an exception which causes a disconnection as described in the issue.
