### PR TITLE
Bump LightInject to 6.6.0

### DIFF
--- a/Source/EasyNetQ/EasyNetQ.csproj
+++ b/Source/EasyNetQ/EasyNetQ.csproj
@@ -9,9 +9,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="LightInject.Source" Version="6.5.2">
+    <PackageReference Include="LightInject.Source" Version="6.6.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Source/EasyNetQ/EasyNetQ.csproj
+++ b/Source/EasyNetQ/EasyNetQ.csproj
@@ -19,9 +19,9 @@
     </PackageReference>
     <PackageReference Include="NullGuard.Fody" Version="3.1.0" PrivateAssets="All" />
     <PackageReference Include="RabbitMQ.Client" Version="6.4.*" />
-    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-      <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    </ItemGroup>
     <InternalsVisibleTo Include="EasyNetQ.DI.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100B9880ED386BC2576BA1C405A35E05E57629D54CAAF50FE9ADA301BA3BD504BDD897D1EC2F9C328B66EBE72F57463DDC7BCB074D72F633FE4F21F6E9F3F79160AF30A11CA7A107B0568C3489A61C7E1EC31652497A7E553DE113DF7FB105E115F217A4F8E84D7162D57046BE1D1DEE9F04C3FFBA31BEA7DE4B809DC82DF736890" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/Source/EasyNetQ/EasyNetQ.csproj
+++ b/Source/EasyNetQ/EasyNetQ.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="LightInject.Source" Version="6.6.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
@@ -20,6 +19,9 @@
     </PackageReference>
     <PackageReference Include="NullGuard.Fody" Version="3.1.0" PrivateAssets="All" />
     <PackageReference Include="RabbitMQ.Client" Version="6.4.*" />
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+      <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    </ItemGroup>
     <InternalsVisibleTo Include="EasyNetQ.DI.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100B9880ED386BC2576BA1C405A35E05E57629D54CAAF50FE9ADA301BA3BD504BDD897D1EC2F9C328B66EBE72F57463DDC7BCB074D72F633FE4F21F6E9F3F79160AF30A11CA7A107B0568C3489A61C7E1EC31652497A7E553DE113DF7FB105E115F217A4F8E84D7162D57046BE1D1DEE9F04C3FFBA31BEA7DE4B809DC82DF736890" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Because of `IAsyncDisposable` support added in v6.6.0, `Microsoft.Bcl.AsyncInterfaces` is required to compile.

https://github.com/seesharper/LightInject/commit/373ccceaf1f80148388e5e285332236061aba8a4#diff-4ab818dce2e04c8ff0267f39a441efc07c904c8f6167e37fbf0fe0b8aa1abf6eR49