### PR TITLE
Allow to bind w/o Exchange/Queue instances

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -17,6 +17,8 @@ namespace EasyNetQ
         public static EasyNetQ.Topology.Binding<EasyNetQ.Topology.Exchange> Bind(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Exchange source, EasyNetQ.Topology.Exchange destination, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task<EasyNetQ.Topology.Binding<EasyNetQ.Topology.Exchange>> BindAsync(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Exchange source, EasyNetQ.Topology.Exchange destination, string routingKey, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task<EasyNetQ.Topology.Binding<EasyNetQ.Topology.Queue>> BindAsync(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Exchange source, EasyNetQ.Topology.Queue queue, string routingKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.Task<EasyNetQ.Topology.Binding<EasyNetQ.Topology.Queue>> BindAsync(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Exchange exchange, EasyNetQ.Topology.Queue queue, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.Task<EasyNetQ.Topology.Binding<EasyNetQ.Topology.Exchange>> BindAsync(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Exchange source, EasyNetQ.Topology.Exchange destination, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.IDisposable Consume(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Queue queue, EasyNetQ.Consumer.MessageHandler handler) { }
         public static System.IDisposable Consume(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Queue queue, System.Action<EasyNetQ.Consumer.IHandlerRegistration> addHandlers) { }
         public static System.IDisposable Consume(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Queue queue, System.Action<System.ReadOnlyMemory<byte>, EasyNetQ.MessageProperties, EasyNetQ.MessageReceivedInfo> handler) { }
@@ -287,12 +289,11 @@ namespace EasyNetQ
         event System.EventHandler<EasyNetQ.DisconnectedEventArgs> Disconnected;
         event System.EventHandler<EasyNetQ.MessageReturnedEventArgs> MessageReturned;
         event System.EventHandler<EasyNetQ.UnblockedEventArgs> Unblocked;
-        System.Threading.Tasks.Task<EasyNetQ.Topology.Binding<EasyNetQ.Topology.Queue>> BindAsync(EasyNetQ.Topology.Exchange exchange, EasyNetQ.Topology.Queue queue, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.Task<EasyNetQ.Topology.Binding<EasyNetQ.Topology.Exchange>> BindAsync(EasyNetQ.Topology.Exchange source, EasyNetQ.Topology.Exchange destination, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task ConnectAsync(System.Threading.CancellationToken cancellationToken = default);
         System.IDisposable Consume(System.Action<EasyNetQ.IConsumeConfiguration> configure);
         EasyNetQ.IPullingConsumer<EasyNetQ.PullResult> CreatePullingConsumer(in EasyNetQ.Topology.Queue queue, bool autoAck = true);
         EasyNetQ.IPullingConsumer<EasyNetQ.PullResult<T>> CreatePullingConsumer<T>(in EasyNetQ.Topology.Queue queue, bool autoAck = true);
+        System.Threading.Tasks.Task ExchangeBindAsync(string destinationExchange, string sourceExchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<EasyNetQ.Topology.Exchange> ExchangeDeclareAsync(string name, System.Action<EasyNetQ.IExchangeDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task ExchangeDeclarePassiveAsync(string name, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task ExchangeDeleteAsync(EasyNetQ.Topology.Exchange exchange, bool ifUnused = false, System.Threading.CancellationToken cancellationToken = default);
@@ -301,6 +302,7 @@ namespace EasyNetQ
         System.Threading.Tasks.Task PublishAsync(EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.IMessage message, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task PublishAsync(EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task PublishAsync<T>(EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.IMessage<T> message, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task QueueBindAsync(string queue, string exchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(string name, System.Action<EasyNetQ.IQueueDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task QueueDeclarePassiveAsync(string name, System.Threading.CancellationToken cancellationToken = default);
@@ -822,13 +824,12 @@ namespace EasyNetQ
         public event System.EventHandler<EasyNetQ.DisconnectedEventArgs>? Disconnected;
         public event System.EventHandler<EasyNetQ.MessageReturnedEventArgs>? MessageReturned;
         public event System.EventHandler<EasyNetQ.UnblockedEventArgs>? Unblocked;
-        public System.Threading.Tasks.Task<EasyNetQ.Topology.Binding<EasyNetQ.Topology.Queue>> BindAsync(EasyNetQ.Topology.Exchange exchange, EasyNetQ.Topology.Queue queue, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken) { }
-        public System.Threading.Tasks.Task<EasyNetQ.Topology.Binding<EasyNetQ.Topology.Exchange>> BindAsync(EasyNetQ.Topology.Exchange source, EasyNetQ.Topology.Exchange destination, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task ConnectAsync(System.Threading.CancellationToken cancellationToken = default) { }
         public System.IDisposable Consume(System.Action<EasyNetQ.IConsumeConfiguration> configure) { }
         public EasyNetQ.IPullingConsumer<EasyNetQ.PullResult> CreatePullingConsumer(in EasyNetQ.Topology.Queue queue, bool autoAck = true) { }
         public EasyNetQ.IPullingConsumer<EasyNetQ.PullResult<T>> CreatePullingConsumer<T>(in EasyNetQ.Topology.Queue queue, bool autoAck = true) { }
         public virtual void Dispose() { }
+        public virtual System.Threading.Tasks.Task ExchangeBindAsync(string destinationExchange, string sourceExchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<EasyNetQ.Topology.Exchange> ExchangeDeclareAsync(string name, System.Action<EasyNetQ.IExchangeDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task ExchangeDeclarePassiveAsync(string name, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.Task ExchangeDeleteAsync(EasyNetQ.Topology.Exchange exchange, bool ifUnused = false, System.Threading.CancellationToken cancellationToken = default) { }
@@ -837,6 +838,7 @@ namespace EasyNetQ
         public virtual System.Threading.Tasks.Task PublishAsync(EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.IMessage message, System.Threading.CancellationToken cancellationToken) { }
         public virtual System.Threading.Tasks.Task PublishAsync(EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body, System.Threading.CancellationToken cancellationToken) { }
         public virtual System.Threading.Tasks.Task PublishAsync<T>(EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.IMessage<T> message, System.Threading.CancellationToken cancellationToken) { }
+        public virtual System.Threading.Tasks.Task QueueBindAsync(string queue, string exchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(string name, System.Action<EasyNetQ.IQueueDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task QueueDeclarePassiveAsync(string name, System.Threading.CancellationToken cancellationToken = default) { }

--- a/Source/EasyNetQ.Tests/MessageVersioningTests/VersionedExchangeDeclareStrategyTests.cs
+++ b/Source/EasyNetQ.Tests/MessageVersioningTests/VersionedExchangeDeclareStrategyTests.cs
@@ -54,9 +54,9 @@ public class VersionedExchangeDeclareStrategyTests
     public void When_declaring_exchanges_for_unversioned_message_one_exchange_created()
     {
         var exchanges = new List<Exchange>();
-        var boundExchanges = new Dictionary<Exchange, Exchange>();
+        var boundExchanges = new Dictionary<string, string>();
         var advancedBus = Substitute.For<IAdvancedBus>();
-        advancedBus.ExchangeDeclareAsync(null, null)
+        advancedBus.ExchangeDeclareAsync(Arg.Any<string>(), Arg.Any<Action<IExchangeDeclareConfiguration>>())
             .ReturnsForAnyArgs(mi =>
             {
                 var exchange = new Exchange((string)mi[0]);
@@ -64,15 +64,13 @@ public class VersionedExchangeDeclareStrategyTests
                 return Task.FromResult(exchange);
             });
 
-        advancedBus.BindAsync(Arg.Any<Exchange>(), Arg.Any<Exchange>(), Arg.Is("#"), Arg.Any<IDictionary<string, object>>())
+        advancedBus.ExchangeBindAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Is("#"), Arg.Any<IDictionary<string, object>>())
             .Returns(mi =>
             {
-                var source = (Exchange)mi[0];
-                var destination = (Exchange)mi[1];
-                var routingKey = (string)mi[2];
-                var arguments = (IDictionary<string, object>)mi[3];
+                var source = (string)mi[0];
+                var destination = (string)mi[1];
                 boundExchanges.Add(source, destination);
-                return Task.FromResult(new Binding<Exchange>(source, destination, routingKey, arguments));
+                return Task.CompletedTask;
             });
 
         var conventions = Substitute.For<IConventions>();
@@ -90,26 +88,24 @@ public class VersionedExchangeDeclareStrategyTests
     [Fact]
     public void When_declaring_exchanges_for_versioned_message_exchange_per_version_created_and_bound_to_superceding_version()
     {
-        var exchanges = new List<Exchange>();
-        var boundExchanges = new Dictionary<Exchange, Exchange>();
+        var exchanges = new List<string>();
+        var boundExchanges = new Dictionary<string, string>();
         var advancedBus = Substitute.For<IAdvancedBus>();
-        advancedBus.ExchangeDeclareAsync(null, null)
+        advancedBus.ExchangeDeclareAsync(Arg.Any<string>(), Arg.Any<Action<IExchangeDeclareConfiguration>>())
             .ReturnsForAnyArgs(mi =>
             {
-                var exchange = new Exchange((string)mi[0]);
+                var exchange = (string)mi[0];
                 exchanges.Add(exchange);
-                return Task.FromResult(exchange);
+                return Task.FromResult(new Exchange(exchange));
             });
 
-        advancedBus.BindAsync(Arg.Any<Exchange>(), Arg.Any<Exchange>(), Arg.Is("#"), Arg.Any<IDictionary<string, object>>())
+        advancedBus.ExchangeBindAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Is("#"), Arg.Any<IDictionary<string, object>>())
             .Returns(mi =>
             {
-                var source = (Exchange)mi[0];
-                var destination = (Exchange)mi[1];
-                var routingKey = (string)mi[2];
-                var arguments = (IDictionary<string, object>)mi[3];
+                var destination = (string)mi[0];
+                var source = (string)mi[1];
                 boundExchanges.Add(source, destination);
-                return Task.FromResult(new Binding<Exchange>(source, destination, routingKey, arguments));
+                return Task.CompletedTask;
             });
 
         var conventions = Substitute.For<IConventions>();
@@ -120,10 +116,10 @@ public class VersionedExchangeDeclareStrategyTests
         publishExchangeStrategy.DeclareExchange(typeof(MyMessageV2), ExchangeType.Topic);
 
         Assert.Equal(2, exchanges.Count); //, "Two exchanges should have been created" );
-        Assert.Equal("MyMessage", exchanges[0].Name); //, "Superseded message exchange should been created first" );
-        Assert.Equal("MyMessageV2", exchanges[1].Name); //, "Superseding message exchange should been created second" );
+        Assert.Equal("MyMessage", exchanges[0]); //, "Superseded message exchange should been created first" );
+        Assert.Equal("MyMessageV2", exchanges[1]); //, "Superseding message exchange should been created second" );
 
-        boundExchanges.Should().BeEquivalentTo(new Dictionary<Exchange, Exchange>
+        boundExchanges.Should().BeEquivalentTo(new Dictionary<string, string>
         {
             {exchanges[1], exchanges[0]}
         });

--- a/Source/EasyNetQ/AdvancedBusExtensions.cs
+++ b/Source/EasyNetQ/AdvancedBusExtensions.cs
@@ -632,6 +632,53 @@ public static class AdvancedBusExtensions
             .GetResult();
     }
 
+
+    /// <summary>
+    /// Bind an exchange to a queue. Does nothing if the binding already exists.
+    /// </summary>
+    /// <param name="bus">The bus instance</param>
+    /// <param name="exchange">The exchange to bind</param>
+    /// <param name="queue">The queue to bind</param>
+    /// <param name="routingKey">The routing key</param>
+    /// <param name="arguments">The arguments</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <returns>A binding</returns>
+    public static async Task<Binding<Queue>> BindAsync(
+        this IAdvancedBus bus,
+        Exchange exchange,
+        Queue queue,
+        string routingKey,
+        IDictionary<string, object>? arguments,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await bus.QueueBindAsync(queue.Name, exchange.Name, routingKey, arguments, cancellationToken).ConfigureAwait(false);
+        return new Binding<Queue>(exchange, queue, routingKey, arguments);
+    }
+
+    /// <summary>
+    /// Bind two exchanges. Does nothing if the binding already exists.
+    /// </summary>
+    /// <param name="bus">The bus instance</param>
+    /// <param name="source">The source exchange</param>
+    /// <param name="destination">The destination exchange</param>
+    /// <param name="routingKey">The routing key</param>
+    /// <param name="arguments">The arguments</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <returns>A binding</returns>
+    public static async Task<Binding<Exchange>> BindAsync(
+        this IAdvancedBus bus,
+        Exchange source,
+        Exchange destination,
+        string routingKey,
+        IDictionary<string, object>? arguments,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await bus.ExchangeBindAsync(destination.Name, source.Name, routingKey, arguments, cancellationToken).ConfigureAwait(false);
+        return new Binding<Exchange>(source, destination, routingKey, arguments);
+    }
+
     /// <summary>
     /// Bind two exchanges. Does nothing if the binding already exists.
     /// </summary>

--- a/Source/EasyNetQ/IAdvancedBus.cs
+++ b/Source/EasyNetQ/IAdvancedBus.cs
@@ -201,34 +201,11 @@ public interface IAdvancedBus : IDisposable
     );
 
     /// <summary>
-    /// Bind an exchange to a queue. Does nothing if the binding already exists.
+    /// Bind a queue to an exchange.
     /// </summary>
-    /// <param name="exchange">The exchange to bind</param>
-    /// <param name="queue">The queue to bind</param>
-    /// <param name="routingKey">The routing key</param>
-    /// <param name="arguments">The arguments</param>
-    /// <param name="cancellationToken">The cancellation token</param>
-    /// <returns>A binding</returns>
-    Task<Binding<Queue>> BindAsync(
-        Exchange exchange,
-        Queue queue,
-        string routingKey,
-        IDictionary<string, object>? arguments,
-        CancellationToken cancellationToken = default
-    );
-
-    /// <summary>
-    /// Bind two exchanges. Does nothing if the binding already exists.
-    /// </summary>
-    /// <param name="source">The source exchange</param>
-    /// <param name="destination">The destination exchange</param>
-    /// <param name="routingKey">The routing key</param>
-    /// <param name="arguments">The arguments</param>
-    /// <param name="cancellationToken">The cancellation token</param>
-    /// <returns>A binding</returns>
-    Task<Binding<Exchange>> BindAsync(
-        Exchange source,
-        Exchange destination,
+    Task QueueBindAsync(
+        string queue,
+        string exchange,
         string routingKey,
         IDictionary<string, object>? arguments,
         CancellationToken cancellationToken = default
@@ -240,6 +217,17 @@ public interface IAdvancedBus : IDisposable
     Task QueueUnbindAsync(
         string queue,
         string exchange,
+        string routingKey,
+        IDictionary<string, object>? arguments,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Bind an exchange to an exchange.
+    /// </summary>
+    Task ExchangeBindAsync(
+        string destinationExchange,
+        string sourceExchange,
         string routingKey,
         IDictionary<string, object>? arguments,
         CancellationToken cancellationToken = default

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -580,7 +580,7 @@ public class RabbitAdvancedBus : IAdvancedBus
         if (logger.IsDebugEnabled())
         {
             logger.DebugFormat(
-                $"Unbound destination exchange {{destinationExchange}} from source exchange {{sourceExchange}} with routing key {{routingKey}} and arguments {arguments}",
+                "Unbound destination exchange {destinationExchange} from source exchange {sourceExchange} with routing key {routingKey} and arguments {arguments}",
                 destinationExchange,
                 sourceExchange,
                 routingKey,


### PR DESCRIPTION
We have the same for Declare, Delete, Purge, Unbind. Have no idea why it hasn't been done for Bind. 