### PR TITLE
Client side of RPC should listen for consumer connection

### DIFF
--- a/Source/EasyNetQ/DefaultRpc.cs
+++ b/Source/EasyNetQ/DefaultRpc.cs
@@ -128,7 +128,7 @@ public class DefaultRpc : IRpc
 
     private void OnConnectionRecovered(in ConnectionRecoveredEvent @event)
     {
-        if (@event.Type != PersistentConnectionType.Producer)
+        if (@event.Type != PersistentConnectionType.Consumer)
             return;
 
         var responseActionsValues = responseActions.Values;


### PR DESCRIPTION
Fixes #1483.

The code below this check relies on the consumer connection, no on the producer one.