### PR TITLE
Allow use of quorum queues in RPC

### DIFF
--- a/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_configured_queues.cs
+++ b/Source/EasyNetQ.IntegrationTests/Rpc/When_request_and_respond_with_configured_queues.cs
@@ -1,0 +1,96 @@
+using EasyNetQ.Management.Client;
+using EasyNetQ.Management.Client.Model;
+using FluentAssertions;
+using RabbitMQ.Client.Exceptions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EasyNetQ.IntegrationTests.Rpc
+{
+    [Collection("RabbitMQ")]
+    public class When_request_and_respond_with_configured_queues : IDisposable
+    {
+        public When_request_and_respond_with_configured_queues(RabbitMQFixture fixture)
+        {
+            bus = RabbitHutch.CreateBus($"host={fixture.Host};prefetchCount=1;timeout=-1");
+            this.fixture = fixture;
+        }
+
+        public void Dispose()
+        {
+            bus.Dispose();
+        }
+
+        private readonly IBus bus;
+        private readonly RabbitMQFixture fixture;
+
+        [Fact]
+        public async Task Should_create_classic_queues_by_defualt()
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+            using (await bus.Rpc.RespondAsync<RabbitRequest, RabbitResponse>((x, ct) =>
+            {
+                return x switch
+                {
+                    RabbitRequest b => Task.FromResult(new RabbitResponse(b.Id)),
+                    _ => throw new ArgumentOutOfRangeException(nameof(x), x, null)
+                };
+            },
+            c => { },
+            cts.Token))
+            {
+                var bunnyResponse = await bus.Rpc.RequestAsync<RabbitRequest, RabbitResponse>(
+                    new RabbitRequest(42), cts.Token
+                );
+                bunnyResponse.Should().Be(new RabbitResponse(42));
+            }
+
+            string destinationQueueName =
+                bus.Advanced.Conventions.RpcRoutingKeyNamingConvention.Invoke(typeof(RabbitRequest));
+
+            Exception e =
+                Record.Exception(() => bus.Advanced.QueueDeclare(destinationQueueName, c => c.WithQueueType("quorum")));
+
+            e.Should().BeOfType<OperationInterruptedException>();
+            e.Message.Should().Contain("inequivalent arg 'x-queue-type' for queue");
+        }
+
+        [Fact]
+        public async Task Should_create_quorum_queues_if_requested()
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+            using (await bus.Rpc.RespondAsync<BunnyRequest, BunnyResponse>((x, ct) =>
+            {
+                return x switch
+                {
+                    BunnyRequest b => Task.FromResult(new BunnyResponse(b.Id)),
+                    _ => throw new ArgumentOutOfRangeException(nameof(x), x, null)
+                };
+            },
+            c => c.WithQueueType("quorum"),
+            cts.Token))
+            {
+                var bunnyResponse = await bus.Rpc.RequestAsync<BunnyRequest, BunnyResponse>(
+                    new BunnyRequest(42), c => c.WithQueueType("quorum"), cts.Token
+                );
+                bunnyResponse.Should().Be(new BunnyResponse(42));
+            }
+
+            string destinationQueueName =
+                bus.Advanced.Conventions.RpcRoutingKeyNamingConvention.Invoke(typeof(BunnyRequest));
+
+            Exception e =
+                Record.Exception(() => bus.Advanced.QueueDeclare(destinationQueueName, c => c.WithQueueType("classic")));
+
+            e.Should().BeOfType<OperationInterruptedException>();
+            e.Message.Should().Contain("inequivalent arg 'x-queue-type' for queue");
+        }
+    }
+}

--- a/Source/EasyNetQ/RequestConfiguration.cs
+++ b/Source/EasyNetQ/RequestConfiguration.cs
@@ -33,6 +33,13 @@ public interface IRequestConfiguration
     IRequestConfiguration WithQueueName(string queueName);
 
     /// <summary>
+    /// Sets the queue type. Valid types are "classic" and "quorum". Works with RabbitMQ version 3.8+.
+    /// </summary>
+    /// <param name="queueType">Desired queue type.</param>
+    /// <returns>Returns a reference to itself</returns>
+    IRequestConfiguration WithQueueType(string queueType);
+
+    /// <summary>
     /// Sets headers
     /// </summary>
     /// <param name="headers">Headers to set</param>
@@ -42,13 +49,15 @@ public interface IRequestConfiguration
 
 internal class RequestConfiguration : IRequestConfiguration
 {
-    public RequestConfiguration(string queueName, TimeSpan expiration)
+    public RequestConfiguration(string queueName, TimeSpan expiration, string queueType = EasyNetQ.QueueType.Classic)
     {
         QueueName = queueName;
         Expiration = expiration;
+        QueueType = queueType;
     }
 
     public string QueueName { get; private set; }
+    public string QueueType { get; private set; }
     public TimeSpan Expiration { get; private set; }
     public byte? Priority { get; private set; }
     public IDictionary<string, object?>? Headers { get; private set; }
@@ -68,6 +77,12 @@ internal class RequestConfiguration : IRequestConfiguration
     public IRequestConfiguration WithQueueName(string queueName)
     {
         QueueName = queueName;
+        return this;
+    }
+
+    public IRequestConfiguration WithQueueType(string queueType)
+    {
+        QueueType = queueType;
         return this;
     }
 

--- a/Source/EasyNetQ/ResponderConfiguration.cs
+++ b/Source/EasyNetQ/ResponderConfiguration.cs
@@ -20,9 +20,16 @@ public interface IResponderConfiguration
     /// <summary>
     /// Sets the queue name
     /// </summary>
-    /// <param name="queueName"></param>
+    /// <param name="queueName">The name of the queue</param>
     /// <returns>Reference to the same <see cref="IResponderConfiguration"/> to allow methods chaining</returns>
     IResponderConfiguration WithQueueName(string queueName);
+
+    /// <summary>
+    /// Sets the queue type. Valid values are "classic" and "quorum".
+    /// </summary>
+    /// <param name="queueType">The queue type</param>
+    /// <returns>Reference to the same <see cref="IResponderConfiguration"/> to allow methods chaining</returns>
+    IResponderConfiguration WithQueueType(string queueType);
 
     /// <summary>
     /// Configures the queue's durability
@@ -60,6 +67,7 @@ internal class ResponderConfiguration : IResponderConfiguration
 
     public ushort PrefetchCount { get; private set; }
     public string? QueueName { get; private set; }
+    public string? QueueType { get; private set; }
     public bool Durable { get; private set; } = true;
     public TimeSpan? Expires { get; private set; }
     public byte? MaxPriority { get; private set; }
@@ -73,6 +81,12 @@ internal class ResponderConfiguration : IResponderConfiguration
     public IResponderConfiguration WithQueueName(string queueName)
     {
         QueueName = queueName;
+        return this;
+    }
+
+    public IResponderConfiguration WithQueueType(string queueType)
+    {
+        QueueType = queueType;
         return this;
     }
 


### PR DESCRIPTION
Allows users of the library to specify types (classic, quorum) for destination and/or return queues created by the RPC module. Admittedly not the most elegant solution, especially when it comes to deconfiguring other values (autodelete etc.) when a quorum queue is configured. The integration tests I have added do not check that the return queue is the right kind because I saw no way to get its name; however, I have verified it manually.