### PR TITLE
Remove leaked abstractions from IAdvancedBus

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -282,8 +282,6 @@ namespace EasyNetQ
     }
     public interface IAdvancedBus : System.IDisposable
     {
-        EasyNetQ.DI.IServiceResolver Container { get; }
-        EasyNetQ.IConventions Conventions { get; }
         bool IsConnected { get; }
         event System.EventHandler<EasyNetQ.BlockedEventArgs> Blocked;
         event System.EventHandler<EasyNetQ.ConnectedEventArgs> Connected;

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
@@ -22,9 +22,9 @@ public class When_a_responder_is_cancelled : IDisposable
     {
         mockBuilder = new MockBuilder();
 
-        conventions = mockBuilder.Bus.Advanced.Conventions;
-        typeNameSerializer = mockBuilder.Bus.Advanced.Container.Resolve<ITypeNameSerializer>();
-        serializer = mockBuilder.Bus.Advanced.Container.Resolve<ISerializer>();
+        conventions = mockBuilder.Conventions;
+        typeNameSerializer = mockBuilder.TypeNameSerializer;
+        serializer = mockBuilder.Serializer;
 
         mockBuilder.Rpc.Respond<RpcRequest, RpcResponse>(_ =>
         {

--- a/Source/EasyNetQ/IAdvancedBus.cs
+++ b/Source/EasyNetQ/IAdvancedBus.cs
@@ -25,16 +25,6 @@ public interface IAdvancedBus : IDisposable
     Task ConnectAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// The IoC container that EasyNetQ uses to resolve its services.
-    /// </summary>
-    IServiceResolver Container { get; }
-
-    /// <summary>
-    /// The conventions used by EasyNetQ to name its routing topology elements.
-    /// </summary>
-    IConventions Conventions { get; }
-
-    /// <summary>
     /// Consume a stream of messages. Dispatch them to the given handlers
     /// </summary>
     /// <param name="configure">


### PR DESCRIPTION
Consider removing `Container` and `Conventions` properties from `IAdvancedBus`.

It seems they are only used in the tests when mocking a custom bus. For me, it's a good sign that there aren't any classes depending on that.

We are using only a subset of EasyNetQ interfaces with an external container.
For example we don't use `IBus`. In that case we don't even have to register unused interfaces in the container.
`IConventions` is the only interface that we have to register, because `IAdvancedBus` depends on that, even though it's not used.

1. `Conventions` shouldn't be in the AdvancedBus anyway. We can add them to `IBus` which contains `IPubSub`, `IRpc` and other communication models that are actually dependent on the conventions.
Still, since the conventions are only configured at container build time I don't think they should be publicly available after that.

2. Leaking `Container` in the public interface sets a really bad example of how not to use IoC container. It's especially bad when using adapters to external containers. You can create services through `IAdvancedBus.Container` that are completely outside the scope of EasyNetQ.

To fix that I refactored MockBuilder to use internal container with services required for the tests (like IConnectionFactory for the Docker container). I've also added the mocked services to be resolved directly from this container. They were already some defined like that (ex. IEventBus).