### PR TITLE
Remove IDisposable from some interfaces

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -163,7 +163,7 @@ namespace EasyNetQ
         public virtual System.Threading.Tasks.Task PublishAsync<T>(T message, System.Action<EasyNetQ.IPublishConfiguration> configure, System.Threading.CancellationToken cancellationToken) { }
         public virtual EasyNetQ.Internals.AwaitableDisposable<EasyNetQ.SubscriptionResult> SubscribeAsync<T>(string subscriptionId, System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.Task> onMessage, System.Action<EasyNetQ.ISubscriptionConfiguration> configure, System.Threading.CancellationToken cancellationToken) { }
     }
-    public class DefaultRpc : EasyNetQ.IRpc, System.IDisposable
+    public class DefaultRpc : EasyNetQ.IRpc
     {
         protected const string ExceptionMessageKey = "ExceptionMessage";
         protected const string IsFaultedKey = "IsFaulted";
@@ -280,7 +280,7 @@ namespace EasyNetQ
         public ushort Port { get; set; }
         public RabbitMQ.Client.SslOption Ssl { get; }
     }
-    public interface IAdvancedBus : System.IDisposable
+    public interface IAdvancedBus
     {
         bool IsConnected { get; }
         event System.EventHandler<EasyNetQ.BlockedEventArgs> Blocked;
@@ -458,7 +458,7 @@ namespace EasyNetQ
         EasyNetQ.IResponderConfiguration WithPrefetchCount(ushort prefetchCount);
         EasyNetQ.IResponderConfiguration WithQueueName(string queueName);
     }
-    public interface IRpc : System.IDisposable
+    public interface IRpc
     {
         System.Threading.Tasks.Task<TResponse> RequestAsync<TRequest, TResponse>(TRequest request, System.Action<EasyNetQ.IRequestConfiguration> configure, System.Threading.CancellationToken cancellationToken = default);
         EasyNetQ.Internals.AwaitableDisposable<System.IDisposable> RespondAsync<TRequest, TResponse>(System.Func<TRequest, System.Threading.CancellationToken, System.Threading.Tasks.Task<TResponse>> responder, System.Action<EasyNetQ.IResponderConfiguration> configure, System.Threading.CancellationToken cancellationToken = default);
@@ -795,7 +795,7 @@ namespace EasyNetQ
         public const string Quorum = "quorum";
     }
     public delegate string? QueueTypeConvention(System.Type messageType);
-    public class RabbitAdvancedBus : EasyNetQ.IAdvancedBus, System.IDisposable
+    public class RabbitAdvancedBus : EasyNetQ.IAdvancedBus
     {
         public RabbitAdvancedBus(
                     EasyNetQ.Logging.ILogger<EasyNetQ.RabbitAdvancedBus> logger,
@@ -1030,12 +1030,12 @@ namespace EasyNetQ.AutoSubscribe
 }
 namespace EasyNetQ.ChannelDispatcher
 {
-    public interface IPersistentChannelDispatcher : System.IDisposable
+    public interface IPersistentChannelDispatcher
     {
         System.Threading.Tasks.Task<TResult> InvokeAsync<TResult, TChannelAction>(TChannelAction channelAction, EasyNetQ.ChannelDispatcher.PersistentChannelDispatchOptions options, System.Threading.CancellationToken cancellationToken = default)
             where TChannelAction :  struct, EasyNetQ.Persistent.IPersistentChannelAction<TResult>;
     }
-    public sealed class MultiPersistentChannelDispatcher : EasyNetQ.ChannelDispatcher.IPersistentChannelDispatcher, System.IDisposable
+    public sealed class MultiPersistentChannelDispatcher : EasyNetQ.ChannelDispatcher.IPersistentChannelDispatcher
     {
         public MultiPersistentChannelDispatcher(int channelsCount, EasyNetQ.Producer.IProducerConnection producerConnection, EasyNetQ.Consumer.IConsumerConnection consumerConnection, EasyNetQ.Persistent.IPersistentChannelFactory channelFactory) { }
         public void Dispose() { }
@@ -1055,7 +1055,7 @@ namespace EasyNetQ.ChannelDispatcher
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
     }
-    public sealed class SinglePersistentChannelDispatcher : EasyNetQ.ChannelDispatcher.IPersistentChannelDispatcher, System.IDisposable
+    public sealed class SinglePersistentChannelDispatcher : EasyNetQ.ChannelDispatcher.IPersistentChannelDispatcher
     {
         public SinglePersistentChannelDispatcher(EasyNetQ.Producer.IProducerConnection producerConnection, EasyNetQ.Consumer.IConsumerConnection consumerConnection, EasyNetQ.Persistent.IPersistentChannelFactory channelFactory) { }
         public void Dispose() { }
@@ -1126,7 +1126,7 @@ namespace EasyNetQ.Consumer
         public EasyNetQ.Consumer.IConsumer CreateConsumer(EasyNetQ.Consumer.ConsumerConfiguration configuration) { }
         public void Dispose() { }
     }
-    public class DefaultConsumerErrorStrategy : EasyNetQ.Consumer.IConsumerErrorStrategy, System.IDisposable
+    public class DefaultConsumerErrorStrategy : EasyNetQ.Consumer.IConsumerErrorStrategy
     {
         public DefaultConsumerErrorStrategy(EasyNetQ.Logging.ILogger<EasyNetQ.Consumer.DefaultConsumerErrorStrategy> logger, EasyNetQ.Consumer.IConsumerConnection connection, EasyNetQ.ISerializer serializer, EasyNetQ.IConventions conventions, EasyNetQ.ITypeNameSerializer typeNameSerializer, EasyNetQ.Consumer.IErrorMessageSerializer errorMessageSerializer, EasyNetQ.ConnectionConfiguration configuration) { }
         public virtual void Dispose() { }
@@ -1164,7 +1164,7 @@ namespace EasyNetQ.Consumer
         public static EasyNetQ.Consumer.IHandlerRegistration Add<T>(this EasyNetQ.Consumer.IHandlerRegistration handlerRegistration, System.Func<EasyNetQ.IMessage<T>, EasyNetQ.MessageReceivedInfo, System.Threading.Tasks.Task<EasyNetQ.Consumer.AckStrategy>> handler) { }
         public static EasyNetQ.Consumer.IHandlerRegistration Add<T>(this EasyNetQ.Consumer.IHandlerRegistration handlerRegistration, System.Func<EasyNetQ.IMessage<T>, EasyNetQ.MessageReceivedInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler) { }
     }
-    public class HandlerRunner : EasyNetQ.Consumer.IHandlerRunner, System.IDisposable
+    public class HandlerRunner : EasyNetQ.Consumer.IHandlerRunner
     {
         public HandlerRunner(EasyNetQ.Logging.ILogger<EasyNetQ.Consumer.IHandlerRunner> logger, EasyNetQ.Consumer.IConsumerErrorStrategy consumerErrorStrategy) { }
         public virtual void Dispose() { }
@@ -1176,7 +1176,7 @@ namespace EasyNetQ.Consumer
         void StartConsuming();
     }
     public interface IConsumerConnection : EasyNetQ.Persistent.IPersistentConnection, System.IDisposable { }
-    public interface IConsumerErrorStrategy : System.IDisposable
+    public interface IConsumerErrorStrategy
     {
         System.Threading.Tasks.Task<EasyNetQ.Consumer.AckStrategy> HandleConsumerCancelledAsync(EasyNetQ.Consumer.ConsumerExecutionContext context, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<EasyNetQ.Consumer.AckStrategy> HandleConsumerErrorAsync(EasyNetQ.Consumer.ConsumerExecutionContext context, System.Exception exception, System.Threading.CancellationToken cancellationToken = default);
@@ -1204,7 +1204,7 @@ namespace EasyNetQ.Consumer
         bool ThrowOnNoMatchingHandler { set; }
         EasyNetQ.Consumer.IHandlerRegistration Add<T>(EasyNetQ.Consumer.IMessageHandler<T> handler);
     }
-    public interface IHandlerRunner : System.IDisposable
+    public interface IHandlerRunner
     {
         System.Threading.Tasks.Task<EasyNetQ.Consumer.AckStrategy> InvokeUserMessageHandlerAsync(EasyNetQ.Consumer.ConsumerExecutionContext context, System.Threading.CancellationToken cancellationToken = default);
     }
@@ -1257,7 +1257,7 @@ namespace EasyNetQ.Consumer
         public EasyNetQ.Consumer.MessageHandler Handler { get; }
         public bool IsExclusive { get; }
     }
-    public class SimpleConsumerErrorStrategy : EasyNetQ.Consumer.IConsumerErrorStrategy, System.IDisposable
+    public class SimpleConsumerErrorStrategy : EasyNetQ.Consumer.IConsumerErrorStrategy
     {
         public static readonly EasyNetQ.Consumer.SimpleConsumerErrorStrategy Ack;
         public static readonly EasyNetQ.Consumer.SimpleConsumerErrorStrategy NackWithRequeue;

--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -163,7 +163,7 @@ namespace EasyNetQ
         public virtual System.Threading.Tasks.Task PublishAsync<T>(T message, System.Action<EasyNetQ.IPublishConfiguration> configure, System.Threading.CancellationToken cancellationToken) { }
         public virtual EasyNetQ.Internals.AwaitableDisposable<EasyNetQ.SubscriptionResult> SubscribeAsync<T>(string subscriptionId, System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.Task> onMessage, System.Action<EasyNetQ.ISubscriptionConfiguration> configure, System.Threading.CancellationToken cancellationToken) { }
     }
-    public class DefaultRpc : EasyNetQ.IRpc
+    public class DefaultRpc : EasyNetQ.IRpc, System.IDisposable
     {
         protected const string ExceptionMessageKey = "ExceptionMessage";
         protected const string IsFaultedKey = "IsFaulted";
@@ -795,7 +795,7 @@ namespace EasyNetQ
         public const string Quorum = "quorum";
     }
     public delegate string? QueueTypeConvention(System.Type messageType);
-    public class RabbitAdvancedBus : EasyNetQ.IAdvancedBus
+    public class RabbitAdvancedBus : EasyNetQ.IAdvancedBus, System.IDisposable
     {
         public RabbitAdvancedBus(
                     EasyNetQ.Logging.ILogger<EasyNetQ.RabbitAdvancedBus> logger,

--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -1035,7 +1035,7 @@ namespace EasyNetQ.ChannelDispatcher
         System.Threading.Tasks.Task<TResult> InvokeAsync<TResult, TChannelAction>(TChannelAction channelAction, EasyNetQ.ChannelDispatcher.PersistentChannelDispatchOptions options, System.Threading.CancellationToken cancellationToken = default)
             where TChannelAction :  struct, EasyNetQ.Persistent.IPersistentChannelAction<TResult>;
     }
-    public sealed class MultiPersistentChannelDispatcher : EasyNetQ.ChannelDispatcher.IPersistentChannelDispatcher
+    public sealed class MultiPersistentChannelDispatcher : EasyNetQ.ChannelDispatcher.IPersistentChannelDispatcher, System.IDisposable
     {
         public MultiPersistentChannelDispatcher(int channelsCount, EasyNetQ.Producer.IProducerConnection producerConnection, EasyNetQ.Consumer.IConsumerConnection consumerConnection, EasyNetQ.Persistent.IPersistentChannelFactory channelFactory) { }
         public void Dispose() { }
@@ -1055,7 +1055,7 @@ namespace EasyNetQ.ChannelDispatcher
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
     }
-    public sealed class SinglePersistentChannelDispatcher : EasyNetQ.ChannelDispatcher.IPersistentChannelDispatcher
+    public sealed class SinglePersistentChannelDispatcher : EasyNetQ.ChannelDispatcher.IPersistentChannelDispatcher, System.IDisposable
     {
         public SinglePersistentChannelDispatcher(EasyNetQ.Producer.IProducerConnection producerConnection, EasyNetQ.Consumer.IConsumerConnection consumerConnection, EasyNetQ.Persistent.IPersistentChannelFactory channelFactory) { }
         public void Dispose() { }
@@ -1126,7 +1126,7 @@ namespace EasyNetQ.Consumer
         public EasyNetQ.Consumer.IConsumer CreateConsumer(EasyNetQ.Consumer.ConsumerConfiguration configuration) { }
         public void Dispose() { }
     }
-    public class DefaultConsumerErrorStrategy : EasyNetQ.Consumer.IConsumerErrorStrategy
+    public class DefaultConsumerErrorStrategy : EasyNetQ.Consumer.IConsumerErrorStrategy, System.IDisposable
     {
         public DefaultConsumerErrorStrategy(EasyNetQ.Logging.ILogger<EasyNetQ.Consumer.DefaultConsumerErrorStrategy> logger, EasyNetQ.Consumer.IConsumerConnection connection, EasyNetQ.ISerializer serializer, EasyNetQ.IConventions conventions, EasyNetQ.ITypeNameSerializer typeNameSerializer, EasyNetQ.Consumer.IErrorMessageSerializer errorMessageSerializer, EasyNetQ.ConnectionConfiguration configuration) { }
         public virtual void Dispose() { }
@@ -1164,7 +1164,7 @@ namespace EasyNetQ.Consumer
         public static EasyNetQ.Consumer.IHandlerRegistration Add<T>(this EasyNetQ.Consumer.IHandlerRegistration handlerRegistration, System.Func<EasyNetQ.IMessage<T>, EasyNetQ.MessageReceivedInfo, System.Threading.Tasks.Task<EasyNetQ.Consumer.AckStrategy>> handler) { }
         public static EasyNetQ.Consumer.IHandlerRegistration Add<T>(this EasyNetQ.Consumer.IHandlerRegistration handlerRegistration, System.Func<EasyNetQ.IMessage<T>, EasyNetQ.MessageReceivedInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler) { }
     }
-    public class HandlerRunner : EasyNetQ.Consumer.IHandlerRunner
+    public class HandlerRunner : EasyNetQ.Consumer.IHandlerRunner, System.IDisposable
     {
         public HandlerRunner(EasyNetQ.Logging.ILogger<EasyNetQ.Consumer.IHandlerRunner> logger, EasyNetQ.Consumer.IConsumerErrorStrategy consumerErrorStrategy) { }
         public virtual void Dispose() { }
@@ -1257,7 +1257,7 @@ namespace EasyNetQ.Consumer
         public EasyNetQ.Consumer.MessageHandler Handler { get; }
         public bool IsExclusive { get; }
     }
-    public class SimpleConsumerErrorStrategy : EasyNetQ.Consumer.IConsumerErrorStrategy
+    public class SimpleConsumerErrorStrategy : EasyNetQ.Consumer.IConsumerErrorStrategy, System.IDisposable
     {
         public static readonly EasyNetQ.Consumer.SimpleConsumerErrorStrategy Ack;
         public static readonly EasyNetQ.Consumer.SimpleConsumerErrorStrategy NackWithRequeue;

--- a/Source/EasyNetQ.Tests/AdvancedBusEventHandlersTests.cs
+++ b/Source/EasyNetQ.Tests/AdvancedBusEventHandlersTests.cs
@@ -78,7 +78,7 @@ public class AdvancedBusEventHandlersTests : IDisposable
     private bool unBlockedCalled;
     private bool messageReturnedCalled;
     private MessageReturnedEventArgs messageReturnedEventArgs;
-    private readonly IAdvancedBus advancedBus;
+    private readonly RabbitAdvancedBus advancedBus;
     private ConnectedEventArgs connectedEventArgs;
     private DisconnectedEventArgs disconnectedEventArgs;
 

--- a/Source/EasyNetQ.Tests/ChannelDispatcherTests/When_an_action_is_invoked_that_throws_using_multi_channel.cs
+++ b/Source/EasyNetQ.Tests/ChannelDispatcherTests/When_an_action_is_invoked_that_throws_using_multi_channel.cs
@@ -15,7 +15,7 @@ namespace EasyNetQ.Tests.ChannelDispatcherTests;
 
 public class When_an_action_is_invoked_that_throws_using_multi_channel : IDisposable
 {
-    private readonly IPersistentChannelDispatcher dispatcher;
+    private readonly MultiPersistentChannelDispatcher dispatcher;
 
     public When_an_action_is_invoked_that_throws_using_multi_channel()
     {

--- a/Source/EasyNetQ.Tests/ChannelDispatcherTests/When_an_action_is_invoked_that_throws_using_single_channel.cs
+++ b/Source/EasyNetQ.Tests/ChannelDispatcherTests/When_an_action_is_invoked_that_throws_using_single_channel.cs
@@ -15,7 +15,7 @@ namespace EasyNetQ.Tests.ChannelDispatcherTests;
 
 public class When_an_action_is_invoked_that_throws_using_single_channel : IDisposable
 {
-    private readonly IPersistentChannelDispatcher dispatcher;
+    private readonly SinglePersistentChannelDispatcher dispatcher;
 
     public When_an_action_is_invoked_that_throws_using_single_channel()
     {

--- a/Source/EasyNetQ.Tests/ChannelDispatcherTests/When_an_action_is_invoked_using_multi_channel.cs
+++ b/Source/EasyNetQ.Tests/ChannelDispatcherTests/When_an_action_is_invoked_using_multi_channel.cs
@@ -14,7 +14,7 @@ namespace EasyNetQ.Tests.ChannelDispatcherTests;
 
 public class When_an_action_is_invoked_using_multi_channel : IDisposable
 {
-    private readonly IPersistentChannelDispatcher dispatcher;
+    private readonly MultiPersistentChannelDispatcher dispatcher;
     private readonly IPersistentChannelFactory channelFactory;
     private readonly int actionResult;
     private readonly IProducerConnection producerConnection;

--- a/Source/EasyNetQ.Tests/ChannelDispatcherTests/When_an_action_is_invoked_using_single_channel.cs
+++ b/Source/EasyNetQ.Tests/ChannelDispatcherTests/When_an_action_is_invoked_using_single_channel.cs
@@ -14,7 +14,7 @@ namespace EasyNetQ.Tests.ChannelDispatcherTests;
 
 public class When_an_action_is_invoked_using_single_channel : IDisposable
 {
-    private readonly IPersistentChannelDispatcher dispatcher;
+    private readonly SinglePersistentChannelDispatcher dispatcher;
     private readonly IPersistentChannelFactory channelFactory;
     private readonly int actionResult;
 

--- a/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
@@ -32,7 +32,7 @@ public abstract class ConsumerTestBase : IDisposable
     {
         Cancellation = new CancellationTokenSource();
 
-        ConsumerErrorStrategy = Substitute.For<IConsumerErrorStrategy>();
+        ConsumerErrorStrategy = Substitute.For<IConsumerErrorStrategy, IDisposable>();
         MockBuilder = new MockBuilder(x => x.Register(ConsumerErrorStrategy));
         AdditionalSetUp();
     }

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_nack_received_from_the_message_handler.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_nack_received_from_the_message_handler.cs
@@ -2,6 +2,7 @@
 
 using EasyNetQ.Consumer;
 using NSubstitute;
+using System;
 using Xunit;
 
 namespace EasyNetQ.Tests.ConsumeTests;
@@ -25,7 +26,7 @@ public class When_a_nack_received_from_the_message_handler : ConsumerTestBase
     {
         MockBuilder.Dispose();
 
-        ConsumerErrorStrategy.Received().Dispose();
+        ((IDisposable)ConsumerErrorStrategy.Received()).Dispose();
     }
 }
 

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_an_error_occurs_in_the_message_handler.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_an_error_occurs_in_the_message_handler.cs
@@ -48,7 +48,7 @@ public class When_an_error_occurs_in_the_message_handler : ConsumerTestBase
     {
         MockBuilder.Dispose();
 
-        ConsumerErrorStrategy.Received().Dispose();
+        ((IDisposable)ConsumerErrorStrategy.Received()).Dispose();
     }
 }
 

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_cancellation_of_message_handler_occurs.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_cancellation_of_message_handler_occurs.cs
@@ -2,6 +2,7 @@
 
 using EasyNetQ.Consumer;
 using NSubstitute;
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -47,7 +48,7 @@ public class When_cancellation_of_message_handler_occurs : ConsumerTestBase
     {
         MockBuilder.Dispose();
 
-        ConsumerErrorStrategy.Received().Dispose();
+        ((IDisposable)ConsumerErrorStrategy.Received()).Dispose();
     }
 }
 

--- a/Source/EasyNetQ/ChannelDispatcher/IPersistentChannelDispatcher.cs
+++ b/Source/EasyNetQ/ChannelDispatcher/IPersistentChannelDispatcher.cs
@@ -8,7 +8,7 @@ namespace EasyNetQ.ChannelDispatcher;
 /// <summary>
 ///     Responsible for invoking client commands.
 /// </summary>
-public interface IPersistentChannelDispatcher : IDisposable
+public interface IPersistentChannelDispatcher
 {
     /// <summary>
     /// Invokes an action on top of model

--- a/Source/EasyNetQ/ChannelDispatcher/MultiPersistentChannelDispatcher.cs
+++ b/Source/EasyNetQ/ChannelDispatcher/MultiPersistentChannelDispatcher.cs
@@ -13,7 +13,7 @@ namespace EasyNetQ.ChannelDispatcher;
 /// <summary>
 ///     Invokes client commands using multiple channels
 /// </summary>
-public sealed class MultiPersistentChannelDispatcher : IPersistentChannelDispatcher
+public sealed class MultiPersistentChannelDispatcher : IPersistentChannelDispatcher, IDisposable
 {
     private readonly ConcurrentDictionary<PersistentChannelDispatchOptions, AsyncQueue<IPersistentChannel>> channelsPoolPerOptions;
     private readonly Func<PersistentChannelDispatchOptions, AsyncQueue<IPersistentChannel>> channelsPoolFactory;

--- a/Source/EasyNetQ/ChannelDispatcher/SinglePersistentChannelDispatcher.cs
+++ b/Source/EasyNetQ/ChannelDispatcher/SinglePersistentChannelDispatcher.cs
@@ -12,7 +12,7 @@ namespace EasyNetQ.ChannelDispatcher;
 /// <summary>
 ///     Invokes client commands using single channel
 /// </summary>
-public sealed class SinglePersistentChannelDispatcher : IPersistentChannelDispatcher
+public sealed class SinglePersistentChannelDispatcher : IPersistentChannelDispatcher, IDisposable
 {
     private readonly ConcurrentDictionary<PersistentChannelDispatchOptions, IPersistentChannel> channelPerOptions;
     private readonly Func<PersistentChannelDispatchOptions, IPersistentChannel> createChannelFactory;

--- a/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
+++ b/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
@@ -26,7 +26,7 @@ namespace EasyNetQ.Consumer;
 ///
 /// Each exchange is bound to the central EasyNetQ error queue.
 /// </summary>
-public class DefaultConsumerErrorStrategy : IConsumerErrorStrategy
+public class DefaultConsumerErrorStrategy : IConsumerErrorStrategy, IDisposable
 {
     private readonly ILogger<DefaultConsumerErrorStrategy> logger;
     private readonly IConsumerConnection connection;

--- a/Source/EasyNetQ/Consumer/HandlerRunner.cs
+++ b/Source/EasyNetQ/Consumer/HandlerRunner.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 namespace EasyNetQ.Consumer;
 
 /// <inheritdoc />
-public interface IHandlerRunner : IDisposable
+public interface IHandlerRunner
 {
     Task<AckStrategy> InvokeUserMessageHandlerAsync(ConsumerExecutionContext context, CancellationToken cancellationToken = default);
 }

--- a/Source/EasyNetQ/Consumer/HandlerRunner.cs
+++ b/Source/EasyNetQ/Consumer/HandlerRunner.cs
@@ -12,7 +12,7 @@ public interface IHandlerRunner
 }
 
 /// <inheritdoc />
-public class HandlerRunner : IHandlerRunner
+public class HandlerRunner : IHandlerRunner, IDisposable
 {
     private readonly IConsumerErrorStrategy consumerErrorStrategy;
     private readonly ILogger logger;

--- a/Source/EasyNetQ/Consumer/IConsumerErrorStrategy.cs
+++ b/Source/EasyNetQ/Consumer/IConsumerErrorStrategy.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 namespace EasyNetQ.Consumer;
 
 /// <inheritdoc />
-public interface IConsumerErrorStrategy : IDisposable
+public interface IConsumerErrorStrategy
 {
     /// <summary>
     /// This method is fired when an exception is thrown. Implement a strategy for

--- a/Source/EasyNetQ/Consumer/SimpleConsumerErrorStrategy.cs
+++ b/Source/EasyNetQ/Consumer/SimpleConsumerErrorStrategy.cs
@@ -7,7 +7,7 @@ namespace EasyNetQ.Consumer;
 /// <summary>
 ///     A simple strategy which does nothing, only applies AckStrategies
 /// </summary>
-public class SimpleConsumerErrorStrategy : IConsumerErrorStrategy
+public class SimpleConsumerErrorStrategy : IConsumerErrorStrategy, IDisposable
 {
     /// <summary>
     ///     Acks a message in case of an error

--- a/Source/EasyNetQ/DefaultRpc.cs
+++ b/Source/EasyNetQ/DefaultRpc.cs
@@ -16,7 +16,7 @@ namespace EasyNetQ;
 /// <summary>
 ///     Default implementation of EasyNetQ's request-response pattern
 /// </summary>
-public class DefaultRpc : IRpc
+public class DefaultRpc : IRpc, IDisposable
 {
     protected const string IsFaultedKey = "IsFaulted";
     protected const string ExceptionMessageKey = "ExceptionMessage";

--- a/Source/EasyNetQ/IAdvancedBus.cs
+++ b/Source/EasyNetQ/IAdvancedBus.cs
@@ -12,7 +12,7 @@ namespace EasyNetQ;
 /// of routing topology, but keeping the EasyNetQ serialization, persistent connection,
 /// error handling and subscription thread.
 /// </summary>
-public interface IAdvancedBus : IDisposable
+public interface IAdvancedBus
 {
     /// <summary>
     /// <see langword="true"/> if a connection of the given type is established.

--- a/Source/EasyNetQ/IRpc.cs
+++ b/Source/EasyNetQ/IRpc.cs
@@ -8,7 +8,7 @@ namespace EasyNetQ;
 /// <summary>
 ///     An RPC style request-response pattern
 /// </summary>
-public interface IRpc : IDisposable
+public interface IRpc
 {
     /// <summary>
     ///     Make a request to an RPC service

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -18,7 +18,7 @@ using RabbitMQ.Client;
 namespace EasyNetQ;
 
 /// <inheritdoc />
-public class RabbitAdvancedBus : IAdvancedBus
+public class RabbitAdvancedBus : IAdvancedBus, IDisposable
 {
     private readonly IPersistentChannelDispatcher persistentChannelDispatcher;
     private readonly ConnectionConfiguration configuration;


### PR DESCRIPTION
Inspired by #1518. The idea is that you should not always declare `IDisposable` on interfaces. It's an implementation detail. For example, when you desing your framework to work within DI container - DI container tracks created objects; or you just call `Dispose` on the class variable instead of interface variable. Look - only tests use `Dispose` calls and can be easily changed to use class variable. @Pliner I see other interfaces implementing `IDisposable` but I'm not sure that removing `IDisposable` from interface declaraions is a good idea for all of them. You know better.