### PR TITLE
Fix switched logger arguments

### DIFF
--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -208,8 +208,8 @@ public class InternalConsumer : IInternalConsumer
 
                 logger.InfoFormat(
                     "Declared consumer with consumerTag {consumerTag} on queue {queue} and configuration {configuration}",
-                    queue.Name,
                     perQueueConfiguration.ConsumerTag,
+                    queue.Name,
                     configuration
                 );
 
@@ -221,8 +221,8 @@ public class InternalConsumer : IInternalConsumer
                 logger.Error(
                     exception,
                     "Consume with consumerTag {consumerTag} on queue {queue} failed",
-                    queue.Name,
-                    perQueueConfiguration.ConsumerTag
+                    perQueueConfiguration.ConsumerTag,
+                    queue.Name
                 );
 
                 failedQueues.Add(queue);


### PR DESCRIPTION
Fixes switched consumer tag and queue name arguments in `InternalConsumer` logger.