### PR TITLE
Remove unused properties from RabbitAdvancedBus

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -797,25 +797,7 @@ namespace EasyNetQ
     public delegate string? QueueTypeConvention(System.Type messageType);
     public class RabbitAdvancedBus : EasyNetQ.IAdvancedBus, System.IDisposable
     {
-        public RabbitAdvancedBus(
-                    EasyNetQ.Logging.ILogger<EasyNetQ.RabbitAdvancedBus> logger,
-                    EasyNetQ.Producer.IProducerConnection producerConnection,
-                    EasyNetQ.Consumer.IConsumerConnection consumerConnection,
-                    EasyNetQ.Consumer.IConsumerFactory consumerFactory,
-                    EasyNetQ.ChannelDispatcher.IPersistentChannelDispatcher persistentChannelDispatcher,
-                    EasyNetQ.Producer.IPublishConfirmationListener confirmationListener,
-                    EasyNetQ.IEventBus eventBus,
-                    EasyNetQ.Consumer.IHandlerCollectionFactory handlerCollectionFactory,
-                    EasyNetQ.DI.IServiceResolver container,
-                    EasyNetQ.ConnectionConfiguration configuration,
-                    System.Collections.Generic.IEnumerable<EasyNetQ.Interception.IProduceConsumeInterceptor> produceConsumeInterceptors,
-                    EasyNetQ.IMessageSerializationStrategy messageSerializationStrategy,
-                    EasyNetQ.IConventions conventions,
-                    EasyNetQ.IPullingConsumerFactory pullingConsumerFactory,
-                    EasyNetQ.AdvancedBusEventHandlers advancedBusEventHandlers,
-                    EasyNetQ.DI.IConsumeScopeProvider consumeScopeProvider) { }
-        public EasyNetQ.DI.IServiceResolver Container { get; }
-        public EasyNetQ.IConventions Conventions { get; }
+        public RabbitAdvancedBus(EasyNetQ.Logging.ILogger<EasyNetQ.RabbitAdvancedBus> logger, EasyNetQ.Producer.IProducerConnection producerConnection, EasyNetQ.Consumer.IConsumerConnection consumerConnection, EasyNetQ.Consumer.IConsumerFactory consumerFactory, EasyNetQ.ChannelDispatcher.IPersistentChannelDispatcher persistentChannelDispatcher, EasyNetQ.Producer.IPublishConfirmationListener confirmationListener, EasyNetQ.IEventBus eventBus, EasyNetQ.Consumer.IHandlerCollectionFactory handlerCollectionFactory, EasyNetQ.ConnectionConfiguration configuration, System.Collections.Generic.IEnumerable<EasyNetQ.Interception.IProduceConsumeInterceptor> produceConsumeInterceptors, EasyNetQ.IMessageSerializationStrategy messageSerializationStrategy, EasyNetQ.IPullingConsumerFactory pullingConsumerFactory, EasyNetQ.AdvancedBusEventHandlers advancedBusEventHandlers, EasyNetQ.DI.IConsumeScopeProvider consumeScopeProvider) { }
         public bool IsConnected { get; }
         public event System.EventHandler<EasyNetQ.BlockedEventArgs>? Blocked;
         public event System.EventHandler<EasyNetQ.ConnectedEventArgs>? Connected;

--- a/Source/EasyNetQ.Tests/AdvancedBusEventHandlersTests.cs
+++ b/Source/EasyNetQ.Tests/AdvancedBusEventHandlersTests.cs
@@ -54,11 +54,9 @@ public class AdvancedBusEventHandlersTests : IDisposable
             Substitute.For<IPublishConfirmationListener>(),
             eventBus,
             Substitute.For<IHandlerCollectionFactory>(),
-            Substitute.For<IServiceResolver>(),
             Substitute.For<ConnectionConfiguration>(),
             Substitute.For<IEnumerable<IProduceConsumeInterceptor>>(),
             Substitute.For<IMessageSerializationStrategy>(),
-            Substitute.For<IConventions>(),
             Substitute.For<IPullingConsumerFactory>(),
             advancedBusEventHandlers,
             Substitute.For<IConsumeScopeProvider>()

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -50,11 +50,9 @@ public class RabbitAdvancedBus : IAdvancedBus, IDisposable
         IPublishConfirmationListener confirmationListener,
         IEventBus eventBus,
         IHandlerCollectionFactory handlerCollectionFactory,
-        IServiceResolver container,
         ConnectionConfiguration configuration,
         IEnumerable<IProduceConsumeInterceptor> produceConsumeInterceptors,
         IMessageSerializationStrategy messageSerializationStrategy,
-        IConventions conventions,
         IPullingConsumerFactory pullingConsumerFactory,
         AdvancedBusEventHandlers advancedBusEventHandlers,
         IConsumeScopeProvider consumeScopeProvider
@@ -68,13 +66,11 @@ public class RabbitAdvancedBus : IAdvancedBus, IDisposable
         this.confirmationListener = confirmationListener;
         this.eventBus = eventBus;
         this.handlerCollectionFactory = handlerCollectionFactory;
-        Container = container;
         this.configuration = configuration;
         this.produceConsumeInterceptors = produceConsumeInterceptors.ToArray();
         this.messageSerializationStrategy = messageSerializationStrategy;
         this.pullingConsumerFactory = pullingConsumerFactory;
         this.advancedBusEventHandlers = advancedBusEventHandlers;
-        Conventions = conventions;
         this.consumeScopeProvider = consumeScopeProvider;
 
         Connected += advancedBusEventHandlers.Connected;
@@ -218,12 +214,6 @@ public class RabbitAdvancedBus : IAdvancedBus, IDisposable
 
     /// <inheritdoc />
     public event EventHandler<MessageReturnedEventArgs>? MessageReturned;
-
-    /// <inheritdoc />
-    public IServiceResolver Container { get; }
-
-    /// <inheritdoc />
-    public IConventions Conventions { get; }
 
     /// <inheritdoc />
     public virtual void Dispose()


### PR DESCRIPTION
Continuation of #1518.
While I removed `Container` and `Conventions` from the interface I actually didn't remove them from the implementation. 
