### PR TITLE
Basic support for ssl/tls connection in Hosepipe

### DIFF
--- a/Source/EasyNetQ.Hosepipe/ArgParser.cs
+++ b/Source/EasyNetQ.Hosepipe/ArgParser.cs
@@ -6,7 +6,7 @@ namespace EasyNetQ.Hosepipe;
 
 public class ArgParser
 {
-    private readonly Regex argRegex = new(@"([a-z]{1,2})\:(.*)");
+    private readonly Regex argRegex = new(@"([a-z]{1,3})\:(.*)");
 
     public Arguments Parse(string[] args)
     {

--- a/Source/EasyNetQ.Hosepipe/HosepipeConnection.cs
+++ b/Source/EasyNetQ.Hosepipe/HosepipeConnection.cs
@@ -13,8 +13,18 @@ public static class HosepipeConnection
             VirtualHost = parameters.VHost,
             UserName = parameters.Username,
             Password = parameters.Password,
-            Port = parameters.HostPort
+            Port = parameters.HostPort,
         };
+
+        if (parameters.Ssl)
+        {
+            connectionFactory.Ssl = new SslOption
+            {
+                Enabled = true,
+                ServerName = parameters.HostName
+            };
+        }
+
         try
         {
             return connectionFactory.CreateConnection();

--- a/Source/EasyNetQ.Hosepipe/Program.cs
+++ b/Source/EasyNetQ.Hosepipe/Program.cs
@@ -93,6 +93,8 @@ public class Program
             .FailWith(Message("Invalid number of messages to retrieve"));
         arguments.WithTypedKeyOptional<bool>("x", a => parameters.Purge = bool.Parse(a.Value))
             .FailWith(Message("Invalid purge (x) parameter"));
+        arguments.WithTypedKeyOptional<bool>("ssl", a => parameters.Ssl = bool.Parse(a.Value))
+            .FailWith(Message("Invalid Ssl (ssl) parameter"));
 
         try
         {

--- a/Source/EasyNetQ.Hosepipe/QueueParameters.cs
+++ b/Source/EasyNetQ.Hosepipe/QueueParameters.cs
@@ -15,6 +15,7 @@ public class QueueParameters
     public int NumberOfMessagesToRetrieve { get; set; }
     public string MessagesOutputDirectory { get; set; }
     public TimeSpan ConfirmsTimeout { get; }
+    public bool Ssl { get; set; }
 
     public QueueParameters()
     {
@@ -28,5 +29,6 @@ public class QueueParameters
         NumberOfMessagesToRetrieve = 1000;
         MessagesOutputDirectory = Directory.GetCurrentDirectory();
         ConfirmsTimeout = TimeSpan.FromSeconds(30);
+        Ssl = false;
     }
 }

--- a/Source/EasyNetQ.Hosepipe/Usage.txt
+++ b/Source/EasyNetQ.Hosepipe/Usage.txt
@@ -43,6 +43,7 @@ Options
 	o	the directory to output messages to. Default is current directory.
 	n	the maximum number of messages to retrieve. Default is 1000.
 	x	to get (noack) and remove the message from the queue. Default is false.
+	ssl to use SSL/TLS to connect. Default is false
 
 Examples
 	


### PR DESCRIPTION
We do use this tool from time to time and some time ago we updated our RabbitMq cluster and discovered that this capability was missing. Pretty straight forward. No Tests for this as the code for the connection is quite cumbersome to test.