### PR TITLE
Customise error exchange to error queue binding

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -126,8 +126,8 @@ namespace EasyNetQ
         public Conventions(EasyNetQ.ITypeNameSerializer typeNameSerializer) { }
         public EasyNetQ.ConsumerTagConvention ConsumerTagConvention { get; set; }
         public EasyNetQ.ErrorExchangeNameConvention ErrorExchangeNamingConvention { get; set; }
-        public EasyNetQ.ErrorExchangeTypeConvention ErrorExchangeTypeConvention { get; set; }
         public EasyNetQ.ErrorExchangeRoutingKeyConvention ErrorExchangeRoutingKeyConvention { get; set; }
+        public EasyNetQ.ErrorExchangeTypeConvention ErrorExchangeTypeConvention { get; set; }
         public EasyNetQ.ErrorQueueNameConvention ErrorQueueNamingConvention { get; set; }
         public EasyNetQ.ErrorQueueTypeConvention ErrorQueueTypeConvention { get; set; }
         public EasyNetQ.ExchangeNameConvention ExchangeNamingConvention { get; set; }
@@ -256,8 +256,8 @@ namespace EasyNetQ
         public EasyNetQResponderException(string? message, System.Exception? inner) { }
     }
     public delegate string ErrorExchangeNameConvention(EasyNetQ.MessageReceivedInfo receivedInfo);
+    public delegate string ErrorExchangeRoutingKeyConvention(EasyNetQ.MessageReceivedInfo receivedInfo);
     public delegate string ErrorExchangeTypeConvention();
-    public delegate string ErrorExchangeRoutingKeyConvention(EasyNetQ.MessageReceivedInfo receivedInfo);    
     public delegate string ErrorQueueNameConvention(EasyNetQ.MessageReceivedInfo receivedInfo);
     public delegate string? ErrorQueueTypeConvention();
     public sealed class EventBus : EasyNetQ.IEventBus
@@ -333,8 +333,8 @@ namespace EasyNetQ
     {
         EasyNetQ.ConsumerTagConvention ConsumerTagConvention { get; }
         EasyNetQ.ErrorExchangeNameConvention ErrorExchangeNamingConvention { get; }
+        EasyNetQ.ErrorExchangeRoutingKeyConvention ErrorExchangeRoutingKeyConvention { get; }
         EasyNetQ.ErrorExchangeTypeConvention ErrorExchangeTypeConvention { get; }
-        EasyNetQ.ErrorExchangeRoutingKeyConvention ErrorExchangeRoutingKeyConvention { get; }       
         EasyNetQ.ErrorQueueNameConvention ErrorQueueNamingConvention { get; }
         EasyNetQ.ErrorQueueTypeConvention ErrorQueueTypeConvention { get; }
         EasyNetQ.ExchangeNameConvention ExchangeNamingConvention { get; }

--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -334,10 +334,10 @@ namespace EasyNetQ
         EasyNetQ.ConsumerTagConvention ConsumerTagConvention { get; }
         EasyNetQ.ErrorExchangeNameConvention ErrorExchangeNamingConvention { get; }
         EasyNetQ.ErrorExchangeTypeConvention ErrorExchangeTypeConvention { get; }
-        EasyNetQ.ErrorExchangeRoutingKeyConvention ErrorExchangeRoutingKeyConvention { get; }
+        EasyNetQ.ErrorExchangeRoutingKeyConvention ErrorExchangeRoutingKeyConvention { get; }       
         EasyNetQ.ErrorQueueNameConvention ErrorQueueNamingConvention { get; }
         EasyNetQ.ErrorQueueTypeConvention ErrorQueueTypeConvention { get; }
-        EasyNetQ.ExchangeNameConvention ExchangeNamingConvention { get; }        
+        EasyNetQ.ExchangeNameConvention ExchangeNamingConvention { get; }
         EasyNetQ.QueueNameConvention QueueNamingConvention { get; }
         EasyNetQ.QueueTypeConvention QueueTypeConvention { get; }
         EasyNetQ.RpcExchangeNameConvention RpcRequestExchangeNamingConvention { get; }

--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -127,6 +127,7 @@ namespace EasyNetQ
         public EasyNetQ.ConsumerTagConvention ConsumerTagConvention { get; set; }
         public EasyNetQ.ErrorExchangeNameConvention ErrorExchangeNamingConvention { get; set; }
         public EasyNetQ.ErrorExchangeTypeConvention ErrorExchangeTypeConvention { get; set; }
+        public EasyNetQ.ErrorExchangeRoutingKeyConvention ErrorExchangeRoutingKeyConvention { get; set; }
         public EasyNetQ.ErrorQueueNameConvention ErrorQueueNamingConvention { get; set; }
         public EasyNetQ.ErrorQueueTypeConvention ErrorQueueTypeConvention { get; set; }
         public EasyNetQ.ExchangeNameConvention ExchangeNamingConvention { get; set; }
@@ -256,6 +257,7 @@ namespace EasyNetQ
     }
     public delegate string ErrorExchangeNameConvention(EasyNetQ.MessageReceivedInfo receivedInfo);
     public delegate string ErrorExchangeTypeConvention();
+    public delegate string ErrorExchangeRoutingKeyConvention(EasyNetQ.MessageReceivedInfo receivedInfo);    
     public delegate string ErrorQueueNameConvention(EasyNetQ.MessageReceivedInfo receivedInfo);
     public delegate string? ErrorQueueTypeConvention();
     public sealed class EventBus : EasyNetQ.IEventBus
@@ -332,9 +334,10 @@ namespace EasyNetQ
         EasyNetQ.ConsumerTagConvention ConsumerTagConvention { get; }
         EasyNetQ.ErrorExchangeNameConvention ErrorExchangeNamingConvention { get; }
         EasyNetQ.ErrorExchangeTypeConvention ErrorExchangeTypeConvention { get; }
+        EasyNetQ.ErrorExchangeRoutingKeyConvention ErrorExchangeRoutingKeyConvention { get; }
         EasyNetQ.ErrorQueueNameConvention ErrorQueueNamingConvention { get; }
         EasyNetQ.ErrorQueueTypeConvention ErrorQueueTypeConvention { get; }
-        EasyNetQ.ExchangeNameConvention ExchangeNamingConvention { get; }
+        EasyNetQ.ExchangeNameConvention ExchangeNamingConvention { get; }        
         EasyNetQ.QueueNameConvention QueueNamingConvention { get; }
         EasyNetQ.QueueTypeConvention QueueTypeConvention { get; }
         EasyNetQ.RpcExchangeNameConvention RpcRequestExchangeNamingConvention { get; }

--- a/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
+++ b/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
@@ -116,7 +116,7 @@ public class When_using_default_consumer_error_strategy
         );
         mockBuilder.Channels[0].Received().BasicPublish(
             "CustomErrorExchangePrefixName.originalRoutingKey",
-            "CustomRoutingKey",
+            "originalRoutingKey",
             false,
             Arg.Any<IBasicProperties>(),
             Arg.Any<ReadOnlyMemory<byte>>()

--- a/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
+++ b/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
@@ -74,12 +74,12 @@ public class When_using_default_consumer_error_strategy
         mockBuilder.Channels[0].Received().QueueBind(
             "CustomEasyNetQErrorQueueName",
             "CustomErrorExchangePrefixName.originalRoutingKey",
-            "originalRoutingKey",
+            "CustomRoutingKey",
             null
         );
         mockBuilder.Channels[0].Received().BasicPublish(
             "CustomErrorExchangePrefixName.originalRoutingKey",
-            "originalRoutingKey",
+            "CustomRoutingKey",
             false,
             Arg.Any<IBasicProperties>(),
             Arg.Any<ReadOnlyMemory<byte>>()

--- a/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
+++ b/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
@@ -79,7 +79,7 @@ public class When_using_default_consumer_error_strategy
         );
         mockBuilder.Channels[0].Received().BasicPublish(
             "CustomErrorExchangePrefixName.originalRoutingKey",
-            "CustomRoutingKey",
+            "originalRoutingKey",
             false,
             Arg.Any<IBasicProperties>(),
             Arg.Any<ReadOnlyMemory<byte>>()

--- a/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
+++ b/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
@@ -22,7 +22,8 @@ public class When_using_default_consumer_error_strategy
             ErrorQueueNamingConvention = _ => "CustomEasyNetQErrorQueueName",
             ErrorExchangeNamingConvention = info => "CustomErrorExchangePrefixName." + info.RoutingKey,
             ErrorQueueTypeConvention = () => QueueType.Quorum,
-            ErrorExchangeTypeConvention = () => ExchangeType.Topic
+            ErrorExchangeTypeConvention = () => ExchangeType.Topic,
+            ErrorExchangeRoutingKeyConvention = info => info.RoutingKey
         };
 
         const string originalMessage = "";

--- a/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
+++ b/Source/EasyNetQ.Tests/When_using_default_consumer_error_strategy.cs
@@ -23,7 +23,7 @@ public class When_using_default_consumer_error_strategy
             ErrorExchangeNamingConvention = info => "CustomErrorExchangePrefixName." + info.RoutingKey,
             ErrorQueueTypeConvention = () => QueueType.Quorum,
             ErrorExchangeTypeConvention = () => ExchangeType.Topic,
-            ErrorExchangeRoutingKeyConvention = info => info.RoutingKey
+            ErrorExchangeRoutingKeyConvention = info => "CustomRoutingKey"
         };
 
         const string originalMessage = "";
@@ -111,12 +111,12 @@ public class When_using_default_consumer_error_strategy
         mockBuilder.Channels[0].Received().QueueBind(
             "CustomEasyNetQErrorQueueName",
             "CustomErrorExchangePrefixName.originalRoutingKey",
-            "originalRoutingKey",
+            "CustomRoutingKey",
             null
         );
         mockBuilder.Channels[0].Received().BasicPublish(
             "CustomErrorExchangePrefixName.originalRoutingKey",
-            "originalRoutingKey",
+            "CustomRoutingKey",
             false,
             Arg.Any<IBasicProperties>(),
             Arg.Any<ReadOnlyMemory<byte>>()

--- a/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
+++ b/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
@@ -93,13 +93,11 @@ public class DefaultConsumerErrorStrategy : IConsumerErrorStrategy, IDisposable
 
             using var message = CreateErrorMessage(receivedInfo, properties, body, exception);
 
-            var routingKey = GetRoutingKeyForErrorExchange(receivedInfo);
-
             var errorProperties = model.CreateBasicProperties();
             errorProperties.Persistent = true;
             errorProperties.Type = typeNameSerializer.Serialize(typeof(Error));
 
-            model.BasicPublish(errorExchange, routingKey, errorProperties, message.Memory);
+            model.BasicPublish(errorExchange, receivedInfo.RoutingKey, errorProperties, message.Memory);
 
             if (!configuration.PublisherConfirms) return Task.FromResult(AckStrategies.Ack);
 
@@ -181,12 +179,6 @@ public class DefaultConsumerErrorStrategy : IConsumerErrorStrategy, IDisposable
         });
 
         return errorExchangeName;
-    }
-
-    private string GetRoutingKeyForErrorExchange(MessageReceivedInfo receivedInfo)
-    {
-        var errorRoutingKey = conventions.ErrorExchangeRoutingKeyConvention(receivedInfo);
-        return errorRoutingKey;
     }
 
     private IMemoryOwner<byte> CreateErrorMessage(

--- a/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
+++ b/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
@@ -167,7 +167,7 @@ public class DefaultConsumerErrorStrategy : IConsumerErrorStrategy, IDisposable
         var errorExchangeType = conventions.ErrorExchangeTypeConvention();
         var errorQueueName = conventions.ErrorQueueNamingConvention(receivedInfo);
         var errorQueueType = conventions.ErrorQueueTypeConvention();
-        var routingKey = receivedInfo.RoutingKey;
+        var routingKey = conventions.ErrorExchangeRoutingKeyConvention(receivedInfo);
 
         var errorTopologyIdentifier = $"{errorExchangeName}-{errorQueueName}-{routingKey}";
 

--- a/Source/EasyNetQ/Conventions.cs
+++ b/Source/EasyNetQ/Conventions.cs
@@ -191,7 +191,7 @@ public class Conventions : IConventions
         ErrorExchangeNamingConvention = receivedInfo => "ErrorExchange_" + receivedInfo.RoutingKey;
         ErrorQueueTypeConvention = () => null;
         ErrorExchangeTypeConvention = () => ExchangeType.Direct;
-        ErrorExchangeRoutingKeyConvention = receivedInfo =>  receivedInfo.RoutingKey;
+        ErrorExchangeRoutingKeyConvention = receivedInfo => receivedInfo.RoutingKey;
 
         RpcRequestExchangeNamingConvention = _ => "easy_net_q_rpc";
         RpcResponseExchangeNamingConvention = _ => "easy_net_q_rpc";
@@ -250,5 +250,5 @@ public class Conventions : IConventions
     public ConsumerTagConvention ConsumerTagConvention { get; set; }
 
     /// <inheritdoc />
-    public ErrorExchangeRoutingKeyConvention ErrorExchangeRoutingKeyConvention { get; set;}
+    public ErrorExchangeRoutingKeyConvention ErrorExchangeRoutingKeyConvention { get; set; }
 }

--- a/Source/EasyNetQ/Conventions.cs
+++ b/Source/EasyNetQ/Conventions.cs
@@ -44,6 +44,12 @@ public delegate string ErrorExchangeNameConvention(MessageReceivedInfo receivedI
 /// </summary>
 public delegate string ErrorExchangeTypeConvention();
 
+
+/// <summary>
+///     Convention for error exchange Routing Key
+/// </summary>
+public delegate string ErrorExchangeRoutingKeyConvention(MessageReceivedInfo receivedInfo);
+
 /// <summary>
 ///     Convention for rpc routing key naming
 /// </summary>
@@ -133,6 +139,11 @@ public interface IConventions
     ///     Convention for error exchange type
     /// </summary>
     ErrorExchangeTypeConvention ErrorExchangeTypeConvention { get; }
+
+    /// <summary>
+    ///     Convention for error exchange Routing key
+    /// </summary>
+    ErrorExchangeRoutingKeyConvention ErrorExchangeRoutingKeyConvention { get; }
 }
 
 /// <inheritdoc />
@@ -180,6 +191,7 @@ public class Conventions : IConventions
         ErrorExchangeNamingConvention = receivedInfo => "ErrorExchange_" + receivedInfo.RoutingKey;
         ErrorQueueTypeConvention = () => null;
         ErrorExchangeTypeConvention = () => ExchangeType.Direct;
+        ErrorExchangeRoutingKeyConvention = (MessageReceivedInfo receivedInfo) =>  receivedInfo.RoutingKey;
 
         RpcRequestExchangeNamingConvention = _ => "easy_net_q_rpc";
         RpcResponseExchangeNamingConvention = _ => "easy_net_q_rpc";
@@ -236,4 +248,6 @@ public class Conventions : IConventions
 
     /// <inheritdoc />
     public ConsumerTagConvention ConsumerTagConvention { get; set; }
+
+    public ErrorExchangeRoutingKeyConvention ErrorExchangeRoutingKeyConvention { get; set;}
 }

--- a/Source/EasyNetQ/Conventions.cs
+++ b/Source/EasyNetQ/Conventions.cs
@@ -191,7 +191,7 @@ public class Conventions : IConventions
         ErrorExchangeNamingConvention = receivedInfo => "ErrorExchange_" + receivedInfo.RoutingKey;
         ErrorQueueTypeConvention = () => null;
         ErrorExchangeTypeConvention = () => ExchangeType.Direct;
-        ErrorExchangeRoutingKeyConvention = (MessageReceivedInfo receivedInfo) =>  receivedInfo.RoutingKey;
+        ErrorExchangeRoutingKeyConvention = receivedInfo =>  receivedInfo.RoutingKey;
 
         RpcRequestExchangeNamingConvention = _ => "easy_net_q_rpc";
         RpcResponseExchangeNamingConvention = _ => "easy_net_q_rpc";
@@ -249,5 +249,6 @@ public class Conventions : IConventions
     /// <inheritdoc />
     public ConsumerTagConvention ConsumerTagConvention { get; set; }
 
+    /// <inheritdoc />
     public ErrorExchangeRoutingKeyConvention ErrorExchangeRoutingKeyConvention { get; set;}
 }


### PR DESCRIPTION
To add the routing key parameter for the error exchange and error queue when default conventions are overriden