### PR TITLE
Save headers with type info for System.Text.Json

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.Serialization.SystemTextJson.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.Serialization.SystemTextJson.approved.txt
@@ -1,5 +1,11 @@
 namespace EasyNetQ.Serialization.SystemTextJson
 {
+    public class MessagePropertiesConverter : System.Text.Json.Serialization.JsonConverter<EasyNetQ.MessageProperties>
+    {
+        public MessagePropertiesConverter() { }
+        public override EasyNetQ.MessageProperties? Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) { }
+        public override void Write(System.Text.Json.Utf8JsonWriter writer, EasyNetQ.MessageProperties value, System.Text.Json.JsonSerializerOptions options) { }
+    }
     public class SystemObjectNewtonsoftCompatibleConverter : System.Text.Json.Serialization.JsonConverter<object>
     {
         public SystemObjectNewtonsoftCompatibleConverter() { }
@@ -13,6 +19,13 @@ namespace EasyNetQ.Serialization.SystemTextJson
         public object BytesToMessage(System.Type messageType, in System.ReadOnlyMemory<byte> bytes) { }
         public System.Buffers.IMemoryOwner<byte> MessageToBytes(System.Type messageType, object message) { }
     }
+    public sealed class SystemTextJsonSerializerV2 : EasyNetQ.ISerializer
+    {
+        public SystemTextJsonSerializerV2() { }
+        public SystemTextJsonSerializerV2(System.Text.Json.JsonSerializerOptions options) { }
+        public object BytesToMessage(System.Type messageType, in System.ReadOnlyMemory<byte> bytes) { }
+        public System.Buffers.IMemoryOwner<byte> MessageToBytes(System.Type messageType, object message) { }
+    }
 }
 namespace EasyNetQ
 {
@@ -20,5 +33,7 @@ namespace EasyNetQ
     {
         public static EasyNetQ.DI.IServiceRegister EnableSystemTextJson(this EasyNetQ.DI.IServiceRegister serviceRegister) { }
         public static EasyNetQ.DI.IServiceRegister EnableSystemTextJson(this EasyNetQ.DI.IServiceRegister serviceRegister, System.Text.Json.JsonSerializerOptions options) { }
+        public static EasyNetQ.DI.IServiceRegister EnableSystemTextJsonV2(this EasyNetQ.DI.IServiceRegister serviceRegister) { }
+        public static EasyNetQ.DI.IServiceRegister EnableSystemTextJsonV2(this EasyNetQ.DI.IServiceRegister serviceRegister, System.Text.Json.JsonSerializerOptions options) { }
     }
 }

--- a/Source/EasyNetQ.Serialization.SystemTextJson/JsonHeaderExtensions.cs
+++ b/Source/EasyNetQ.Serialization.SystemTextJson/JsonHeaderExtensions.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using RabbitMQ.Client;
+
+namespace EasyNetQ.Serialization.SystemTextJson;
+
+internal static class JsonHeaderExtensions
+{
+    public static Dictionary<string, object?> ConvertJsonToHeaders(this JsonElement jsonElement, JsonSerializerOptions options)
+    {
+        var headers = new Dictionary<string, object?>();
+        foreach (var property in jsonElement.EnumerateObject())
+        {
+            var type = property.Value.GetProperty(options.ConvertName("Type")).GetInt32();
+            var value = property.Value.GetProperty(options.ConvertName("Value"));
+            headers.Add(property.Name, (type, value).ConvertJsonToObject(options));
+        }
+        return headers;
+    }
+
+    public static void AddHeaderToJson(this JsonObject json, string name, object? value, JsonSerializerOptions options)
+    {
+        var (valueType, valueJson) = value.ConvertToTypeAndJson(options);
+        var valueContainer = new JsonObject
+        {
+            { options.ConvertName("Type"), JsonValue.Create(valueType) },
+            { options.ConvertName("Value"), valueJson }
+        };
+        json.Add(name, valueContainer);
+    }
+
+    private static (int, JsonNode?) ConvertToTypeAndJson(this object? value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case null:
+                return (JsonHeaderType.Null, null);
+            case bool boolValue:
+                return (JsonHeaderType.Bool, JsonValue.Create(boolValue));
+            case byte byteValue:
+                return (JsonHeaderType.Byte, JsonValue.Create(byteValue));
+            case sbyte sByteValue:
+                return (JsonHeaderType.SByte, JsonValue.Create(sByteValue));
+            case short int16Value:
+                return (JsonHeaderType.Int16, JsonValue.Create(int16Value));
+            case int int32Value:
+                return (JsonHeaderType.Int32, JsonValue.Create(int32Value));
+            case uint uint32Value:
+                return (JsonHeaderType.UInt32, JsonValue.Create(uint32Value));
+            case long int64Value:
+                return (JsonHeaderType.Int64, JsonValue.Create(int64Value));
+            case float singleValue:
+                return (JsonHeaderType.Single, JsonValue.Create(singleValue));
+            case double doubleValue:
+                return (JsonHeaderType.Double, JsonValue.Create(doubleValue));
+            case decimal decimalValue:
+                return (JsonHeaderType.Decimal, JsonValue.Create(decimalValue));
+            case AmqpTimestamp amqpTimestamp:
+                return (JsonHeaderType.AmqpTimestamp, JsonValue.Create(amqpTimestamp.UnixTime));
+            case string stringValue:
+                return (JsonHeaderType.String, JsonValue.Create(stringValue));
+            case byte[] bytesValue:
+                return (JsonHeaderType.Bytes, JsonValue.Create(bytesValue));
+            case IList listValue:
+                var list = new List<JsonNode>();
+                foreach (var listItem in listValue)
+                {
+                    var (listItemType, listItemJson) = ConvertToTypeAndJson(listItem, options);
+                    list.Add(new JsonObject
+                    {
+                        { options.ConvertName("Type"), JsonValue.Create(listItemType) },
+                        { options.ConvertName("Value"), listItemJson }
+                    });
+                }
+                return (JsonHeaderType.List, new JsonArray(list.ToArray()));
+            case IDictionary dictionaryValue:
+                var dictionaryJson = new JsonObject();
+                foreach (DictionaryEntry dictionaryItem in dictionaryValue)
+                {
+                    var (dictionaryItemType, dictionaryItemJson) = ConvertToTypeAndJson(dictionaryItem.Value, options);
+                    dictionaryJson.Add(
+                        options.ConvertName(dictionaryItem.Key.ToString()!),
+                        new JsonObject
+                        {
+                            { options.ConvertName("Type"), JsonValue.Create(dictionaryItemType) },
+                            { options.ConvertName("Value"), dictionaryItemJson }
+                        }
+                    );
+                }
+                return (JsonHeaderType.Dictionary, dictionaryJson);
+            case BinaryTableValue binaryTableValue:
+                return (JsonHeaderType.BinaryTable, JsonValue.Create(binaryTableValue.Bytes));
+        }
+
+        throw new InternalBufferOverflowException();
+    }
+
+    private static object? ConvertJsonToObject(this (int Type, JsonElement Value) valueContainer, JsonSerializerOptions options)
+    {
+        var (type, json) = valueContainer;
+        switch (type)
+        {
+            case JsonHeaderType.Null:
+                return null;
+            case JsonHeaderType.Int32:
+                return json.GetInt32();
+            case JsonHeaderType.UInt32:
+                return json.GetUInt32();
+            case JsonHeaderType.Int64:
+                return json.GetInt64();
+            case JsonHeaderType.Bool:
+                return json.GetBoolean();
+            case JsonHeaderType.Single:
+                return json.GetSingle();
+            case JsonHeaderType.Double:
+                return json.GetDouble();
+            case JsonHeaderType.Decimal:
+                return json.GetDecimal();
+            case JsonHeaderType.Byte:
+                return json.GetByte();
+            case JsonHeaderType.SByte:
+                return json.GetSByte();
+            case JsonHeaderType.Int16:
+                return json.GetInt16();
+            case JsonHeaderType.String:
+                return json.GetString();
+            case JsonHeaderType.Bytes:
+                return json.GetBytesFromBase64();
+            case JsonHeaderType.AmqpTimestamp:
+                return new AmqpTimestamp(json.GetInt64());
+            case JsonHeaderType.List:
+                var list = new List<object?>();
+                foreach (var arrayItem in json.EnumerateArray())
+                {
+                    var arrayItemType = arrayItem.GetProperty(options.ConvertName("Type")).GetInt32();
+                    var arrayItemValue = arrayItem.GetProperty(options.ConvertName("Value"));
+                    list.Add((arrayItemType, arrayItemValue).ConvertJsonToObject(options));
+                }
+
+                return list;
+            case JsonHeaderType.Dictionary:
+                var dictionary = new Dictionary<string, object?>();
+                foreach (var objectItem in json.EnumerateObject())
+                {
+                    var objectItemType = objectItem.Value.GetProperty(options.ConvertName("Type")).GetInt32();
+                    var objectItemValue = objectItem.Value.GetProperty(options.ConvertName("Value"));
+                    dictionary.Add(objectItem.Name, (objectItemType, objectItemValue).ConvertJsonToObject(options));
+                }
+                return dictionary;
+            case JsonHeaderType.BinaryTable:
+                return new BinaryTableValue(json.GetBytesFromBase64());
+            default:
+                throw new InvalidOperationException();
+        }
+    }
+}

--- a/Source/EasyNetQ.Serialization.SystemTextJson/JsonHeaderExtensions.cs
+++ b/Source/EasyNetQ.Serialization.SystemTextJson/JsonHeaderExtensions.cs
@@ -154,7 +154,7 @@ internal static class JsonHeaderExtensions
             case JsonHeaderType.BinaryTable:
                 return new BinaryTableValue(json.GetBytesFromBase64());
             default:
-                throw new InvalidOperationException();
+                throw new ArgumentOutOfRangeException(nameof(type), type, null);
         }
     }
 }

--- a/Source/EasyNetQ.Serialization.SystemTextJson/JsonHeaderType.cs
+++ b/Source/EasyNetQ.Serialization.SystemTextJson/JsonHeaderType.cs
@@ -1,0 +1,28 @@
+namespace EasyNetQ.Serialization.SystemTextJson;
+
+internal static class JsonHeaderType
+{
+    public const int Null = 1;
+
+    public const int Bool = 2;
+
+    public const int Byte = 3;
+    public const int SByte = 4;
+
+    public const int Int16 = 5;
+    public const int Int32 = 6;
+    public const int UInt32 = 7;
+    public const int Int64 = 8;
+
+    public const int Single = 9;
+    public const int Double = 10;
+
+    public const int Decimal = 11;
+    public const int AmqpTimestamp = 12;
+
+    public const int String = 13;
+    public const int Bytes = 14;
+    public const int List = 15;
+    public const int Dictionary = 16;
+    public const int BinaryTable = 17;
+}

--- a/Source/EasyNetQ.Serialization.SystemTextJson/JsonSerializerOptionsExtensions.cs
+++ b/Source/EasyNetQ.Serialization.SystemTextJson/JsonSerializerOptionsExtensions.cs
@@ -1,0 +1,8 @@
+using System.Text.Json;
+
+namespace EasyNetQ.Serialization.SystemTextJson;
+
+internal static class JsonSerializerOptionsExtensions
+{
+    public static string ConvertName(this JsonSerializerOptions options, string name) => options.PropertyNamingPolicy?.ConvertName(name) ?? name;
+}

--- a/Source/EasyNetQ.Serialization.SystemTextJson/MessagePropertiesConverter.cs
+++ b/Source/EasyNetQ.Serialization.SystemTextJson/MessagePropertiesConverter.cs
@@ -44,8 +44,7 @@ public class MessagePropertiesConverter : JsonConverter<MessageProperties>
                 messageProperties.Headers = headers.ConvertJsonToHeaders(options);
             return messageProperties;
         }
-
-        throw new ArgumentOutOfRangeException(nameof(reader.TokenType), reader.TokenType, "Cannot read message properties");
+        throw new ArgumentOutOfRangeException(nameof(reader.TokenType), reader.TokenType, null);
     }
 
     public override void Write(Utf8JsonWriter writer, MessageProperties value, JsonSerializerOptions options)

--- a/Source/EasyNetQ.Serialization.SystemTextJson/MessagePropertiesConverter.cs
+++ b/Source/EasyNetQ.Serialization.SystemTextJson/MessagePropertiesConverter.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace EasyNetQ.Serialization.SystemTextJson;
+
+public class MessagePropertiesConverter : JsonConverter<MessageProperties>
+{
+    public override MessageProperties? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var parsed = JsonElement.ParseValue(ref reader);
+        if (parsed.ValueKind == JsonValueKind.Null) return null;
+        if (parsed.ValueKind == JsonValueKind.Object)
+        {
+            var messageProperties = new MessageProperties();
+            if (parsed.TryGetProperty(options.ConvertName("ContentType"), out var contentType))
+                messageProperties.ContentType = contentType.GetString();
+            if (parsed.TryGetProperty(options.ConvertName("ContentEncoding"), out var contentEncoding))
+                messageProperties.ContentEncoding = contentEncoding.GetString();
+            if (parsed.TryGetProperty(options.ConvertName("DeliveryMode"), out var deliveryMode))
+                messageProperties.DeliveryMode = deliveryMode.GetByte();
+            if (parsed.TryGetProperty(options.ConvertName("Priority"), out var priority))
+                messageProperties.Priority = priority.GetByte();
+            if (parsed.TryGetProperty(options.ConvertName("CorrelationId"), out var correlationId))
+                messageProperties.CorrelationId = correlationId.GetString();
+            if (parsed.TryGetProperty(options.ConvertName("ReplyTo"), out var replyTo))
+                messageProperties.ReplyTo = replyTo.GetString();
+            if (parsed.TryGetProperty(options.ConvertName("Expiration"), out var expiration))
+                messageProperties.Expiration = expiration.Deserialize<TimeSpan>();
+            if (parsed.TryGetProperty(options.ConvertName("MessageId"), out var messageId))
+                messageProperties.MessageId = messageId.GetString();
+            if (parsed.TryGetProperty(options.ConvertName("Timestamp"), out var timestamp))
+                messageProperties.Timestamp = timestamp.GetInt64();
+            if (parsed.TryGetProperty(options.ConvertName("Type"), out var type))
+                messageProperties.Type = type.GetString();
+            if (parsed.TryGetProperty(options.ConvertName("UserId"), out var userId))
+                messageProperties.UserId = userId.GetString();
+            if (parsed.TryGetProperty(options.ConvertName("AppId"), out var appId))
+                messageProperties.AppId = appId.GetString();
+            if (parsed.TryGetProperty(options.ConvertName("ClusterId"), out var clusterId))
+                messageProperties.ClusterId = clusterId.GetString();
+            if (parsed.TryGetProperty(options.ConvertName("Headers"), out var headers))
+                messageProperties.Headers = headers.ConvertJsonToHeaders(options);
+            return messageProperties;
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(reader.TokenType), reader.TokenType, "Cannot read message properties");
+    }
+
+    public override void Write(Utf8JsonWriter writer, MessageProperties value, JsonSerializerOptions options)
+    {
+        var json = new JsonObject();
+        if (value.ContentTypePresent)
+            json.Add(options.ConvertName("ContentType"), value.ContentType);
+        if (value.ContentEncodingPresent)
+            json.Add(options.ConvertName("ContentEncoding"), value.ContentEncoding);
+        if (value.DeliveryModePresent)
+            json.Add(options.ConvertName("DeliveryMode"), value.DeliveryMode);
+        if (value.PriorityPresent)
+            json.Add(options.ConvertName("Priority"), value.Priority);
+        if (value.CorrelationIdPresent)
+            json.Add(options.ConvertName("CorrelationId"), value.CorrelationId);
+        if (value.ReplyToPresent)
+            json.Add(options.ConvertName("ReplyTo"), value.ReplyTo);
+        if (value.ExpirationPresent)
+            json.Add(options.ConvertName("Expiration"), JsonValue.Create(value.Expiration));
+        if (value.MessageIdPresent)
+            json.Add(options.ConvertName("MessageId"), value.MessageId);
+        if (value.TimestampPresent)
+            json.Add(options.ConvertName("Timestamp"), value.Timestamp);
+        if (value.TypePresent)
+            json.Add(options.ConvertName("Type"), value.Type);
+        if (value.UserIdPresent)
+            json.Add(options.ConvertName("UserId"), value.UserId);
+        if (value.AppIdPresent)
+            json.Add(options.ConvertName("AppId"), value.AppId);
+        if (value.ClusterIdPresent)
+            json.Add(options.ConvertName("ClusterId"), value.ClusterId);
+        if (value.HeadersPresent)
+        {
+            var headersJson = new JsonObject();
+            foreach (var kvp in value.Headers)
+                headersJson.AddHeaderToJson(kvp.Key, kvp.Value, options);
+            json.Add(options.ConvertName("Headers"), headersJson);
+        }
+        json.WriteTo(writer);
+    }
+}

--- a/Source/EasyNetQ.Serialization.SystemTextJson/ServiceRegisterExtensions.cs
+++ b/Source/EasyNetQ.Serialization.SystemTextJson/ServiceRegisterExtensions.cs
@@ -12,14 +12,24 @@ public static class ServiceRegisterExtensions
     /// <summary>
     ///     Enables serializer based on System.Text.Json
     /// </summary>
-    /// <param name="serviceRegister">The register</param>
     public static IServiceRegister EnableSystemTextJson(this IServiceRegister serviceRegister)
-    {
-        return serviceRegister.Register<ISerializer, SystemTextJsonSerializer>();
-    }
+        => serviceRegister.Register<ISerializer, SystemTextJsonSerializer>();
 
+    /// <summary>
+    ///     Enables serializer based on System.Text.Json
+    /// </summary>
     public static IServiceRegister EnableSystemTextJson(this IServiceRegister serviceRegister, System.Text.Json.JsonSerializerOptions options)
-    {
-        return serviceRegister.Register<ISerializer>(_ => new SystemTextJsonSerializer(options));
-    }
+        => serviceRegister.Register<ISerializer>(_ => new SystemTextJsonSerializer(options));
+
+    /// <summary>
+    ///     Enables serializer based on System.Text.Json
+    /// </summary>
+    public static IServiceRegister EnableSystemTextJsonV2(this IServiceRegister serviceRegister)
+        => serviceRegister.Register<ISerializer, SystemTextJsonSerializerV2>();
+
+    /// <summary>
+    ///     Enables serializer based on System.Text.Json
+    /// </summary>
+    public static IServiceRegister EnableSystemTextJsonV2(this IServiceRegister serviceRegister, System.Text.Json.JsonSerializerOptions options)
+        => serviceRegister.Register<ISerializer>(_ => new SystemTextJsonSerializerV2(options));
 }

--- a/Source/EasyNetQ.Serialization.SystemTextJson/SystemTextJsonSerializerV2.cs
+++ b/Source/EasyNetQ.Serialization.SystemTextJson/SystemTextJsonSerializerV2.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Buffers;
+using EasyNetQ.Internals;
+
+namespace EasyNetQ.Serialization.SystemTextJson;
+
+public sealed class SystemTextJsonSerializerV2 : ISerializer
+{
+    private readonly System.Text.Json.JsonSerializerOptions options;
+
+    public SystemTextJsonSerializerV2()
+        : this(new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.General))
+    {
+    }
+
+    // ReSharper disable once MemberCanBePrivate.Global
+    public SystemTextJsonSerializerV2(System.Text.Json.JsonSerializerOptions options)
+    {
+        this.options = new System.Text.Json.JsonSerializerOptions(options);
+        this.options.Converters.Add(new MessagePropertiesConverter());
+    }
+
+    public IMemoryOwner<byte> MessageToBytes(Type messageType, object message)
+    {
+        var stream = new ArrayPooledMemoryStream();
+        System.Text.Json.JsonSerializer.Serialize(stream, message, messageType, options);
+        return stream;
+    }
+
+    public object BytesToMessage(Type messageType, in ReadOnlyMemory<byte> bytes)
+    {
+        return System.Text.Json.JsonSerializer.Deserialize(bytes.Span, messageType, options)!;
+    }
+}

--- a/Source/EasyNetQ.Serialization.Tests/SerializerTests.cs
+++ b/Source/EasyNetQ.Serialization.Tests/SerializerTests.cs
@@ -1,5 +1,7 @@
 // ReSharper disable InconsistentNaming
+
 using System.Collections.Generic;
+using System.Text;
 using EasyNetQ.Serialization.NewtonsoftJson;
 using EasyNetQ.Serialization.SystemTextJson;
 using FluentAssertions;
@@ -26,7 +28,7 @@ public class SerializerTests
 
     [Theory]
     [MemberData(nameof(GetSerializers))]
-    public void Should_be_able_to_serialize_basic_properties(string name, ISerializer serializer)
+    public void Should_be_able_to_serialize_message_properties_simple(string name, ISerializer serializer)
     {
         var originalProperties = new EasyNetQ.Tests.BasicProperties
         {
@@ -63,11 +65,70 @@ public class SerializerTests
         originalProperties.Should().BeEquivalentTo(newProperties);
     }
 
+
+    [Theory]
+    [MemberData(nameof(GetSerializers))]
+    public void Should_be_able_to_serialize_message_properties_extended(string name, ISerializer serializer)
+    {
+        if (name != "SystemTextJsonV2") return;
+
+        var originalProperties = new EasyNetQ.Tests.BasicProperties
+        {
+            AppId = "some app id",
+            ClusterId = "cluster id",
+            ContentEncoding = "content encoding",
+            ContentType = "content type",
+            CorrelationId = "correlation id",
+            DeliveryMode = 4,
+            Expiration = "1",
+            MessageId = "message id",
+            Priority = 1,
+            ReplyTo = "abc",
+            Timestamp = new AmqpTimestamp(123344044),
+            Type = "Type",
+            UserId = "user id",
+            Headers = new Dictionary<string, object>
+            {
+                { "Bool", false },
+                { "Byte", (byte)1 },
+                { "Sbyte", (sbyte)2 },
+                { "Int16", (short)3 },
+                { "Int32", 4 },
+                { "Uint32", 5U },
+                { "Int64", 6L },
+                { "Single", 1F },
+                { "Double", 8D },
+                { "Decimal", 9M },
+                { "AmqpTimestamp", new AmqpTimestamp(10) },
+                { "String", "11" },
+                { "Bytes", new byte[] { 12 } },
+                { "List", new[] { "13" } },
+                { "Dictionary", new Dictionary<string, object> { { "14", 15 } } },
+                { "BinaryTable", new BinaryTableValue(new byte[] {16})}
+            }
+        };
+
+        var messageBasicProperties = new MessageProperties();
+        messageBasicProperties.CopyFrom(originalProperties);
+        using var serializedMessage = serializer.MessageToBytes(typeof(MessageProperties), messageBasicProperties);
+
+        var deserializedMessageBasicProperties = (MessageProperties)serializer.BytesToMessage(
+            typeof(MessageProperties), serializedMessage.Memory
+        );
+
+        var newProperties = new EasyNetQ.Tests.BasicProperties();
+        deserializedMessageBasicProperties.CopyTo(newProperties);
+
+        originalProperties.Should().BeEquivalentTo(newProperties);
+    }
+
+
     [Theory]
     [MemberData(nameof(GetSerializers))]
     public void Should_be_able_to_serialize_and_deserialize_polymorphic_properties(string name, ISerializer serializer)
     {
         if (name == "SystemTextJson") return; // Polymorphic deserialization doesn't work out of the box
+        if (name == "SystemTextJsonV2") return; // Polymorphic deserialization doesn't work out of the box
 
         using var serializedMessage = serializer.MessageToBytes(typeof(PolyMessage), new PolyMessage { AorB = new B() });
         var result = (PolyMessage)serializer.BytesToMessage(typeof(PolyMessage), serializedMessage.Memory);
@@ -79,15 +140,22 @@ public class SerializerTests
         yield return new object[] { "Newtonsoft", new NewtonsoftJsonSerializer() };
         yield return new object[] { "Default", new JsonSerializer() };
         yield return new object[] { "SystemTextJson", new SystemTextJsonSerializer() };
+        yield return new object[] { "SystemTextJsonV2", new SystemTextJsonSerializerV2() };
     }
 
+    private class A
+    {
+    }
 
-    private class A { }
-    private class B : A { }
+    private class B : A
+    {
+    }
+
     private class PolyMessage
     {
         public A AorB { get; set; }
     }
+
     private class Message
     {
         public string Text { get; set; }

--- a/Source/EasyNetQ/MessageProperties.cs
+++ b/Source/EasyNetQ/MessageProperties.cs
@@ -57,7 +57,11 @@ public class MessageProperties : ICloneable
     public string? ContentType
     {
         get => contentType;
-        set { contentType = CheckShortString(value, nameof(ContentType)); contentTypePresent = true; }
+        set
+        {
+            contentType = CheckShortString(value, nameof(ContentType));
+            contentTypePresent = true;
+        }
     }
 
     private string? contentEncoding;
@@ -68,7 +72,11 @@ public class MessageProperties : ICloneable
     public string? ContentEncoding
     {
         get => contentEncoding;
-        set { contentEncoding = CheckShortString(value, nameof(ContentEncoding)); contentEncodingPresent = true; }
+        set
+        {
+            contentEncoding = CheckShortString(value, nameof(ContentEncoding));
+            contentEncodingPresent = true;
+        }
     }
 
     private IDictionary<string, object?>? headers;
@@ -90,7 +98,11 @@ public class MessageProperties : ICloneable
     public byte DeliveryMode
     {
         get => deliveryMode;
-        set { deliveryMode = value; deliveryModePresent = true; }
+        set
+        {
+            deliveryMode = value;
+            deliveryModePresent = true;
+        }
     }
 
     private byte priority;
@@ -101,7 +113,11 @@ public class MessageProperties : ICloneable
     public byte Priority
     {
         get => priority;
-        set { priority = value; priorityPresent = true; }
+        set
+        {
+            priority = value;
+            priorityPresent = true;
+        }
     }
 
     private string? correlationId;
@@ -112,7 +128,11 @@ public class MessageProperties : ICloneable
     public string? CorrelationId
     {
         get => correlationId;
-        set { correlationId = CheckShortString(value, nameof(CorrelationId)); correlationIdPresent = true; }
+        set
+        {
+            correlationId = CheckShortString(value, nameof(CorrelationId));
+            correlationIdPresent = true;
+        }
     }
 
     private string? replyTo;
@@ -123,7 +143,11 @@ public class MessageProperties : ICloneable
     public string? ReplyTo
     {
         get => replyTo;
-        set { replyTo = CheckShortString(value, nameof(ReplyTo)); replyToPresent = true; }
+        set
+        {
+            replyTo = CheckShortString(value, nameof(ReplyTo));
+            replyToPresent = true;
+        }
     }
 
     private TimeSpan? expiration;
@@ -134,7 +158,11 @@ public class MessageProperties : ICloneable
     public TimeSpan? Expiration
     {
         get => expiration;
-        set { expiration = value; expirationPresent = true; }
+        set
+        {
+            expiration = value;
+            expirationPresent = true;
+        }
     }
 
     private string? messageId;
@@ -145,7 +173,11 @@ public class MessageProperties : ICloneable
     public string? MessageId
     {
         get => messageId;
-        set { messageId = CheckShortString(value, nameof(MessageId)); messageIdPresent = true; }
+        set
+        {
+            messageId = CheckShortString(value, nameof(MessageId));
+            messageIdPresent = true;
+        }
     }
 
     private long timestamp;
@@ -156,7 +188,11 @@ public class MessageProperties : ICloneable
     public long Timestamp
     {
         get => timestamp;
-        set { timestamp = value; timestampPresent = true; }
+        set
+        {
+            timestamp = value;
+            timestampPresent = true;
+        }
     }
 
     private string? type;
@@ -167,7 +203,11 @@ public class MessageProperties : ICloneable
     public string? Type
     {
         get => type;
-        set { type = CheckShortString(value, nameof(Type)); typePresent = true; }
+        set
+        {
+            type = CheckShortString(value, nameof(Type));
+            typePresent = true;
+        }
     }
 
     private string? userId;
@@ -178,7 +218,11 @@ public class MessageProperties : ICloneable
     public string? UserId
     {
         get => userId;
-        set { userId = CheckShortString(value, nameof(UserId)); userIdPresent = true; }
+        set
+        {
+            userId = CheckShortString(value, nameof(UserId));
+            userIdPresent = true;
+        }
     }
 
     private string? appId;
@@ -189,7 +233,11 @@ public class MessageProperties : ICloneable
     public string? AppId
     {
         get => appId;
-        set { appId = CheckShortString(value, nameof(AppId)); appIdPresent = true; }
+        set
+        {
+            appId = CheckShortString(value, nameof(AppId));
+            appIdPresent = true;
+        }
     }
 
     private string? clusterId;
@@ -200,7 +248,11 @@ public class MessageProperties : ICloneable
     public string? ClusterId
     {
         get => clusterId;
-        set { clusterId = CheckShortString(value, nameof(ClusterId)); clusterIdPresent = true; }
+        set
+        {
+            clusterId = CheckShortString(value, nameof(ClusterId));
+            clusterIdPresent = true;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Related to #1532.

1. Amqp headers could contain only a fixed list of type.
2. At the moment, serializer are not able deserialize all of them properly, because they serialized as Dictionary<str, object> without custom converters.

The idea here is to save type information for all headers to deserialize them properly.