### PR TITLE
Await async consumer methods in tests

### DIFF
--- a/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
@@ -79,11 +79,6 @@ public abstract class ConsumerTestBase : IDisposable
         };
         OriginalBody = "Hello World"u8.ToArray();
 
-        var waiter = new CountdownEvent(2);
-
-        MockBuilder.EventBus.Subscribe((in DeliveredMessageEvent _) => waiter.Signal());
-        MockBuilder.EventBus.Subscribe((in AckEvent _) => waiter.Signal());
-
         MockBuilder.Consumers[0].HandleBasicDeliver(
             ConsumerTag,
             DeliverTag,
@@ -92,11 +87,6 @@ public abstract class ConsumerTestBase : IDisposable
             "the_routing_key",
             OriginalProperties,
             OriginalBody
-        );
-
-        if (!waiter.Wait(5000))
-        {
-            throw new TimeoutException();
-        }
+        ).GetAwaiter().GetResult();
     }
 }

--- a/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/ConsumerTestBase.cs
@@ -1,10 +1,8 @@
 using EasyNetQ.Consumer;
 using EasyNetQ.DI;
-using EasyNetQ.Events;
 using EasyNetQ.Tests.Mocking;
 using EasyNetQ.Topology;
 using RabbitMQ.Client;
-using System.Text;
 
 namespace EasyNetQ.Tests.ConsumeTests;
 

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_received.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_received.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using EasyNetQ.Events;
 using EasyNetQ.Tests.Mocking;
 
 namespace EasyNetQ.Tests.ConsumeTests;

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_received.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_message_is_received.cs
@@ -51,8 +51,6 @@ public class When_a_message_is_received : IDisposable
         };
         var body = Encoding.UTF8.GetBytes(message);
 
-        var autoResetEvent = new AutoResetEvent(false);
-        mockBuilder.EventBus.Subscribe((in AckEvent _) => autoResetEvent.Set());
         mockBuilder.Consumers[0].HandleBasicDeliver(
             "consumer tag",
             0,
@@ -61,11 +59,6 @@ public class When_a_message_is_received : IDisposable
             "the_routing_key",
             properties,
             body
-        );
-
-        if (!autoResetEvent.WaitOne(5000))
-        {
-            throw new TimeoutException();
-        }
+        ).GetAwaiter().GetResult();
     }
 }

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_polymorphic_message_is_delivered_to_the_consumer.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_polymorphic_message_is_delivered_to_the_consumer.cs
@@ -14,12 +14,7 @@ public class When_a_polymorphic_message_is_delivered_to_the_consumer : IDisposab
 
         var queue = new Queue("test_queue", false);
 
-        var are = new AutoResetEvent(false);
-        mockBuilder.Bus.Advanced.Consume<ITestMessageInterface>(queue, (message, _) => Task.Factory.StartNew(() =>
-        {
-            receivedMessage = message.Body;
-            are.Set();
-        }));
+        mockBuilder.Bus.Advanced.Consume<ITestMessageInterface>(queue, (message, _) => receivedMessage = message.Body);
 
         var publishedMessage = new Implementation { Text = "Hello Polymorphs!" };
         var serializedMessage = new JsonSerializer().MessageToBytes(typeof(Implementation), publishedMessage);
@@ -36,12 +31,7 @@ public class When_a_polymorphic_message_is_delivered_to_the_consumer : IDisposab
             "routing_key",
             properties,
             serializedMessage.Memory
-        );
-
-        if (!are.WaitOne(5000))
-        {
-            throw new TimeoutException();
-        }
+        ).GetAwaiter().GetResult();
     }
 
     public void Dispose()

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
@@ -75,7 +75,7 @@ public class When_a_responder_is_cancelled : IDisposable
             "the_routing_key",
             properties,
             serializedMessage.Memory
-        );
+        ).GetAwaiter().GetResult();
 
         if (!waiter.Wait(5000))
             throw new TimeoutException();

--- a/Source/EasyNetQ.Tests/Interception/BuildInInterceptorsTests.cs
+++ b/Source/EasyNetQ.Tests/Interception/BuildInInterceptorsTests.cs
@@ -1,5 +1,4 @@
 using EasyNetQ.Interception;
-using System.Text;
 
 namespace EasyNetQ.Tests.Interception;
 

--- a/Source/EasyNetQ.Tests/Mocking/MockBuilder.cs
+++ b/Source/EasyNetQ.Tests/Mocking/MockBuilder.cs
@@ -54,7 +54,9 @@ public class MockBuilder : IDisposable
                     var consumer = (AsyncDefaultBasicConsumer)consumeInvocation[6];
 
                     ConsumerQueueNames.Add(queueName);
-                    consumer.HandleBasicConsumeOk(consumerTag);
+                    consumer.HandleBasicConsumeOk(consumerTag)
+                        .GetAwaiter()
+                        .GetResult();
                     consumers.Add(consumer);
                     return string.Empty;
                 });

--- a/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent.cs
+++ b/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent.cs
@@ -2,7 +2,6 @@ using EasyNetQ.DI;
 using EasyNetQ.Events;
 using EasyNetQ.Tests.Mocking;
 using RabbitMQ.Client;
-using System.Text;
 
 namespace EasyNetQ.Tests.ProducerTests;
 

--- a/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent.cs
+++ b/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent.cs
@@ -56,7 +56,7 @@ public class When_a_request_is_sent : IDisposable
             "the_routing_key",
             properties,
             body
-        );
+        ).GetAwaiter().GetResult();
     }
 
     [Fact]

--- a/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent_but_an_exception_is_thrown_by_responder.cs
+++ b/Source/EasyNetQ.Tests/ProducerTests/When_a_request_is_sent_but_an_exception_is_thrown_by_responder.cs
@@ -97,6 +97,6 @@ public class When_a_request_is_sent_but_an_exception_is_thrown_by_responder : ID
             "the_routing_key",
             properties,
             body
-        );
+        ).GetAwaiter().GetResult();
     }
 }

--- a/Source/EasyNetQ.Tests/SubscribeTests.cs
+++ b/Source/EasyNetQ.Tests/SubscribeTests.cs
@@ -230,9 +230,6 @@ public class When_a_message_is_delivered : IDisposable
 
         mockBuilder = new MockBuilder(x => x.Register<IConventions>(conventions));
 
-        var autoResetEvent = new AutoResetEvent(false);
-        mockBuilder.EventBus.Subscribe((in AckEvent _) => autoResetEvent.Set());
-
         mockBuilder.PubSub.Subscribe<MyMessage>(subscriptionId, message => { deliveredMessage = message; });
 
         const string text = "Hello there, I am the text!";
@@ -253,10 +250,7 @@ public class When_a_message_is_delivered : IDisposable
                 CorrelationId = correlationId
             },
             serializedMessage.Memory
-        );
-
-        // wait for the subscription thread to handle the message ...
-        autoResetEvent.WaitOne(1000);
+        ).GetAwaiter().GetResult();
     }
 
     public void Dispose()
@@ -340,12 +334,7 @@ public class When_the_handler_throws_an_exception : IDisposable
                 CorrelationId = correlationId
             },
             serializedMessage.Memory
-        );
-
-        // wait for the subscription thread to handle the message ...
-        var autoResetEvent = new AutoResetEvent(false);
-        mockBuilder.EventBus.Subscribe((in AckEvent _) => autoResetEvent.Set());
-        autoResetEvent.WaitOne(1000);
+        ).GetAwaiter().GetResult();
     }
 
     public void Dispose()


### PR DESCRIPTION
It simplifies tests slightly, because there is no more need to set up AutoResetEvent/CountdownEvent in some cases.