### PR TITLE
Convert MessageReceivedInfo to readonly record struct

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -115,7 +115,7 @@ namespace EasyNetQ
     }
     public readonly struct ConsumedMessage
     {
-        public ConsumedMessage(EasyNetQ.MessageReceivedInfo receivedInfo, EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
+        public ConsumedMessage(in EasyNetQ.MessageReceivedInfo receivedInfo, in EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
         public System.ReadOnlyMemory<byte> Body { get; }
         public EasyNetQ.MessageProperties Properties { get; }
         public EasyNetQ.MessageReceivedInfo ReceivedInfo { get; }
@@ -608,7 +608,7 @@ namespace EasyNetQ
     }
     public class MessageReturnedEventArgs : System.EventArgs
     {
-        public MessageReturnedEventArgs(in System.ReadOnlyMemory<byte> messageBody, EasyNetQ.MessageProperties messageProperties, in EasyNetQ.MessageReturnedInfo messageReturnedInfo) { }
+        public MessageReturnedEventArgs(in System.ReadOnlyMemory<byte> messageBody, in EasyNetQ.MessageProperties messageProperties, in EasyNetQ.MessageReturnedInfo messageReturnedInfo) { }
         public System.ReadOnlyMemory<byte> MessageBody { get; }
         public EasyNetQ.MessageProperties MessageProperties { get; }
         public EasyNetQ.MessageReturnedInfo MessageReturnedInfo { get; }
@@ -676,7 +676,7 @@ namespace EasyNetQ
     }
     public readonly struct ProducedMessage
     {
-        public ProducedMessage(EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
+        public ProducedMessage(in EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
         public System.ReadOnlyMemory<byte> Body { get; }
         public EasyNetQ.MessageProperties Properties { get; }
     }
@@ -1124,7 +1124,7 @@ namespace EasyNetQ.Consumer
     }
     public readonly struct ConsumerExecutionContext
     {
-        public ConsumerExecutionContext(EasyNetQ.Consumer.MessageHandler handler, EasyNetQ.MessageReceivedInfo receivedInfo, EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
+        public ConsumerExecutionContext(EasyNetQ.Consumer.MessageHandler handler, in EasyNetQ.MessageReceivedInfo receivedInfo, in EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
         public System.ReadOnlyMemory<byte> Body { get; }
         public EasyNetQ.Consumer.MessageHandler Handler { get; }
         public EasyNetQ.MessageProperties Properties { get; }
@@ -1361,7 +1361,7 @@ namespace EasyNetQ.Events
 {
     public readonly struct AckEvent
     {
-        public AckEvent(EasyNetQ.MessageReceivedInfo info, EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body, EasyNetQ.Events.AckResult ackResult) { }
+        public AckEvent(in EasyNetQ.MessageReceivedInfo info, in EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body, EasyNetQ.Events.AckResult ackResult) { }
         public EasyNetQ.Events.AckResult AckResult { get; }
         public System.ReadOnlyMemory<byte> Body { get; }
         public EasyNetQ.MessageProperties Properties { get; }
@@ -1420,7 +1420,7 @@ namespace EasyNetQ.Events
     }
     public readonly struct DeliveredMessageEvent
     {
-        public DeliveredMessageEvent(EasyNetQ.MessageReceivedInfo info, EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
+        public DeliveredMessageEvent(in EasyNetQ.MessageReceivedInfo info, in EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
         public System.ReadOnlyMemory<byte> Body { get; }
         public EasyNetQ.MessageProperties Properties { get; }
         public EasyNetQ.MessageReceivedInfo ReceivedInfo { get; }
@@ -1436,7 +1436,7 @@ namespace EasyNetQ.Events
     }
     public readonly struct PublishedMessageEvent
     {
-        public PublishedMessageEvent(in EasyNetQ.Topology.Exchange exchange, string routingKey, EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
+        public PublishedMessageEvent(in EasyNetQ.Topology.Exchange exchange, string routingKey, in EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
         public System.ReadOnlyMemory<byte> Body { get; }
         public EasyNetQ.Topology.Exchange Exchange { get; }
         public EasyNetQ.MessageProperties Properties { get; }
@@ -1444,7 +1444,7 @@ namespace EasyNetQ.Events
     }
     public readonly struct ReturnedMessageEvent
     {
-        public ReturnedMessageEvent(RabbitMQ.Client.IModel channel, in System.ReadOnlyMemory<byte> body, EasyNetQ.MessageProperties properties, in EasyNetQ.MessageReturnedInfo info) { }
+        public ReturnedMessageEvent(RabbitMQ.Client.IModel channel, in System.ReadOnlyMemory<byte> body, in EasyNetQ.MessageProperties properties, in EasyNetQ.MessageReturnedInfo info) { }
         public System.ReadOnlyMemory<byte> Body { get; }
         public RabbitMQ.Client.IModel Channel { get; }
         public EasyNetQ.MessageReturnedInfo Info { get; }

--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -596,16 +596,15 @@ namespace EasyNetQ
         public static void CopyTo(in this EasyNetQ.MessageProperties source, RabbitMQ.Client.IBasicProperties basicProperties) { }
         public static EasyNetQ.MessageProperties SetHeader(in this EasyNetQ.MessageProperties source, string key, object? value) { }
     }
-    public class MessageReceivedInfo
+    public readonly struct MessageReceivedInfo : System.IEquatable<EasyNetQ.MessageReceivedInfo>
     {
-        public MessageReceivedInfo(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, string queue) { }
-        public string ConsumerTag { get; }
-        public ulong DeliveryTag { get; }
-        public string Exchange { get; }
-        public string Queue { get; }
-        public bool Redelivered { get; }
-        public string RoutingKey { get; }
-        public override string ToString() { }
+        public MessageReceivedInfo(string ConsumerTag, ulong DeliveryTag, bool Redelivered, string Exchange, string RoutingKey, string Queue) { }
+        public string ConsumerTag { get; set; }
+        public ulong DeliveryTag { get; set; }
+        public string Exchange { get; set; }
+        public string Queue { get; set; }
+        public bool Redelivered { get; set; }
+        public string RoutingKey { get; set; }
     }
     public class MessageReturnedEventArgs : System.EventArgs
     {
@@ -713,7 +712,7 @@ namespace EasyNetQ
         public EasyNetQ.MessageReceivedInfo ReceivedInfo { get; }
         public static EasyNetQ.PullResult NotAvailable { get; }
         public void Dispose() { }
-        public static EasyNetQ.PullResult Available(ulong messagesCount, EasyNetQ.MessageReceivedInfo receivedInfo, in EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body, System.IDisposable? disposable) { }
+        public static EasyNetQ.PullResult Available(ulong messagesCount, in EasyNetQ.MessageReceivedInfo receivedInfo, in EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body, System.IDisposable? disposable) { }
     }
     public readonly struct PullResult<T> : EasyNetQ.IPullResult, System.IDisposable
     {

--- a/Source/EasyNetQ.Hosepipe.Tests/ErrorRetryTests.cs
+++ b/Source/EasyNetQ.Hosepipe.Tests/ErrorRetryTests.cs
@@ -29,7 +29,7 @@ public class ErrorRetryTests
         };
 
         var rawErrorMessages = new MessageReader()
-            .ReadMessages(parameters, conventions.ErrorQueueNamingConvention(null));
+            .ReadMessages(parameters, conventions.ErrorQueueNamingConvention(default));
 
         errorRetry.RetryErrors(rawErrorMessages, parameters);
     }

--- a/Source/EasyNetQ.Hosepipe.Tests/MessageReaderTests.cs
+++ b/Source/EasyNetQ.Hosepipe.Tests/MessageReaderTests.cs
@@ -46,7 +46,7 @@ public class MessageReaderTests
             MessagesOutputDirectory = @"C:\temp\MessageOutput"
         };
 
-        var messages = messageReader.ReadMessages(parameters, conventions.ErrorQueueNamingConvention(null));
+        var messages = messageReader.ReadMessages(parameters, conventions.ErrorQueueNamingConvention(default));
         foreach (var message in messages)
         {
             Console.WriteLine(message.Body);

--- a/Source/EasyNetQ.Hosepipe/HosepipeMessage.cs
+++ b/Source/EasyNetQ.Hosepipe/HosepipeMessage.cs
@@ -6,10 +6,10 @@ public class HosepipeMessage
     public MessageProperties Properties { get; }
     public MessageReceivedInfo Info { get; }
 
-    public HosepipeMessage(string body, in MessageProperties properties, MessageReceivedInfo info)
+    public HosepipeMessage(string body, in MessageProperties properties, in MessageReceivedInfo info)
     {
         Body = body ?? throw new ArgumentNullException(nameof(body));
         Properties = properties;
-        Info = info ?? throw new ArgumentNullException(nameof(info));
+        Info = info;
     }
 }

--- a/Source/EasyNetQ.Hosepipe/Program.cs
+++ b/Source/EasyNetQ.Hosepipe/Program.cs
@@ -154,14 +154,14 @@ public class Program
     private void ErrorDump(QueueParameters parameters)
     {
         if (parameters.QueueName == null)
-            parameters.QueueName = conventions.ErrorQueueNamingConvention(null);
+            parameters.QueueName = conventions.ErrorQueueNamingConvention(default);
         Dump(parameters);
     }
 
     private void Retry(QueueParameters parameters)
     {
         var count = 0;
-        var queueName = parameters.QueueName ?? conventions.ErrorQueueNamingConvention(null);
+        var queueName = parameters.QueueName ?? conventions.ErrorQueueNamingConvention(default);
 
         errorRetry.RetryErrors(
             WithEach(messageReader.ReadMessages(parameters, queueName), () => count++), parameters

--- a/Source/EasyNetQ.Tests/ConsumeTests/HandlerCollectionTests.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/HandlerCollectionTests.cs
@@ -21,7 +21,7 @@ public class HandlerCollectionTests
     {
         var handler = handlerCollection.GetHandler(typeof(MyMessage));
 
-        await handler(new Message<MyMessage>(new MyMessage()), null, default);
+        await handler(new Message<MyMessage>(new MyMessage()), default, default);
 
         myMessageHandlerExecuted.Should().BeTrue();
         animalHandlerExecuted.Should().BeFalse();
@@ -32,7 +32,7 @@ public class HandlerCollectionTests
     {
         var handler = handlerCollection.GetHandler(typeof(Dog));
 
-        await handler(new Message<Dog>(new Dog()), null, default);
+        await handler(new Message<Dog>(new Dog()), default, default);
 
         animalHandlerExecuted.Should().BeTrue();
         myMessageHandlerExecuted.Should().BeFalse();
@@ -49,7 +49,7 @@ public class HandlerCollectionTests
     {
         var handler = handlerCollection.GetHandler(typeof(MyMessage));
 
-        await handler(new Message<MyMessage>(new MyMessage()), null, default);
+        await handler(new Message<MyMessage>(new MyMessage()), default, default);
 
         myMessageHandlerExecuted.Should().BeTrue();
         animalHandlerExecuted.Should().BeFalse();
@@ -60,7 +60,7 @@ public class HandlerCollectionTests
     {
         var handler = handlerCollection.GetHandler(typeof(Dog));
 
-        await handler(new Message<Dog>(new Dog()), null, default);
+        await handler(new Message<Dog>(new Dog()), default, default);
 
         animalHandlerExecuted.Should().BeTrue();
         myMessageHandlerExecuted.Should().BeFalse();
@@ -73,7 +73,7 @@ public class HandlerCollectionTests
 
         var handler = handlerCollection.GetHandler(typeof(MyOtherMessage));
 
-        await handler(new Message<MyOtherMessage>(new MyOtherMessage()), null, default);
+        await handler(new Message<MyOtherMessage>(new MyOtherMessage()), default, default);
 
         myMessageHandlerExecuted.Should().BeFalse();
         animalHandlerExecuted.Should().BeFalse();

--- a/Source/EasyNetQ.Tests/ConventionsTests.cs
+++ b/Source/EasyNetQ.Tests/ConventionsTests.cs
@@ -27,7 +27,7 @@ public class When_using_default_conventions
     [Fact]
     public void The_default_error_queue_name_should_be()
     {
-        var result = conventions.ErrorQueueNamingConvention(null);
+        var result = conventions.ErrorQueueNamingConvention(default);
         result.Should().Be("EasyNetQ_Default_Error_Queue");
     }
 

--- a/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_executed.cs
+++ b/Source/EasyNetQ.Tests/HandlerRunnerTests/When_a_user_handler_is_executed.cs
@@ -72,7 +72,7 @@ public class When_a_user_handler_is_executed
     [Fact]
     public void Should_deliver_info()
     {
-        deliveredInfo.Should().BeSameAs(messageInfo);
+        deliveredInfo.Should().BeEquivalentTo(messageInfo);
     }
 
     [Fact]

--- a/Source/EasyNetQ/ConsumedMessage.cs
+++ b/Source/EasyNetQ/ConsumedMessage.cs
@@ -11,7 +11,7 @@ public readonly struct ConsumedMessage
     /// <param name="receivedInfo">The received info</param>
     /// <param name="properties">The properties</param>
     /// <param name="body">The body</param>
-    public ConsumedMessage(MessageReceivedInfo receivedInfo, MessageProperties properties, in ReadOnlyMemory<byte> body)
+    public ConsumedMessage(in MessageReceivedInfo receivedInfo, in MessageProperties properties, in ReadOnlyMemory<byte> body)
     {
         ReceivedInfo = receivedInfo;
         Properties = properties;

--- a/Source/EasyNetQ/Consumer/AsyncBasicConsumer.cs
+++ b/Source/EasyNetQ/Consumer/AsyncBasicConsumer.cs
@@ -119,7 +119,7 @@ internal class AsyncBasicConsumer : AsyncDefaultBasicConsumer, IDisposable
         eventBus.Publish(new ConsumerModelDisposedEvent(ConsumerTags));
     }
 
-    private AckResult Ack(AckStrategy ackStrategy, MessageReceivedInfo receivedInfo)
+    private AckResult Ack(AckStrategy ackStrategy, in MessageReceivedInfo receivedInfo)
     {
         try
         {

--- a/Source/EasyNetQ/Consumer/ConsumerExecutionContext.cs
+++ b/Source/EasyNetQ/Consumer/ConsumerExecutionContext.cs
@@ -30,8 +30,8 @@ public readonly struct ConsumerExecutionContext
     /// </summary>
     public ConsumerExecutionContext(
         MessageHandler handler,
-        MessageReceivedInfo receivedInfo,
-        MessageProperties properties,
+        in MessageReceivedInfo receivedInfo,
+        in MessageProperties properties,
         in ReadOnlyMemory<byte> body
     )
     {

--- a/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
+++ b/Source/EasyNetQ/Consumer/DefaultConsumerErrorStrategy.cs
@@ -161,7 +161,7 @@ public class DefaultConsumerErrorStrategy : IConsumerErrorStrategy
     }
 
     private IMemoryOwner<byte> CreateErrorMessage(
-        MessageReceivedInfo receivedInfo, MessageProperties properties, byte[] body, Exception exception
+        in MessageReceivedInfo receivedInfo, in MessageProperties properties, byte[] body, Exception exception
     )
     {
         var error = new Error(

--- a/Source/EasyNetQ/Events/AckEvent.cs
+++ b/Source/EasyNetQ/Events/AckEvent.cs
@@ -28,7 +28,7 @@ public readonly struct AckEvent
     /// <summary>
     ///     Creates AckEvent
     /// </summary>
-    public AckEvent(MessageReceivedInfo info, MessageProperties properties, in ReadOnlyMemory<byte> body, AckResult ackResult)
+    public AckEvent(in MessageReceivedInfo info, in MessageProperties properties, in ReadOnlyMemory<byte> body, AckResult ackResult)
     {
         ReceivedInfo = info;
         Properties = properties;

--- a/Source/EasyNetQ/Events/DeliveredMessageEvent.cs
+++ b/Source/EasyNetQ/Events/DeliveredMessageEvent.cs
@@ -6,7 +6,7 @@ public readonly struct DeliveredMessageEvent
     public MessageProperties Properties { get; }
     public ReadOnlyMemory<byte> Body { get; }
 
-    public DeliveredMessageEvent(MessageReceivedInfo info, MessageProperties properties, in ReadOnlyMemory<byte> body)
+    public DeliveredMessageEvent(in MessageReceivedInfo info, in MessageProperties properties, in ReadOnlyMemory<byte> body)
     {
         ReceivedInfo = info;
         Properties = properties;

--- a/Source/EasyNetQ/Events/PublishedMessageEvent.cs
+++ b/Source/EasyNetQ/Events/PublishedMessageEvent.cs
@@ -14,7 +14,7 @@ public readonly struct PublishedMessageEvent
     /// <param name="routingKey">The routing key</param>
     /// <param name="properties">The properties</param>
     /// <param name="body">The body</param>
-    public PublishedMessageEvent(in Exchange exchange, string routingKey, MessageProperties properties, in ReadOnlyMemory<byte> body)
+    public PublishedMessageEvent(in Exchange exchange, string routingKey, in MessageProperties properties, in ReadOnlyMemory<byte> body)
     {
         Exchange = exchange;
         RoutingKey = routingKey;

--- a/Source/EasyNetQ/Events/ReturnedMessageEvent.cs
+++ b/Source/EasyNetQ/Events/ReturnedMessageEvent.cs
@@ -14,7 +14,7 @@ public readonly struct ReturnedMessageEvent
     /// <param name="body">The message body</param>
     /// <param name="properties">The message properties</param>
     /// <param name="info">The returned message info</param>
-    public ReturnedMessageEvent(IModel channel, in ReadOnlyMemory<byte> body, MessageProperties properties, in MessageReturnedInfo info)
+    public ReturnedMessageEvent(IModel channel, in ReadOnlyMemory<byte> body, in MessageProperties properties, in MessageReturnedInfo info)
     {
         Channel = channel;
         Body = body;

--- a/Source/EasyNetQ/MessageReceivedInfo.cs
+++ b/Source/EasyNetQ/MessageReceivedInfo.cs
@@ -3,61 +3,11 @@ namespace EasyNetQ;
 /// <summary>
 ///     Represents various properties of a received message
 /// </summary>
-public class MessageReceivedInfo
-{
-    /// <summary>
-    ///     Consumer tag
-    /// </summary>
-    public string ConsumerTag { get; }
-
-    /// <summary>
-    ///     Delivery tag
-    /// </summary>
-    public ulong DeliveryTag { get; }
-
-    /// <summary>
-    ///     <see langword="true"/> if a message is redelivered
-    /// </summary>
-    public bool Redelivered { get; }
-
-    /// <summary>
-    ///     Exchange
-    /// </summary>
-    public string Exchange { get; }
-
-    /// <summary>
-    ///     Routing key
-    /// </summary>
-    public string RoutingKey { get; }
-
-    /// <summary>
-    ///     Queue
-    /// </summary>
-    public string Queue { get; }
-
-    /// <summary>
-    ///     Creates MessageReceivedInfo
-    /// </summary>
-    public MessageReceivedInfo(
-        string consumerTag,
-        ulong deliveryTag,
-        bool redelivered,
-        string exchange,
-        string routingKey,
-        string queue
-    )
-    {
-        ConsumerTag = consumerTag;
-        DeliveryTag = deliveryTag;
-        Redelivered = redelivered;
-        Exchange = exchange;
-        RoutingKey = routingKey;
-        Queue = queue;
-    }
-
-    /// <inheritdoc />
-    public override string ToString()
-    {
-        return $"[ConsumerTag={ConsumerTag}, DeliveryTag={DeliveryTag}, Redelivered={Redelivered}, Exchange={Exchange}, RoutingKey={RoutingKey}, Queue={Queue}]";
-    }
-}
+public readonly record struct MessageReceivedInfo(
+    string ConsumerTag,
+    ulong DeliveryTag,
+    bool Redelivered,
+    string Exchange,
+    string RoutingKey,
+    string Queue
+);

--- a/Source/EasyNetQ/MessageReturnedEventArgs.cs
+++ b/Source/EasyNetQ/MessageReturnedEventArgs.cs
@@ -6,7 +6,7 @@ public class MessageReturnedEventArgs : EventArgs
     public MessageProperties MessageProperties { get; }
     public MessageReturnedInfo MessageReturnedInfo { get; }
 
-    public MessageReturnedEventArgs(in ReadOnlyMemory<byte> messageBody, MessageProperties messageProperties, in MessageReturnedInfo messageReturnedInfo)
+    public MessageReturnedEventArgs(in ReadOnlyMemory<byte> messageBody, in MessageProperties messageProperties, in MessageReturnedInfo messageReturnedInfo)
     {
         MessageBody = messageBody;
         MessageProperties = messageProperties;

--- a/Source/EasyNetQ/ProducedMessage.cs
+++ b/Source/EasyNetQ/ProducedMessage.cs
@@ -10,7 +10,7 @@ public readonly struct ProducedMessage
     /// </summary>
     /// <param name="properties">The properties</param>
     /// <param name="body">The body</param>
-    public ProducedMessage(MessageProperties properties, in ReadOnlyMemory<byte> body)
+    public ProducedMessage(in MessageProperties properties, in ReadOnlyMemory<byte> body)
     {
         Properties = properties;
         Body = body;

--- a/Source/EasyNetQ/PullingConsumer.cs
+++ b/Source/EasyNetQ/PullingConsumer.cs
@@ -34,7 +34,7 @@ public interface IPullResult : IDisposable
 /// </summary>
 public readonly struct PullResult : IPullResult
 {
-    private readonly MessageReceivedInfo? receivedInfo;
+    private readonly MessageReceivedInfo receivedInfo;
     private readonly MessageProperties properties;
     private readonly ReadOnlyMemory<byte> body;
     private readonly ulong messagesCount;
@@ -43,7 +43,7 @@ public readonly struct PullResult : IPullResult
     /// <summary>
     ///     Represents a result when no message is available
     /// </summary>
-    public static PullResult NotAvailable { get; } = new(false, 0, null, default, null, null);
+    public static PullResult NotAvailable { get; } = new(false, 0, default, default, null, null);
 
     /// <summary>
     ///     Represents a result when a message is available
@@ -51,7 +51,7 @@ public readonly struct PullResult : IPullResult
     /// <returns></returns>
     public static PullResult Available(
         ulong messagesCount,
-        MessageReceivedInfo receivedInfo,
+        in MessageReceivedInfo receivedInfo,
         in MessageProperties properties,
         in ReadOnlyMemory<byte> body,
         IDisposable? disposable
@@ -63,7 +63,7 @@ public readonly struct PullResult : IPullResult
     private PullResult(
         bool isAvailable,
         ulong messagesCount,
-        MessageReceivedInfo? receivedInfo,
+        in MessageReceivedInfo receivedInfo,
         in MessageProperties properties,
         in ReadOnlyMemory<byte> body,
         IDisposable? disposable
@@ -108,7 +108,7 @@ public readonly struct PullResult : IPullResult
             if (!IsAvailable)
                 throw new InvalidOperationException("No message is available");
 
-            return receivedInfo!;
+            return receivedInfo;
         }
     }
 
@@ -154,14 +154,14 @@ public readonly struct PullResult : IPullResult
 /// </summary>
 public readonly struct PullResult<T> : IPullResult
 {
-    private readonly MessageReceivedInfo? receivedInfo;
+    private readonly MessageReceivedInfo receivedInfo;
     private readonly IMessage<T>? message;
     private readonly ulong messagesCount;
 
     /// <summary>
     ///     Represents a result when no message is available
     /// </summary>
-    public static PullResult<T> NotAvailable { get; } = new(false, 0, null, null);
+    public static PullResult<T> NotAvailable { get; } = new(false, 0, default, null);
 
     /// <summary>
     ///     Represents a result when a message is available
@@ -177,7 +177,7 @@ public readonly struct PullResult<T> : IPullResult
     private PullResult(
         bool isAvailable,
         ulong messagesCount,
-        MessageReceivedInfo? receivedInfo,
+        in MessageReceivedInfo receivedInfo,
         IMessage<T>? message
     )
     {
@@ -218,7 +218,7 @@ public readonly struct PullResult<T> : IPullResult
             if (!IsAvailable)
                 throw new InvalidOperationException("No message is available");
 
-            return receivedInfo!;
+            return receivedInfo;
         }
     }
 


### PR DESCRIPTION
Continues #1586

```
using EasyNetQ;

var cts = new CancellationTokenSource();
Console.CancelKeyPress += (_, _) => cts.Cancel();

using var bus = RabbitHutch.CreateBus(
    "host=localhost", x => x.EnableNewtonsoftJson().EnableAlwaysNackWithoutRequeueConsumerErrorStrategy()
);

var eventQueue = await bus.Advanced.QueueDeclareAsync(
    "events",
    c => c.WithQueueType(QueueType.Quorum)
        .WithOverflowType(OverflowType.RejectPublish),
    cts.Token
);

//for (var i = 0; i < 10_000_000; ++i)
//    await bus.Advanced.PublishAsync(Exchange.Default, "events", false, new MessageProperties(), ReadOnlyMemory<byte>.Empty, CancellationToken.None);

using var eventsConsumer1 = bus.Advanced.Consume(eventQueue, (_, _, _) => { });
using var eventsConsumer2 = bus.Advanced.Consume(eventQueue, (_, _, _) => { });
using var eventsConsumer3 = bus.Advanced.Consume(eventQueue, (_, _, _) => { });
using var eventsConsumer4 = bus.Advanced.Consume(eventQueue, (_, _, _) => { });
using var eventsConsumer5 = bus.Advanced.Consume(eventQueue, (_, _, _) => { });

await Task.Delay(5 * 60000);
```

Before:
<img width="1320" alt="Screenshot 2023-01-12 at 20 23 24" src="https://user-images.githubusercontent.com/664889/212175597-a5b659b1-f696-49b9-b3b0-70027214dd86.png">

After:
<img width="1324" alt="Screenshot 2023-01-12 at 20 33 37" src="https://user-images.githubusercontent.com/664889/212175635-ee1234b7-bc25-4210-a9dc-4f8043cb2a36.png">
