### PR TITLE
Reduce confirmation id allocations

### DIFF
--- a/Source/EasyNetQ.Tests/Internals/NumberHelpersTests.cs
+++ b/Source/EasyNetQ.Tests/Internals/NumberHelpersTests.cs
@@ -59,6 +59,6 @@ public class NumberHelpersTests
     {
         var bytes = Encoding.UTF8.GetBytes(value.ToString());
         NumberHelpers.TryParseULongFromBytes(bytes, out var result).Should().BeTrue();
-        result.Should().Be(ulong.Parse(Encoding.UTF8.GetString(bytes)));
+        result.Should().Be(value);
     }
 }

--- a/Source/EasyNetQ.Tests/Internals/NumberHelpersTests.cs
+++ b/Source/EasyNetQ.Tests/Internals/NumberHelpersTests.cs
@@ -1,0 +1,64 @@
+using System.Text;
+using EasyNetQ.Internals;
+
+namespace EasyNetQ.Tests.Internals;
+
+public class NumberHelpersTests
+{
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(1L)]
+    [InlineData(9L)]
+    [InlineData(10)]
+    [InlineData(99)]
+    [InlineData(100)]
+    [InlineData(999)]
+    [InlineData(1000)]
+    [InlineData(9999)]
+    [InlineData(10000)]
+    [InlineData(99999)]
+    [InlineData(ulong.MaxValue)]
+    public void TestDigitBytesCount(ulong value)
+    {
+        NumberHelpers.ULongBytesCount(value).Should().Be(value.ToString().Length);
+    }
+
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(1L)]
+    [InlineData(9L)]
+    [InlineData(10)]
+    [InlineData(99)]
+    [InlineData(100)]
+    [InlineData(999)]
+    [InlineData(1000)]
+    [InlineData(9999)]
+    [InlineData(10000)]
+    [InlineData(99999)]
+    [InlineData(ulong.MaxValue)]
+    public void TestToDigitBytes(ulong value)
+    {
+        NumberHelpers.FormatULongToBytes(value).Should().BeEquivalentTo(Encoding.UTF8.GetBytes(value.ToString()));
+    }
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(1L)]
+    [InlineData(9L)]
+    [InlineData(10)]
+    [InlineData(99)]
+    [InlineData(100)]
+    [InlineData(999)]
+    [InlineData(1000)]
+    [InlineData(9999)]
+    [InlineData(10000)]
+    [InlineData(99999)]
+    [InlineData(ulong.MaxValue)]
+    public void TestFromDigitBytes(ulong value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value.ToString());
+        NumberHelpers.TryParseULongFromBytes(bytes, out var result).Should().BeTrue();
+        result.Should().Be(ulong.Parse(Encoding.UTF8.GetString(bytes)));
+    }
+}

--- a/Source/EasyNetQ/Internals/NumberHelpers.cs
+++ b/Source/EasyNetQ/Internals/NumberHelpers.cs
@@ -45,7 +45,7 @@ internal static class NumberHelpers
             if (bytes[i] < '0' || bytes[i] > '9')
                 return false;
 
-            value = value * 10 + bytes[i] - '0';
+            value = value * 10 + (bytes[i] - '0');
         }
 
         return true;

--- a/Source/EasyNetQ/Internals/NumberHelpers.cs
+++ b/Source/EasyNetQ/Internals/NumberHelpers.cs
@@ -1,6 +1,6 @@
 namespace EasyNetQ.Internals;
 
-public static class NumberHelpers
+internal static class NumberHelpers
 {
     private static readonly ulong[] UlongDigitsCountLookup;
 

--- a/Source/EasyNetQ/Internals/NumberHelpers.cs
+++ b/Source/EasyNetQ/Internals/NumberHelpers.cs
@@ -45,7 +45,7 @@ internal static class NumberHelpers
             if (bytes[i] < '0' || bytes[i] > '9')
                 return false;
 
-            value = value * 10 + (bytes[i] - '0');
+            value = value * 10 + (ulong)(bytes[i] - '0');
         }
 
         return true;

--- a/Source/EasyNetQ/Internals/NumberHelpers.cs
+++ b/Source/EasyNetQ/Internals/NumberHelpers.cs
@@ -1,0 +1,53 @@
+namespace EasyNetQ.Internals;
+
+public static class NumberHelpers
+{
+    private static readonly ulong[] UlongDigitsCountLookup;
+
+    static NumberHelpers()
+    {
+        UlongDigitsCountLookup = new ulong[20];
+        UlongDigitsCountLookup[0] = 1;
+        for (var i = 1; i < UlongDigitsCountLookup.Length; ++i)
+            UlongDigitsCountLookup[i] = UlongDigitsCountLookup[i - 1] * 10;
+    }
+
+    public static int ULongBytesCount(ulong value)
+    {
+        if (value == 0) return 1;
+
+        var count = 0;
+        for (; count < UlongDigitsCountLookup.Length; count++)
+            if (UlongDigitsCountLookup[count] > value)
+                break;
+        return count;
+    }
+
+    public static byte[] FormatULongToBytes(ulong value)
+    {
+        var bytes = new byte[ULongBytesCount(value)];
+        for (var i = bytes.Length - 1; i >= 0; --i)
+        {
+            bytes[i] = (byte)('0' + value % 10);
+            value /= 10;
+        }
+        return bytes;
+    }
+
+    public static bool TryParseULongFromBytes(byte[] bytes, out ulong value)
+    {
+        value = 0;
+        if (bytes.Length == 0) return false;
+
+        // ReSharper disable once ForCanBeConvertedToForeach
+        for (var i = 0; i < bytes.Length; ++i)
+        {
+            if (bytes[i] < '0' || bytes[i] > '9')
+                return false;
+
+            value = value * 10 + bytes[i] - '0';
+        }
+
+        return true;
+    }
+}

--- a/Source/EasyNetQ/MessageProperties.cs
+++ b/Source/EasyNetQ/MessageProperties.cs
@@ -1,4 +1,3 @@
-using System.Collections.ObjectModel;
 using RabbitMQ.Client;
 
 namespace EasyNetQ;


### PR DESCRIPTION
```
using System.Text;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using ConsoleApp1;

BenchmarkRunner.Run<Benchmark>();

[MemoryDiagnoser(false)]
public class Benchmark
{
    [Benchmark]
    public ulong First()
    {
        ulong total = 0;
        for (var i = 0; i < 10 * 100 * 100 * 100; ++i)
        {
            var bytes = Encoding.UTF8.GetBytes(i.ToString());
            var valueBack = ulong.Parse(Encoding.UTF8.GetString(bytes));
            total += (ulong)(valueBack % 2 == 0 ? 1 : 0);
        }

        return total;
    } 
    
    [Benchmark]
    public ulong Second()
    {
        Span<char> charSpan = stackalloc char[20]; // length of ulong.MaxValue
        Span<byte> bytesSpan = stackalloc byte[20];

        ulong total = 0;
        for (var i = 0; i < 10 * 100 * 100 * 100; ++i)
        {
            var ok = i.TryFormat(charSpan, out var charsWritten);
            if (!ok)
                throw new InvalidOperationException("TryFormat failed"); // should not happen
            var writtenBytes = Encoding.UTF8.GetBytes(charSpan[..charsWritten], bytesSpan);
            var bytes = bytesSpan[..writtenBytes].ToArray();
            var valueBack = ulong.Parse(Encoding.UTF8.GetString(bytes));
            total += (ulong)(valueBack % 2 == 0 ? 1 : 0);
        }

        return total;
    }

    [Benchmark]
    public ulong Third()
    {
        ulong total = 0;
        for (ulong i = 0; i < 10 * 100 * 100 * 100; ++i)
        {
            var bytes = NumberHelpers.FormatULongToBytes(i);
            NumberHelpers.TryParseULongFromBytes(bytes, out var valueBack);
            total += (ulong)(valueBack % 2 == 0 ? 1 : 0);
        }
        return total;
    }
}
```
```
| Method |     Mean |   Error |   StdDev |  Allocated |
|------- |---------:|--------:|---------:|-----------:|
|  First | 715.1 ms | 2.25 ms |  2.11 ms | 1066.59 MB |
| Second | 388.9 ms | 0.62 ms |  0.55 ms |  685.88 MB |
|  Third | 281.8 ms | 6.52 ms | 19.22 ms |  305.18 MB |
```