### PR TITLE
IAdvancedBus.Publish should accept string as exchange

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -1441,7 +1441,7 @@ namespace EasyNetQ.Events
     }
     public readonly struct PublishedMessageEvent
     {
-        public PublishedMessageEvent(in string exchange, string routingKey, in EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
+        public PublishedMessageEvent(string exchange, string routingKey, in EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
         public System.ReadOnlyMemory<byte> Body { get; }
         public string Exchange { get; }
         public EasyNetQ.MessageProperties Properties { get; }

--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -45,8 +45,13 @@ namespace EasyNetQ
         public static System.Threading.Tasks.Task ExchangeDeleteAsync(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Exchange exchange, bool ifUnused = false, System.Threading.CancellationToken cancellationToken = default) { }
         public static void ExchangeUnbindAsync(this EasyNetQ.IAdvancedBus bus, string destinationExchange, string sourceExchange, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments, System.Threading.CancellationToken cancellationToken = default) { }
         public static EasyNetQ.QueueStats GetQueueStats(this EasyNetQ.IAdvancedBus bus, string queue, System.Threading.CancellationToken cancellationToken = default) { }
-        public static void Publish(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.MessageProperties messageProperties, System.ReadOnlyMemory<byte> body, System.Threading.CancellationToken cancellationToken = default) { }
-        public static void Publish<T>(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.IMessage<T> message, System.Threading.CancellationToken cancellationToken = default) { }
+        public static void Publish(this EasyNetQ.IAdvancedBus bus, string exchange, string routingKey, bool mandatory, in EasyNetQ.MessageProperties messageProperties, in System.ReadOnlyMemory<byte> body, System.Threading.CancellationToken cancellationToken = default) { }
+        public static void Publish(this EasyNetQ.IAdvancedBus bus, in EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, in EasyNetQ.MessageProperties messageProperties, in System.ReadOnlyMemory<byte> body, System.Threading.CancellationToken cancellationToken = default) { }
+        public static void Publish<T>(this EasyNetQ.IAdvancedBus bus, string exchange, string routingKey, bool mandatory, EasyNetQ.IMessage<T> message, System.Threading.CancellationToken cancellationToken = default) { }
+        public static void Publish<T>(this EasyNetQ.IAdvancedBus bus, in EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.IMessage<T> message, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.Task PublishAsync(this EasyNetQ.IAdvancedBus bus, in EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.IMessage message, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.Task PublishAsync(this EasyNetQ.IAdvancedBus bus, in EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, in EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.Task PublishAsync<T>(this EasyNetQ.IAdvancedBus bus, in EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.IMessage<T> message, System.Threading.CancellationToken cancellationToken = default) { }
         public static EasyNetQ.Topology.Queue QueueDeclare(this EasyNetQ.IAdvancedBus bus, System.Threading.CancellationToken cancellationToken = default) { }
         public static EasyNetQ.Topology.Queue QueueDeclare(this EasyNetQ.IAdvancedBus bus, string queue, System.Threading.CancellationToken cancellationToken = default) { }
         public static EasyNetQ.Topology.Queue QueueDeclare(this EasyNetQ.IAdvancedBus bus, string queue, System.Action<EasyNetQ.IQueueDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default) { }
@@ -311,9 +316,9 @@ namespace EasyNetQ
         System.Threading.Tasks.Task ExchangeDeleteAsync(string exchange, bool ifUnused = false, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task ExchangeUnbindAsync(string destinationExchange, string sourceExchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<EasyNetQ.QueueStats> GetQueueStatsAsync(string queue, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.Task PublishAsync(EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.IMessage message, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.Task PublishAsync(EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.Task PublishAsync<T>(EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.IMessage<T> message, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task PublishAsync(string exchange, string routingKey, bool mandatory, EasyNetQ.IMessage message, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task PublishAsync(string exchange, string routingKey, bool mandatory, EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task PublishAsync<T>(string exchange, string routingKey, bool mandatory, EasyNetQ.IMessage<T> message, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task QueueBindAsync(string queue, string exchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(string queue, System.Action<EasyNetQ.IQueueDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default);
@@ -833,9 +838,9 @@ namespace EasyNetQ
         public virtual System.Threading.Tasks.Task ExchangeDeleteAsync(string exchange, bool ifUnused = false, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.Task ExchangeUnbindAsync(string destinationExchange, string sourceExchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<EasyNetQ.QueueStats> GetQueueStatsAsync(string queue, System.Threading.CancellationToken cancellationToken) { }
-        public virtual System.Threading.Tasks.Task PublishAsync(EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.IMessage message, System.Threading.CancellationToken cancellationToken) { }
-        public virtual System.Threading.Tasks.Task PublishAsync(EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body, System.Threading.CancellationToken cancellationToken) { }
-        public virtual System.Threading.Tasks.Task PublishAsync<T>(EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.IMessage<T> message, System.Threading.CancellationToken cancellationToken) { }
+        public virtual System.Threading.Tasks.Task PublishAsync(string exchange, string routingKey, bool mandatory, EasyNetQ.IMessage message, System.Threading.CancellationToken cancellationToken) { }
+        public virtual System.Threading.Tasks.Task PublishAsync(string exchange, string routingKey, bool mandatory, EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body, System.Threading.CancellationToken cancellationToken) { }
+        public virtual System.Threading.Tasks.Task PublishAsync<T>(string exchange, string routingKey, bool mandatory, EasyNetQ.IMessage<T> message, System.Threading.CancellationToken cancellationToken) { }
         public virtual System.Threading.Tasks.Task QueueBindAsync(string queue, string exchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(string queue, System.Action<EasyNetQ.IQueueDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default) { }
@@ -1436,9 +1441,9 @@ namespace EasyNetQ.Events
     }
     public readonly struct PublishedMessageEvent
     {
-        public PublishedMessageEvent(in EasyNetQ.Topology.Exchange exchange, string routingKey, in EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
+        public PublishedMessageEvent(in string exchange, string routingKey, in EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body) { }
         public System.ReadOnlyMemory<byte> Body { get; }
-        public EasyNetQ.Topology.Exchange Exchange { get; }
+        public string Exchange { get; }
         public EasyNetQ.MessageProperties Properties { get; }
         public string RoutingKey { get; }
     }
@@ -1907,6 +1912,7 @@ namespace EasyNetQ.Topology
     }
     public readonly struct Exchange : EasyNetQ.Topology.IBindable
     {
+        public const string DefaultName = "";
         public Exchange(string name, string type = "direct", bool durable = true, bool autoDelete = false, System.Collections.Generic.IDictionary<string, object>? arguments = null) { }
         public System.Collections.Generic.IDictionary<string, object>? Arguments { get; }
         public bool IsAutoDelete { get; }

--- a/Source/EasyNetQ.Tests/MessagePropertiesTests.cs
+++ b/Source/EasyNetQ.Tests/MessagePropertiesTests.cs
@@ -1,5 +1,3 @@
-using System.Reflection;
-
 namespace EasyNetQ.Tests;
 
 public class MessagePropertiesTests

--- a/Source/EasyNetQ/AdvancedBusExtensions.cs
+++ b/Source/EasyNetQ/AdvancedBusExtensions.cs
@@ -402,6 +402,88 @@ public static class AdvancedBusExtensions
     }
 
     /// <summary>
+    /// Publish a message as a .NET type when the type is only known at runtime.
+    /// Use the generic version of this method <see cref="PublishAsync{T}"/> when you know the type of the message at compile time.
+    /// Task completes after publish has completed. If publisherConfirms=true is set in the connection string,
+    /// the task completes after an ACK is received. The task will throw on either NACK or timeout.
+    /// </summary>
+    /// <param name="bus">The bus instance</param>
+    /// <param name="exchange">The exchange to publish to</param>
+    /// <param name="routingKey">
+    /// The routing key for the message. The routing key is used for routing messages depending on the
+    /// exchange configuration.</param>
+    /// <param name="mandatory">
+    /// This flag tells the server how to react if the message cannot be routed to a queue.
+    /// If this flag is true, the server will return an unroutable message with a Return method.
+    /// If this flag is false, the server silently drops the message.
+    /// </param>
+    /// <param name="message">The message to publish</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    public static Task PublishAsync(
+        this IAdvancedBus bus,
+        in Exchange exchange,
+        string routingKey,
+        bool mandatory,
+        IMessage message,
+        CancellationToken cancellationToken = default
+    ) => bus.PublishAsync(exchange.Name, routingKey, mandatory, message, cancellationToken);
+
+    /// <summary>
+    /// Publish a message as a .NET type
+    /// Task completes after publish has completed. If publisherConfirms=true is set in the connection string,
+    /// the task completes after an ACK is received. The task will throw on either NACK or timeout.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="bus">The bus instance</param>
+    /// <param name="exchange">The exchange to publish to</param>
+    /// <param name="routingKey">
+    /// The routing key for the message. The routing key is used for routing messages depending on the
+    /// exchange configuration.</param>
+    /// <param name="mandatory">
+    /// This flag tells the server how to react if the message cannot be routed to a queue.
+    /// If this flag is true, the server will return an unroutable message with a Return method.
+    /// If this flag is false, the server silently drops the message.
+    /// </param>
+    /// <param name="message">The message to publish</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    public static Task PublishAsync<T>(
+        this IAdvancedBus bus,
+        in Exchange exchange,
+        string routingKey,
+        bool mandatory,
+        IMessage<T> message,
+        CancellationToken cancellationToken = default
+    ) => bus.PublishAsync(exchange.Name, routingKey, mandatory, message, cancellationToken);
+
+    /// <summary>
+    /// Publish a message as a byte array.
+    /// Task completes after publish has completed. If publisherConfirms=true is set in the connection string,
+    /// the task completes after an ACK is received. The task will throw on either NACK or timeout.
+    /// </summary>
+    /// <param name="bus">The bus instance</param>
+    /// <param name="exchange">The exchange to publish to</param>
+    /// <param name="routingKey">
+    /// The routing key for the message. The routing key is used for routing messages depending on the
+    /// exchange configuration.</param>
+    /// <param name="mandatory">
+    /// This flag tells the server how to react if the message cannot be routed to a queue.
+    /// If this flag is true, the server will return an unroutable message with a Return method.
+    /// If this flag is false, the server silently drops the message.
+    /// </param>
+    /// <param name="properties">The message properties</param>
+    /// <param name="body">The message body</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    public static Task PublishAsync(
+        this IAdvancedBus bus,
+        in Exchange exchange,
+        string routingKey,
+        bool mandatory,
+        in MessageProperties properties,
+        in ReadOnlyMemory<byte> body,
+        CancellationToken cancellationToken = default
+    ) => bus.PublishAsync(exchange.Name, routingKey, mandatory, properties, body, cancellationToken);
+
+    /// <summary>
     ///     Publish a message as a byte array
     /// </summary>
     /// <param name="bus">The bus instance</param>
@@ -420,11 +502,11 @@ public static class AdvancedBusExtensions
     /// <param name="cancellationToken">The cancellation token</param>
     public static void Publish(
         this IAdvancedBus bus,
-        Exchange exchange,
+        in Exchange exchange,
         string routingKey,
         bool mandatory,
-        MessageProperties messageProperties,
-        ReadOnlyMemory<byte> body,
+        in MessageProperties messageProperties,
+        in ReadOnlyMemory<byte> body,
         CancellationToken cancellationToken = default
     )
     {
@@ -452,7 +534,70 @@ public static class AdvancedBusExtensions
     /// <param name="cancellationToken">The cancellation token</param>
     public static void Publish<T>(
         this IAdvancedBus bus,
-        Exchange exchange,
+        in Exchange exchange,
+        string routingKey,
+        bool mandatory,
+        IMessage<T> message,
+        CancellationToken cancellationToken = default
+    )
+    {
+        bus.PublishAsync(exchange, routingKey, mandatory, message, cancellationToken)
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    /// <summary>
+    ///     Publish a message as a byte array
+    /// </summary>
+    /// <param name="bus">The bus instance</param>
+    /// <param name="exchange">The exchange to publish to</param>
+    /// <param name="routingKey">
+    ///     The routing key for the message. The routing key is used for routing messages depending on the
+    ///     exchange configuration.
+    /// </param>
+    /// <param name="mandatory">
+    ///     This flag tells the server how to react if the message cannot be routed to a queue.
+    ///     If this flag is true, the server will return an unroutable message with a Return method.
+    ///     If this flag is false, the server silently drops the message.
+    /// </param>
+    /// <param name="messageProperties">The message properties</param>
+    /// <param name="body">The message body</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    public static void Publish(
+        this IAdvancedBus bus,
+        string exchange,
+        string routingKey,
+        bool mandatory,
+        in MessageProperties messageProperties,
+        in ReadOnlyMemory<byte> body,
+        CancellationToken cancellationToken = default
+    )
+    {
+        bus.PublishAsync(exchange, routingKey, mandatory, messageProperties, body, cancellationToken)
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    /// <summary>
+    ///     Publish a message as a .NET type
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="bus">The bus instance</param>
+    /// <param name="exchange">The exchange to publish to</param>
+    /// <param name="routingKey">
+    ///     The routing key for the message. The routing key is used for routing messages depending on the
+    ///     exchange configuration.
+    /// </param>
+    /// <param name="mandatory">
+    ///     This flag tells the server how to react if the message cannot be routed to a queue.
+    ///     If this flag is true, the server will return an unroutable message with a Return method.
+    ///     If this flag is false, the server silently drops the message.
+    /// </param>
+    /// <param name="message">The message to publish</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    public static void Publish<T>(
+        this IAdvancedBus bus,
+        string exchange,
         string routingKey,
         bool mandatory,
         IMessage<T> message,

--- a/Source/EasyNetQ/DeadLetterExchangeAndMessageTtlScheduler.cs
+++ b/Source/EasyNetQ/DeadLetterExchangeAndMessageTtlScheduler.cs
@@ -84,7 +84,7 @@ public class DeadLetterExchangeAndMessageTtlScheduler : IScheduler
         };
         var advancedMessage = new Message<T>(message, properties);
         await advancedBus.PublishAsync(
-            futureExchange, topic, configuration.MandatoryPublish, advancedMessage, cts.Token
+            futureExchange.Name, topic, configuration.MandatoryPublish, advancedMessage, cts.Token
         ).ConfigureAwait(false);
     }
 }

--- a/Source/EasyNetQ/DefaultPubSub.cs
+++ b/Source/EasyNetQ/DefaultPubSub.cs
@@ -57,7 +57,7 @@ public class DefaultPubSub : IPubSub
             messageType, ExchangeType.Topic, cts.Token
         ).ConfigureAwait(false);
         await advancedBus.PublishAsync(
-            exchange, publishConfiguration.Topic, configuration.MandatoryPublish, advancedMessage, cts.Token
+            exchange.Name, publishConfiguration.Topic, configuration.MandatoryPublish, advancedMessage, cts.Token
         ).ConfigureAwait(false);
     }
 

--- a/Source/EasyNetQ/DefaultRpc.cs
+++ b/Source/EasyNetQ/DefaultRpc.cs
@@ -251,7 +251,7 @@ public class DefaultRpc : IRpc, IDisposable
         };
 
         var requestMessage = new Message<TRequest>(request, properties);
-        await advancedBus.PublishAsync(exchange, routingKey, mandatory, requestMessage, cancellationToken)
+        await advancedBus.PublishAsync(exchange.Name, routingKey, mandatory, requestMessage, cancellationToken)
             .ConfigureAwait(false);
     }
 
@@ -323,7 +323,7 @@ public class DefaultRpc : IRpc, IDisposable
                 }
             );
             await advancedBus.PublishAsync(
-                exchange,
+                exchange.Name,
                 requestMessage.Properties.ReplyTo!,
                 false,
                 responseMessage,
@@ -346,7 +346,7 @@ public class DefaultRpc : IRpc, IDisposable
                 }
             );
             await advancedBus.PublishAsync(
-                exchange,
+                exchange.Name,
                 requestMessage.Properties.ReplyTo!,
                 false,
                 responseMessage,

--- a/Source/EasyNetQ/DefaultSendReceive.cs
+++ b/Source/EasyNetQ/DefaultSendReceive.cs
@@ -51,7 +51,7 @@ public class DefaultSendReceive : ISendReceive
             DeliveryMode = messageDeliveryModeStrategy.GetDeliveryMode(typeof(T))
         };
         await advancedBus.PublishAsync(
-            Exchange.Default, queue, configuration.MandatoryPublish, new Message<T>(message, properties), cts.Token
+            Exchange.DefaultName, queue, configuration.MandatoryPublish, new Message<T>(message, properties), cts.Token
         ).ConfigureAwait(false);
     }
 

--- a/Source/EasyNetQ/DelayedExchangeScheduler.cs
+++ b/Source/EasyNetQ/DelayedExchangeScheduler.cs
@@ -69,7 +69,7 @@ public class DelayedExchangeScheduler : IScheduler
         }.WithDelay(delay);
 
         await advancedBus.PublishAsync(
-            futureExchange, topic, configuration.MandatoryPublish, new Message<T>(message, properties), cts.Token
+            futureExchange.Name, topic, configuration.MandatoryPublish, new Message<T>(message, properties), cts.Token
         ).ConfigureAwait(false);
     }
 }

--- a/Source/EasyNetQ/Events/PublishedMessageEvent.cs
+++ b/Source/EasyNetQ/Events/PublishedMessageEvent.cs
@@ -14,7 +14,7 @@ public readonly struct PublishedMessageEvent
     /// <param name="routingKey">The routing key</param>
     /// <param name="properties">The properties</param>
     /// <param name="body">The body</param>
-    public PublishedMessageEvent(in Exchange exchange, string routingKey, in MessageProperties properties, in ReadOnlyMemory<byte> body)
+    public PublishedMessageEvent(in string exchange, string routingKey, in MessageProperties properties, in ReadOnlyMemory<byte> body)
     {
         Exchange = exchange;
         RoutingKey = routingKey;
@@ -25,7 +25,7 @@ public readonly struct PublishedMessageEvent
     /// <summary>
     ///     The exchange name
     /// </summary>
-    public Exchange Exchange { get; }
+    public string Exchange { get; }
 
     /// <summary>
     ///     The routing key

--- a/Source/EasyNetQ/Events/PublishedMessageEvent.cs
+++ b/Source/EasyNetQ/Events/PublishedMessageEvent.cs
@@ -1,5 +1,3 @@
-using EasyNetQ.Topology;
-
 namespace EasyNetQ.Events;
 
 /// <summary>
@@ -14,7 +12,7 @@ public readonly struct PublishedMessageEvent
     /// <param name="routingKey">The routing key</param>
     /// <param name="properties">The properties</param>
     /// <param name="body">The body</param>
-    public PublishedMessageEvent(in string exchange, string routingKey, in MessageProperties properties, in ReadOnlyMemory<byte> body)
+    public PublishedMessageEvent(string exchange, string routingKey, in MessageProperties properties, in ReadOnlyMemory<byte> body)
     {
         Exchange = exchange;
         RoutingKey = routingKey;

--- a/Source/EasyNetQ/IAdvancedBus.cs
+++ b/Source/EasyNetQ/IAdvancedBus.cs
@@ -45,7 +45,7 @@ public interface IAdvancedBus
     /// <param name="message">The message to publish</param>
     /// <param name="cancellationToken">The cancellation token</param>
     Task PublishAsync(
-        Exchange exchange,
+        string exchange,
         string routingKey,
         bool mandatory,
         IMessage message,
@@ -70,7 +70,7 @@ public interface IAdvancedBus
     /// <param name="message">The message to publish</param>
     /// <param name="cancellationToken">The cancellation token</param>
     Task PublishAsync<T>(
-        Exchange exchange,
+        string exchange,
         string routingKey,
         bool mandatory,
         IMessage<T> message,
@@ -95,7 +95,7 @@ public interface IAdvancedBus
     /// <param name="body">The message body</param>
     /// <param name="cancellationToken">The cancellation token</param>
     Task PublishAsync(
-        Exchange exchange,
+        string exchange,
         string routingKey,
         bool mandatory,
         MessageProperties properties,

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -231,7 +231,7 @@ public class RabbitAdvancedBus : IAdvancedBus, IDisposable
 
     /// <inheritdoc />
     public virtual async Task PublishAsync(
-        Exchange exchange,
+        string exchange,
         string routingKey,
         bool mandatory,
         IMessage message,
@@ -246,7 +246,7 @@ public class RabbitAdvancedBus : IAdvancedBus, IDisposable
 
     /// <inheritdoc />
     public virtual async Task PublishAsync<T>(
-        Exchange exchange,
+        string exchange,
         string routingKey,
         bool mandatory,
         IMessage<T> message,
@@ -261,7 +261,7 @@ public class RabbitAdvancedBus : IAdvancedBus, IDisposable
 
     /// <inheritdoc />
     public virtual async Task PublishAsync(
-        Exchange exchange,
+        string exchange,
         string routingKey,
         bool mandatory,
         MessageProperties properties,
@@ -310,7 +310,7 @@ public class RabbitAdvancedBus : IAdvancedBus, IDisposable
         {
             logger.DebugFormat(
                 "Published to exchange {exchange} with routingKey={routingKey} and correlationId={correlationId}",
-                exchange.Name,
+                exchange,
                 routingKey,
                 properties.CorrelationId
             );
@@ -648,12 +648,12 @@ public class RabbitAdvancedBus : IAdvancedBus, IDisposable
 
     private readonly struct BasicPublishAction : IPersistentChannelAction<bool>
     {
-        private readonly Exchange exchange;
+        private readonly string exchange;
         private readonly string routingKey;
         private readonly bool mandatory;
         private readonly ProducedMessage message;
 
-        public BasicPublishAction(in Exchange exchange, string routingKey, bool mandatory, in ProducedMessage message)
+        public BasicPublishAction(string exchange, string routingKey, bool mandatory, in ProducedMessage message)
         {
             this.exchange = exchange;
             this.routingKey = routingKey;
@@ -665,7 +665,7 @@ public class RabbitAdvancedBus : IAdvancedBus, IDisposable
         {
             var basicProperties = model.CreateBasicProperties();
             message.Properties.CopyTo(basicProperties);
-            model.BasicPublish(exchange.Name, routingKey, mandatory, basicProperties, message.Body);
+            model.BasicPublish(exchange, routingKey, mandatory, basicProperties, message.Body);
             return true;
         }
     }
@@ -673,14 +673,14 @@ public class RabbitAdvancedBus : IAdvancedBus, IDisposable
     private readonly struct BasicPublishWithConfirmsAction : IPersistentChannelAction<IPublishPendingConfirmation>
     {
         private readonly IPublishConfirmationListener confirmationListener;
-        private readonly Exchange exchange;
+        private readonly string exchange;
         private readonly string routingKey;
         private readonly bool mandatory;
         private readonly ProducedMessage message;
 
         public BasicPublishWithConfirmsAction(
             IPublishConfirmationListener confirmationListener,
-            in Exchange exchange,
+            string exchange,
             string routingKey,
             bool mandatory,
             in ProducedMessage message
@@ -701,7 +701,7 @@ public class RabbitAdvancedBus : IAdvancedBus, IDisposable
                 .CopyTo(basicProperties);
             try
             {
-                model.BasicPublish(exchange.Name, routingKey, mandatory, basicProperties, message.Body);
+                model.BasicPublish(exchange, routingKey, mandatory, basicProperties, message.Body);
             }
             catch (Exception)
             {

--- a/Source/EasyNetQ/Topology/Exchange.cs
+++ b/Source/EasyNetQ/Topology/Exchange.cs
@@ -6,9 +6,14 @@ namespace EasyNetQ.Topology;
 public readonly struct Exchange : IBindable
 {
     /// <summary>
+    ///     Returns the default exchange name
+    /// </summary>
+    public const string DefaultName = "";
+
+    /// <summary>
     ///     Returns the default exchange
     /// </summary>
-    public static Exchange Default { get; } = new("");
+    public static Exchange Default { get; } = new(DefaultName);
 
     /// <summary>
     ///     Creates Exchange


### PR DESCRIPTION
There is no need to pass exchange struct here. It is in line with previous changed made for the topology manipulation methods.