### PR TITLE
Remove useless generic IAdvancedBus.Publish overload

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -47,11 +47,8 @@ namespace EasyNetQ
         public static EasyNetQ.QueueStats GetQueueStats(this EasyNetQ.IAdvancedBus bus, string queue, System.Threading.CancellationToken cancellationToken = default) { }
         public static void Publish(this EasyNetQ.IAdvancedBus bus, string exchange, string routingKey, bool mandatory, in EasyNetQ.MessageProperties messageProperties, in System.ReadOnlyMemory<byte> body, System.Threading.CancellationToken cancellationToken = default) { }
         public static void Publish(this EasyNetQ.IAdvancedBus bus, in EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, in EasyNetQ.MessageProperties messageProperties, in System.ReadOnlyMemory<byte> body, System.Threading.CancellationToken cancellationToken = default) { }
-        public static void Publish<T>(this EasyNetQ.IAdvancedBus bus, string exchange, string routingKey, bool mandatory, EasyNetQ.IMessage<T> message, System.Threading.CancellationToken cancellationToken = default) { }
-        public static void Publish<T>(this EasyNetQ.IAdvancedBus bus, in EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.IMessage<T> message, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task PublishAsync(this EasyNetQ.IAdvancedBus bus, in EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.IMessage message, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task PublishAsync(this EasyNetQ.IAdvancedBus bus, in EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, in EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body, System.Threading.CancellationToken cancellationToken = default) { }
-        public static System.Threading.Tasks.Task PublishAsync<T>(this EasyNetQ.IAdvancedBus bus, in EasyNetQ.Topology.Exchange exchange, string routingKey, bool mandatory, EasyNetQ.IMessage<T> message, System.Threading.CancellationToken cancellationToken = default) { }
         public static EasyNetQ.Topology.Queue QueueDeclare(this EasyNetQ.IAdvancedBus bus, System.Threading.CancellationToken cancellationToken = default) { }
         public static EasyNetQ.Topology.Queue QueueDeclare(this EasyNetQ.IAdvancedBus bus, string queue, System.Threading.CancellationToken cancellationToken = default) { }
         public static EasyNetQ.Topology.Queue QueueDeclare(this EasyNetQ.IAdvancedBus bus, string queue, System.Action<EasyNetQ.IQueueDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default) { }
@@ -318,7 +315,6 @@ namespace EasyNetQ
         System.Threading.Tasks.Task<EasyNetQ.QueueStats> GetQueueStatsAsync(string queue, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task PublishAsync(string exchange, string routingKey, bool mandatory, EasyNetQ.IMessage message, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task PublishAsync(string exchange, string routingKey, bool mandatory, EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.Task PublishAsync<T>(string exchange, string routingKey, bool mandatory, EasyNetQ.IMessage<T> message, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task QueueBindAsync(string queue, string exchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(string queue, System.Action<EasyNetQ.IQueueDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default);
@@ -840,7 +836,6 @@ namespace EasyNetQ
         public System.Threading.Tasks.Task<EasyNetQ.QueueStats> GetQueueStatsAsync(string queue, System.Threading.CancellationToken cancellationToken) { }
         public virtual System.Threading.Tasks.Task PublishAsync(string exchange, string routingKey, bool mandatory, EasyNetQ.IMessage message, System.Threading.CancellationToken cancellationToken) { }
         public virtual System.Threading.Tasks.Task PublishAsync(string exchange, string routingKey, bool mandatory, EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body, System.Threading.CancellationToken cancellationToken) { }
-        public virtual System.Threading.Tasks.Task PublishAsync<T>(string exchange, string routingKey, bool mandatory, EasyNetQ.IMessage<T> message, System.Threading.CancellationToken cancellationToken) { }
         public virtual System.Threading.Tasks.Task QueueBindAsync(string queue, string exchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(string queue, System.Action<EasyNetQ.IQueueDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default) { }

--- a/Source/EasyNetQ/AdvancedBusExtensions.cs
+++ b/Source/EasyNetQ/AdvancedBusExtensions.cs
@@ -403,7 +403,6 @@ public static class AdvancedBusExtensions
 
     /// <summary>
     /// Publish a message as a .NET type when the type is only known at runtime.
-    /// Use the generic version of this method <see cref="PublishAsync{T}"/> when you know the type of the message at compile time.
     /// Task completes after publish has completed. If publisherConfirms=true is set in the connection string,
     /// the task completes after an ACK is received. The task will throw on either NACK or timeout.
     /// </summary>
@@ -425,33 +424,6 @@ public static class AdvancedBusExtensions
         string routingKey,
         bool mandatory,
         IMessage message,
-        CancellationToken cancellationToken = default
-    ) => bus.PublishAsync(exchange.Name, routingKey, mandatory, message, cancellationToken);
-
-    /// <summary>
-    /// Publish a message as a .NET type
-    /// Task completes after publish has completed. If publisherConfirms=true is set in the connection string,
-    /// the task completes after an ACK is received. The task will throw on either NACK or timeout.
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="bus">The bus instance</param>
-    /// <param name="exchange">The exchange to publish to</param>
-    /// <param name="routingKey">
-    /// The routing key for the message. The routing key is used for routing messages depending on the
-    /// exchange configuration.</param>
-    /// <param name="mandatory">
-    /// This flag tells the server how to react if the message cannot be routed to a queue.
-    /// If this flag is true, the server will return an unroutable message with a Return method.
-    /// If this flag is false, the server silently drops the message.
-    /// </param>
-    /// <param name="message">The message to publish</param>
-    /// <param name="cancellationToken">The cancellation token</param>
-    public static Task PublishAsync<T>(
-        this IAdvancedBus bus,
-        in Exchange exchange,
-        string routingKey,
-        bool mandatory,
-        IMessage<T> message,
         CancellationToken cancellationToken = default
     ) => bus.PublishAsync(exchange.Name, routingKey, mandatory, message, cancellationToken);
 
@@ -516,37 +488,6 @@ public static class AdvancedBusExtensions
     }
 
     /// <summary>
-    ///     Publish a message as a .NET type
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="bus">The bus instance</param>
-    /// <param name="exchange">The exchange to publish to</param>
-    /// <param name="routingKey">
-    ///     The routing key for the message. The routing key is used for routing messages depending on the
-    ///     exchange configuration.
-    /// </param>
-    /// <param name="mandatory">
-    ///     This flag tells the server how to react if the message cannot be routed to a queue.
-    ///     If this flag is true, the server will return an unroutable message with a Return method.
-    ///     If this flag is false, the server silently drops the message.
-    /// </param>
-    /// <param name="message">The message to publish</param>
-    /// <param name="cancellationToken">The cancellation token</param>
-    public static void Publish<T>(
-        this IAdvancedBus bus,
-        in Exchange exchange,
-        string routingKey,
-        bool mandatory,
-        IMessage<T> message,
-        CancellationToken cancellationToken = default
-    )
-    {
-        bus.PublishAsync(exchange, routingKey, mandatory, message, cancellationToken)
-            .GetAwaiter()
-            .GetResult();
-    }
-
-    /// <summary>
     ///     Publish a message as a byte array
     /// </summary>
     /// <param name="bus">The bus instance</param>
@@ -574,37 +515,6 @@ public static class AdvancedBusExtensions
     )
     {
         bus.PublishAsync(exchange, routingKey, mandatory, messageProperties, body, cancellationToken)
-            .GetAwaiter()
-            .GetResult();
-    }
-
-    /// <summary>
-    ///     Publish a message as a .NET type
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="bus">The bus instance</param>
-    /// <param name="exchange">The exchange to publish to</param>
-    /// <param name="routingKey">
-    ///     The routing key for the message. The routing key is used for routing messages depending on the
-    ///     exchange configuration.
-    /// </param>
-    /// <param name="mandatory">
-    ///     This flag tells the server how to react if the message cannot be routed to a queue.
-    ///     If this flag is true, the server will return an unroutable message with a Return method.
-    ///     If this flag is false, the server silently drops the message.
-    /// </param>
-    /// <param name="message">The message to publish</param>
-    /// <param name="cancellationToken">The cancellation token</param>
-    public static void Publish<T>(
-        this IAdvancedBus bus,
-        string exchange,
-        string routingKey,
-        bool mandatory,
-        IMessage<T> message,
-        CancellationToken cancellationToken = default
-    )
-    {
-        bus.PublishAsync(exchange, routingKey, mandatory, message, cancellationToken)
             .GetAwaiter()
             .GetResult();
     }

--- a/Source/EasyNetQ/IAdvancedBus.cs
+++ b/Source/EasyNetQ/IAdvancedBus.cs
@@ -29,7 +29,6 @@ public interface IAdvancedBus
 
     /// <summary>
     /// Publish a message as a .NET type when the type is only known at runtime.
-    /// Use the generic version of this method <see cref="PublishAsync{T}"/> when you know the type of the message at compile time.
     /// Task completes after publish has completed. If publisherConfirms=true is set in the connection string,
     /// the task completes after an ACK is received. The task will throw on either NACK or timeout.
     /// </summary>
@@ -49,31 +48,6 @@ public interface IAdvancedBus
         string routingKey,
         bool mandatory,
         IMessage message,
-        CancellationToken cancellationToken = default
-    );
-
-    /// <summary>
-    /// Publish a message as a .NET type
-    /// Task completes after publish has completed. If publisherConfirms=true is set in the connection string,
-    /// the task completes after an ACK is received. The task will throw on either NACK or timeout.
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="exchange">The exchange to publish to</param>
-    /// <param name="routingKey">
-    /// The routing key for the message. The routing key is used for routing messages depending on the
-    /// exchange configuration.</param>
-    /// <param name="mandatory">
-    /// This flag tells the server how to react if the message cannot be routed to a queue.
-    /// If this flag is true, the server will return an unroutable message with a Return method.
-    /// If this flag is false, the server silently drops the message.
-    /// </param>
-    /// <param name="message">The message to publish</param>
-    /// <param name="cancellationToken">The cancellation token</param>
-    Task PublishAsync<T>(
-        string exchange,
-        string routingKey,
-        bool mandatory,
-        IMessage<T> message,
         CancellationToken cancellationToken = default
     );
 

--- a/Source/EasyNetQ/RabbitAdvancedBus.cs
+++ b/Source/EasyNetQ/RabbitAdvancedBus.cs
@@ -245,21 +245,6 @@ public class RabbitAdvancedBus : IAdvancedBus, IDisposable
     }
 
     /// <inheritdoc />
-    public virtual async Task PublishAsync<T>(
-        string exchange,
-        string routingKey,
-        bool mandatory,
-        IMessage<T> message,
-        CancellationToken cancellationToken
-    )
-    {
-        using var serializedMessage = messageSerializationStrategy.SerializeMessage(message);
-        await PublishAsync(
-            exchange, routingKey, mandatory, serializedMessage.Properties, serializedMessage.Body, cancellationToken
-        ).ConfigureAwait(false);
-    }
-
-    /// <inheritdoc />
     public virtual async Task PublishAsync(
         string exchange,
         string routingKey,


### PR DESCRIPTION
The method body is the same as for:

```
Task PublishAsync(
        string exchange,
        string routingKey,
        bool mandatory,
        IMessage message,
        CancellationToken cancellationToken = default
);
```

Also, `IMessage<T>` implements `IMessage`, so no changes are needed after removal.

I don`t see any advantages of having it.