### PR TITLE
Set a default ConnectionConfiguration.Name

### DIFF
--- a/Source/EasyNetQ/ConnectionConfigurationExtensions.cs
+++ b/Source/EasyNetQ/ConnectionConfigurationExtensions.cs
@@ -36,12 +36,13 @@ internal static class ConnectionConfigurationExtensions
             {
             }
 
+        configuration.Name ??= applicationName;
+
         AddValueIfNotExists(configuration.ClientProperties, "client_api", "EasyNetQ");
         AddValueIfNotExists(configuration.ClientProperties, "product", configuration.Product ?? applicationName);
         AddValueIfNotExists(configuration.ClientProperties, "platform", configuration.Platform ?? GetPlatform());
         AddValueIfNotExists(configuration.ClientProperties, "os", Environment.OSVersion.ToString());
         AddValueIfNotExists(configuration.ClientProperties, "version", GetApplicationVersion());
-        AddValueIfNotExists(configuration.ClientProperties, "connection_name", configuration.Name ?? applicationName);
         AddValueIfNotExists(configuration.ClientProperties, "easynetq_version", typeof(ConnectionConfigurationExtensions).Assembly.GetName().Version?.ToString() ?? "unknown");
         AddValueIfNotExists(configuration.ClientProperties, "application", applicationName);
         AddValueIfNotExists(configuration.ClientProperties, "application_location", applicationPath);


### PR DESCRIPTION
Original title: If ClientProvidedName is null use connection_name
Starting with EasyNetQ 7.0.0-beta6 the connection_name of a connection is undefined in the RabbitMQ Management UI.
Same bug reported in the past #986. Fixed in #1062. Commit a106dd779674a586362579313fafc3608c59432c broke it (Removal of the line `configuration.Name ??= applicationName;`).

RabbitMQ overrides client property "connection_name". https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/fc08f5a556e96f47198a7376e7ea4ff56d0730a1/projects/RabbitMQ.Client/client/impl/Connection.cs#L1122-L1126