### PR TITLE
Convert used as a dictionary key structs to record structs

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -196,11 +196,11 @@ namespace EasyNetQ
             public string QueueName { get; }
             public System.Action Unsubscribe { get; }
         }
-        protected readonly struct RpcKey
+        protected readonly struct RpcKey : System.IEquatable<EasyNetQ.DefaultRpc.RpcKey>
         {
-            public RpcKey(System.Type requestType, System.Type responseType) { }
-            public System.Type RequestType { get; }
-            public System.Type ResponseType { get; }
+            public RpcKey(System.Type RequestType, System.Type ResponseType) { }
+            public System.Type RequestType { get; set; }
+            public System.Type ResponseType { get; set; }
         }
     }
     public class DefaultSendReceive : EasyNetQ.ISendReceive

--- a/Source/EasyNetQ/DefaultRpc.cs
+++ b/Source/EasyNetQ/DefaultRpc.cs
@@ -356,17 +356,7 @@ public class DefaultRpc : IRpc, IDisposable
         }
     }
 
-    protected readonly struct RpcKey
-    {
-        public RpcKey(Type requestType, Type responseType)
-        {
-            RequestType = requestType;
-            ResponseType = responseType;
-        }
-
-        public Type RequestType { get; }
-        public Type ResponseType { get; }
-    }
+    protected readonly record struct RpcKey(Type RequestType, Type ResponseType);
 
     protected readonly struct ResponseAction
     {

--- a/Source/EasyNetQ/DefaultTypeNameSerializer.cs
+++ b/Source/EasyNetQ/DefaultTypeNameSerializer.cs
@@ -217,15 +217,5 @@ public class DefaultTypeNameSerializer : ITypeNameSerializer
         return null;
     }
 
-    private readonly struct TypeNameKey
-    {
-        public string? AssemblyName { get; }
-        public string TypeName { get; }
-
-        public TypeNameKey(string? assemblyName, string typeName)
-        {
-            AssemblyName = assemblyName;
-            TypeName = typeName;
-        }
-    }
+    private readonly record struct TypeNameKey(string? AssemblyName, string TypeName);
 }

--- a/Source/EasyNetQ/MessageVersioning/VersionedExchangeDeclareStrategy.cs
+++ b/Source/EasyNetQ/MessageVersioning/VersionedExchangeDeclareStrategy.cs
@@ -47,16 +47,5 @@ public class VersionedExchangeDeclareStrategy : IExchangeDeclareStrategy
         return destinationExchange ?? throw new ArgumentOutOfRangeException(nameof(messageVersions));
     }
 
-    private readonly struct ExchangeKey
-    {
-        public ExchangeKey(string name, string type)
-        {
-            Name = name;
-            Type = type;
-        }
-
-        public string Name { get; }
-
-        public string Type { get; }
-    }
+    private readonly record struct ExchangeKey(string Name, string Type);
 }

--- a/Source/EasyNetQ/MultipleExchange/MultipleExchangeDeclareStrategy.cs
+++ b/Source/EasyNetQ/MultipleExchange/MultipleExchangeDeclareStrategy.cs
@@ -42,16 +42,5 @@ public class MultipleExchangeDeclareStrategy : IExchangeDeclareStrategy
         return declaredExchanges.GetOrAddAsync(new ExchangeKey(exchangeName, exchangeType), cancellationToken);
     }
 
-    private readonly struct ExchangeKey
-    {
-        public ExchangeKey(string name, string type)
-        {
-            Name = name;
-            Type = type;
-        }
-
-        public string Name { get; }
-
-        public string Type { get; }
-    }
+    private readonly record struct ExchangeKey(string Name, string Type);
 }

--- a/Source/EasyNetQ/Producer/DefaultExchangeDeclareStrategy.cs
+++ b/Source/EasyNetQ/Producer/DefaultExchangeDeclareStrategy.cs
@@ -28,16 +28,5 @@ public class DefaultExchangeDeclareStrategy : IExchangeDeclareStrategy
         return DeclareExchangeAsync(exchangeName, exchangeType, cancellationToken);
     }
 
-    private readonly struct ExchangeKey
-    {
-        public ExchangeKey(string name, string type)
-        {
-            Name = name;
-            Type = type;
-        }
-
-        public string Name { get; }
-
-        public string Type { get; }
-    }
+    private readonly record struct ExchangeKey(string Name, string Type);
 }


### PR DESCRIPTION
These structs were boxed due to lack of IEquatable implementation. Their conversion to records is one of the way to eliminate the boxing.

Before:

<img width="1347" alt="image" src="https://user-images.githubusercontent.com/664889/215322154-59369424-8894-4359-b1c0-020463a1c4ec.png">


After:

<img width="1353" alt="image" src="https://user-images.githubusercontent.com/664889/215321821-8df5705c-e9f1-4939-b093-af181fcc962d.png">
