### PR TITLE
PersistentChannel.InvokeChannelActionAsync fast path optimizations

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -1532,7 +1532,7 @@ namespace EasyNetQ.Internals
         public EasyNetQ.Internals.AsyncLock.Releaser Acquire(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task<EasyNetQ.Internals.AsyncLock.Releaser> AcquireAsync(System.Threading.CancellationToken cancellationToken = default) { }
         public void Dispose() { }
-        public bool TryAcquireImmediately(out EasyNetQ.Internals.AsyncLock.Releaser result) { }
+        public bool TryAcquire(out EasyNetQ.Internals.AsyncLock.Releaser result) { }
         public readonly struct Releaser : System.IDisposable
         {
             public Releaser(System.Threading.SemaphoreSlim? semaphore) { }

--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -1043,14 +1043,14 @@ namespace EasyNetQ.ChannelDispatcher
 {
     public interface IPersistentChannelDispatcher
     {
-        System.Threading.Tasks.Task<TResult> InvokeAsync<TResult, TChannelAction>(TChannelAction channelAction, EasyNetQ.ChannelDispatcher.PersistentChannelDispatchOptions options, System.Threading.CancellationToken cancellationToken = default)
+        System.Threading.Tasks.ValueTask<TResult> InvokeAsync<TResult, TChannelAction>(TChannelAction channelAction, EasyNetQ.ChannelDispatcher.PersistentChannelDispatchOptions options, System.Threading.CancellationToken cancellationToken = default)
             where TChannelAction :  struct, EasyNetQ.Persistent.IPersistentChannelAction<TResult>;
     }
     public sealed class MultiPersistentChannelDispatcher : EasyNetQ.ChannelDispatcher.IPersistentChannelDispatcher, System.IDisposable
     {
         public MultiPersistentChannelDispatcher(int channelsCount, EasyNetQ.Producer.IProducerConnection producerConnection, EasyNetQ.Consumer.IConsumerConnection consumerConnection, EasyNetQ.Persistent.IPersistentChannelFactory channelFactory) { }
         public void Dispose() { }
-        public System.Threading.Tasks.Task<TResult> InvokeAsync<TResult, TChannelAction>(TChannelAction channelAction, EasyNetQ.ChannelDispatcher.PersistentChannelDispatchOptions options, System.Threading.CancellationToken cancellationToken = default)
+        public System.Threading.Tasks.ValueTask<TResult> InvokeAsync<TResult, TChannelAction>(TChannelAction channelAction, EasyNetQ.ChannelDispatcher.PersistentChannelDispatchOptions options, System.Threading.CancellationToken cancellationToken = default)
             where TChannelAction :  struct, EasyNetQ.Persistent.IPersistentChannelAction<TResult> { }
     }
     public class PersistentChannelDispatchOptions
@@ -1070,7 +1070,7 @@ namespace EasyNetQ.ChannelDispatcher
     {
         public SinglePersistentChannelDispatcher(EasyNetQ.Producer.IProducerConnection producerConnection, EasyNetQ.Consumer.IConsumerConnection consumerConnection, EasyNetQ.Persistent.IPersistentChannelFactory channelFactory) { }
         public void Dispose() { }
-        public System.Threading.Tasks.Task<TResult> InvokeAsync<TResult, TChannelAction>(TChannelAction channelAction, EasyNetQ.ChannelDispatcher.PersistentChannelDispatchOptions options, System.Threading.CancellationToken cancellationToken = default)
+        public System.Threading.Tasks.ValueTask<TResult> InvokeAsync<TResult, TChannelAction>(TChannelAction channelAction, EasyNetQ.ChannelDispatcher.PersistentChannelDispatchOptions options, System.Threading.CancellationToken cancellationToken = default)
             where TChannelAction :  struct, EasyNetQ.Persistent.IPersistentChannelAction<TResult> { }
     }
 }
@@ -1532,9 +1532,10 @@ namespace EasyNetQ.Internals
         public EasyNetQ.Internals.AsyncLock.Releaser Acquire(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task<EasyNetQ.Internals.AsyncLock.Releaser> AcquireAsync(System.Threading.CancellationToken cancellationToken = default) { }
         public void Dispose() { }
+        public bool TryAcquireImmediately(out EasyNetQ.Internals.AsyncLock.Releaser result) { }
         public readonly struct Releaser : System.IDisposable
         {
-            public Releaser(System.Threading.SemaphoreSlim semaphore) { }
+            public Releaser(System.Threading.SemaphoreSlim? semaphore) { }
             public void Dispose() { }
         }
     }
@@ -1772,7 +1773,7 @@ namespace EasyNetQ.Persistent
     }
     public interface IPersistentChannel : System.IDisposable
     {
-        System.Threading.Tasks.Task<TResult> InvokeChannelActionAsync<TResult, TChannelAction>(TChannelAction channelAction, System.Threading.CancellationToken cancellationToken = default)
+        System.Threading.Tasks.ValueTask<TResult> InvokeChannelActionAsync<TResult, TChannelAction>(TChannelAction channelAction, System.Threading.CancellationToken cancellationToken = default)
             where TChannelAction :  struct, EasyNetQ.Persistent.IPersistentChannelAction<TResult>;
     }
     public interface IPersistentChannelAction<out TResult>
@@ -1793,7 +1794,7 @@ namespace EasyNetQ.Persistent
     {
         public PersistentChannel(in EasyNetQ.Persistent.PersistentChannelOptions options, EasyNetQ.Logging.ILogger<EasyNetQ.Persistent.PersistentChannel> logger, EasyNetQ.Persistent.IPersistentConnection connection, EasyNetQ.IEventBus eventBus) { }
         public void Dispose() { }
-        public System.Threading.Tasks.Task<TResult> InvokeChannelActionAsync<TResult, TChannelAction>(TChannelAction channelAction, System.Threading.CancellationToken cancellationToken = default)
+        public System.Threading.Tasks.ValueTask<TResult> InvokeChannelActionAsync<TResult, TChannelAction>(TChannelAction channelAction, System.Threading.CancellationToken cancellationToken = default)
             where TChannelAction :  struct, EasyNetQ.Persistent.IPersistentChannelAction<TResult> { }
     }
     public class PersistentChannelFactory : EasyNetQ.Persistent.IPersistentChannelFactory

--- a/Source/EasyNetQ.Tests/ChannelDispatcherTests/When_an_action_is_invoked_that_throws_using_multi_channel.cs
+++ b/Source/EasyNetQ.Tests/ChannelDispatcherTests/When_an_action_is_invoked_that_throws_using_multi_channel.cs
@@ -34,7 +34,7 @@ public class When_an_action_is_invoked_that_throws_using_multi_channel : IDispos
     public async Task Should_raise_the_exception_on_the_calling_thread()
     {
         await Assert.ThrowsAsync<CrazyTestOnlyException>(
-            () => dispatcher.InvokeAsync<int>(_ => throw new CrazyTestOnlyException(), PersistentChannelDispatchOptions.ProducerTopology)
+            () => dispatcher.InvokeAsync<int>(_ => throw new CrazyTestOnlyException(), PersistentChannelDispatchOptions.ProducerTopology).AsTask()
         );
     }
 
@@ -42,7 +42,7 @@ public class When_an_action_is_invoked_that_throws_using_multi_channel : IDispos
     public async Task Should_call_action_when_previous_threw_an_exception()
     {
         await Assert.ThrowsAsync<Exception>(
-            () => dispatcher.InvokeAsync<int>(_ => throw new Exception(), PersistentChannelDispatchOptions.ProducerTopology)
+            () => dispatcher.InvokeAsync<int>(_ => throw new Exception(), PersistentChannelDispatchOptions.ProducerTopology).AsTask()
         );
 
         var result = await dispatcher.InvokeAsync(_ => 42, PersistentChannelDispatchOptions.ProducerTopology);

--- a/Source/EasyNetQ.Tests/ChannelDispatcherTests/When_an_action_is_invoked_that_throws_using_single_channel.cs
+++ b/Source/EasyNetQ.Tests/ChannelDispatcherTests/When_an_action_is_invoked_that_throws_using_single_channel.cs
@@ -34,7 +34,7 @@ public class When_an_action_is_invoked_that_throws_using_single_channel : IDispo
     public async Task Should_raise_the_exception_on_the_calling_thread()
     {
         await Assert.ThrowsAsync<CrazyTestOnlyException>(
-            () => dispatcher.InvokeAsync<int>(_ => throw new CrazyTestOnlyException(), PersistentChannelDispatchOptions.ProducerTopology)
+            () => dispatcher.InvokeAsync<int>(_ => throw new CrazyTestOnlyException(), PersistentChannelDispatchOptions.ProducerTopology).AsTask()
         );
     }
 
@@ -42,7 +42,7 @@ public class When_an_action_is_invoked_that_throws_using_single_channel : IDispo
     public async Task Should_call_action_when_previous_threw_an_exception()
     {
         await Assert.ThrowsAsync<Exception>(
-            () => dispatcher.InvokeAsync<int>(_ => throw new Exception(), PersistentChannelDispatchOptions.ProducerTopology)
+            () => dispatcher.InvokeAsync<int>(_ => throw new Exception(), PersistentChannelDispatchOptions.ProducerTopology).AsTask()
         );
 
         var result = await dispatcher.InvokeAsync(_ => 42, PersistentChannelDispatchOptions.ProducerTopology);

--- a/Source/EasyNetQ/ChannelDispatcher/IPersistentChannelDispatcher.cs
+++ b/Source/EasyNetQ/ChannelDispatcher/IPersistentChannelDispatcher.cs
@@ -16,7 +16,7 @@ public interface IPersistentChannelDispatcher
     /// <typeparam name="TResult"></typeparam>
     /// <typeparam name="TChannelAction"></typeparam>
     /// <returns></returns>
-    Task<TResult> InvokeAsync<TResult, TChannelAction>(
+    ValueTask<TResult> InvokeAsync<TResult, TChannelAction>(
         TChannelAction channelAction,
         PersistentChannelDispatchOptions options,
         CancellationToken cancellationToken = default

--- a/Source/EasyNetQ/ChannelDispatcher/MultiPersistentChannelDispatcher.cs
+++ b/Source/EasyNetQ/ChannelDispatcher/MultiPersistentChannelDispatcher.cs
@@ -58,7 +58,7 @@ public sealed class MultiPersistentChannelDispatcher : IPersistentChannelDispatc
     }
 
     /// <inheritdoc />
-    public async Task<TResult> InvokeAsync<TResult, TChannelAction>(
+    public async ValueTask<TResult> InvokeAsync<TResult, TChannelAction>(
         TChannelAction channelAction,
         PersistentChannelDispatchOptions options,
         CancellationToken cancellationToken = default

--- a/Source/EasyNetQ/ChannelDispatcher/PersistentChannelDispatcherExtensions.cs
+++ b/Source/EasyNetQ/ChannelDispatcher/PersistentChannelDispatcherExtensions.cs
@@ -5,7 +5,7 @@ namespace EasyNetQ.ChannelDispatcher;
 
 internal static class PersistentChannelDispatcherExtensions
 {
-    public static Task InvokeAsync(
+    public static ValueTask<bool> InvokeAsync(
         this IPersistentChannelDispatcher dispatcher,
         Action<IModel> channelAction,
         PersistentChannelDispatchOptions options,
@@ -17,7 +17,7 @@ internal static class PersistentChannelDispatcherExtensions
         );
     }
 
-    public static Task<TResult> InvokeAsync<TResult>(
+    public static ValueTask<TResult> InvokeAsync<TResult>(
         this IPersistentChannelDispatcher dispatcher,
         Func<IModel, TResult> channelAction,
         PersistentChannelDispatchOptions options,

--- a/Source/EasyNetQ/ChannelDispatcher/SinglePersistentChannelDispatcher.cs
+++ b/Source/EasyNetQ/ChannelDispatcher/SinglePersistentChannelDispatcher.cs
@@ -41,7 +41,7 @@ public sealed class SinglePersistentChannelDispatcher : IPersistentChannelDispat
     }
 
     /// <inheritdoc />
-    public Task<TResult> InvokeAsync<TResult, TChannelAction>(
+    public ValueTask<TResult> InvokeAsync<TResult, TChannelAction>(
         TChannelAction channelAction,
         PersistentChannelDispatchOptions options,
         CancellationToken cancellationToken = default

--- a/Source/EasyNetQ/Internals/AsyncLock.cs
+++ b/Source/EasyNetQ/Internals/AsyncLock.cs
@@ -50,9 +50,10 @@ public readonly struct AsyncLock : IDisposable
     }
 
     /// <summary>
-    /// Tries to acquires a lock
+    /// Tries to acquire a lock
     /// </summary>
-    /// <returns>Releaser, which should be disposed to release a lock</returns>
+    /// <param name="result">Releaser, which should be disposed to release a lock</param>
+    /// <returns>True if acquired</returns>
     public bool TryAcquireImmediately(out Releaser result)
     {
         if (semaphore.Wait(0))

--- a/Source/EasyNetQ/Internals/AsyncLock.cs
+++ b/Source/EasyNetQ/Internals/AsyncLock.cs
@@ -54,7 +54,7 @@ public readonly struct AsyncLock : IDisposable
     /// </summary>
     /// <param name="result">Releaser, which should be disposed to release a lock</param>
     /// <returns>True if acquired</returns>
-    public bool TryAcquireImmediately(out Releaser result)
+    public bool TryAcquire(out Releaser result)
     {
         if (semaphore.Wait(0))
         {

--- a/Source/EasyNetQ/Internals/AsyncLock.cs
+++ b/Source/EasyNetQ/Internals/AsyncLock.cs
@@ -49,13 +49,29 @@ public readonly struct AsyncLock : IDisposable
         return releaser;
     }
 
+    /// <summary>
+    /// Acquires a lock
+    /// </summary>
+    /// <returns>Releaser, which should be disposed to release a lock</returns>
+    public bool TryAcquireImmediately(out Releaser result)
+    {
+        if (semaphore.Wait(0))
+        {
+            result = releaser;
+            return true;
+        }
+
+        result = default;
+        return false;
+    }
+
     public readonly struct Releaser : IDisposable
     {
-        private readonly SemaphoreSlim semaphore;
+        private readonly SemaphoreSlim? semaphore;
 
-        public Releaser(SemaphoreSlim semaphore) => this.semaphore = semaphore;
+        public Releaser(SemaphoreSlim? semaphore) => this.semaphore = semaphore;
 
-        public void Dispose() => semaphore.Release();
+        public void Dispose() => semaphore?.Release();
     }
 
     /// <inheritdoc />

--- a/Source/EasyNetQ/Internals/AsyncLock.cs
+++ b/Source/EasyNetQ/Internals/AsyncLock.cs
@@ -50,7 +50,7 @@ public readonly struct AsyncLock : IDisposable
     }
 
     /// <summary>
-    /// Acquires a lock
+    /// Tries to acquires a lock
     /// </summary>
     /// <returns>Releaser, which should be disposed to release a lock</returns>
     public bool TryAcquireImmediately(out Releaser result)

--- a/Source/EasyNetQ/Persistent/IPersistentChannel.cs
+++ b/Source/EasyNetQ/Persistent/IPersistentChannel.cs
@@ -23,7 +23,7 @@ public interface IPersistentChannel : IDisposable
     /// </summary>
     /// <param name="channelAction">The action to invoke</param>
     /// <param name="cancellationToken">The cancellation token</param>
-    Task<TResult> InvokeChannelActionAsync<TResult, TChannelAction>(
+    ValueTask<TResult> InvokeChannelActionAsync<TResult, TChannelAction>(
         TChannelAction channelAction, CancellationToken cancellationToken = default
     ) where TChannelAction : struct, IPersistentChannelAction<TResult>;
 }

--- a/Source/EasyNetQ/Persistent/PersistentChannel.cs
+++ b/Source/EasyNetQ/Persistent/PersistentChannel.cs
@@ -78,7 +78,7 @@ public class PersistentChannel : IPersistentChannel
         in TChannelAction channelAction, [MaybeNullWhen(false)] out TResult result
     ) where TChannelAction : struct, IPersistentChannelAction<TResult>
     {
-        if (mutex.TryAcquireImmediately(out var releaser))
+        if (mutex.TryAcquire(out var releaser))
         {
             try
             {

--- a/Source/EasyNetQ/Persistent/PersistentChannel.cs
+++ b/Source/EasyNetQ/Persistent/PersistentChannel.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using EasyNetQ.Events;
 using EasyNetQ.Internals;
 using EasyNetQ.Logging;
@@ -46,13 +47,71 @@ public class PersistentChannel : IPersistentChannel
     }
 
     /// <inheritdoc />
-    public async Task<TResult> InvokeChannelActionAsync<TResult, TChannelAction>(
+    public ValueTask<TResult> InvokeChannelActionAsync<TResult, TChannelAction>(
         TChannelAction channelAction, CancellationToken cancellationToken = default
     ) where TChannelAction : struct, IPersistentChannelAction<TResult>
     {
         if (disposed)
             throw new ObjectDisposedException(nameof(PersistentChannel));
 
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return TryInvokeChannelActionFast<TResult, TChannelAction>(channelAction, out var result)
+            ? new ValueTask<TResult>(result)
+            : new ValueTask<TResult>(InvokeChannelActionSlowAsync<TResult, TChannelAction>(channelAction, cancellationToken));
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (disposed)
+            return;
+
+        disposed = true;
+        disposeCts.Cancel();
+        mutex.Dispose();
+        CloseChannel();
+        disposeCts.Dispose();
+    }
+
+    private bool TryInvokeChannelActionFast<TResult, TChannelAction>(
+        in TChannelAction channelAction, [MaybeNullWhen(false)] out TResult result
+    ) where TChannelAction : struct, IPersistentChannelAction<TResult>
+    {
+        if (mutex.TryAcquireImmediately(out var releaser))
+        {
+            try
+            {
+                var channel = initializedChannel ??= CreateChannel();
+                // ReSharper disable once PossiblyImpureMethodCallOnReadonlyVariable
+                result = channelAction.Invoke(channel);
+                return true;
+            }
+            catch (Exception exception)
+            {
+                var exceptionVerdict = GetExceptionVerdict(exception);
+                if (exceptionVerdict.CloseChannel)
+                    CloseChannel();
+
+                if (exceptionVerdict.Rethrow)
+                    throw;
+
+                logger.Error(exception, "Failed to invoke channel action, invocation will be retried");
+            }
+            finally
+            {
+                releaser.Dispose();
+            }
+        }
+
+        result = default;
+        return false;
+    }
+
+    private async Task<TResult> InvokeChannelActionSlowAsync<TResult, TChannelAction>(
+        TChannelAction channelAction, CancellationToken cancellationToken = default
+    ) where TChannelAction : struct, IPersistentChannelAction<TResult>
+    {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, disposeCts.Token);
         using var _ = await mutex.AcquireAsync(cts.Token).ConfigureAwait(false);
 
@@ -82,19 +141,6 @@ public class PersistentChannel : IPersistentChannel
             await Task.Delay(retryTimeoutMs, cts.Token).ConfigureAwait(false);
             retryTimeoutMs = Math.Min(retryTimeoutMs * 2, MaxRetryTimeoutMs);
         }
-    }
-
-    /// <inheritdoc />
-    public void Dispose()
-    {
-        if (disposed)
-            return;
-
-        disposed = true;
-        disposeCts.Cancel();
-        mutex.Dispose();
-        CloseChannel();
-        disposeCts.Dispose();
     }
 
     private IModel CreateChannel()

--- a/Source/EasyNetQ/Persistent/PersistentChannel.cs
+++ b/Source/EasyNetQ/Persistent/PersistentChannel.cs
@@ -96,7 +96,7 @@ public class PersistentChannel : IPersistentChannel
                 if (exceptionVerdict.Rethrow)
                     throw;
 
-                logger.Error(exception, "Failed to invoke channel action, invocation will be retried");
+                logger.Error(exception, "Failed to fast invoke channel action, invocation will be retried");
             }
             finally
             {

--- a/Source/EasyNetQ/Persistent/PersistentChannelExtensions.cs
+++ b/Source/EasyNetQ/Persistent/PersistentChannelExtensions.cs
@@ -13,7 +13,7 @@ internal static class PersistentChannelExtensions
             .GetResult();
     }
 
-    public static Task InvokeChannelActionAsync(
+    public static ValueTask<bool> InvokeChannelActionAsync(
         this IPersistentChannel source, Action<IModel> channelAction, CancellationToken cancellationToken = default
     )
     {
@@ -22,7 +22,7 @@ internal static class PersistentChannelExtensions
         );
     }
 
-    public static Task<TResult> InvokeChannelActionAsync<TResult>(
+    public static ValueTask<TResult> InvokeChannelActionAsync<TResult>(
         this IPersistentChannel source, Func<IModel, TResult> channelAction, CancellationToken cancellationToken = default
     )
     {


### PR DESCRIPTION
The goal of this PR is aimed to optimise the most frequent path for low concurrent execution scenarios in PersistentChannel: 
1. To execute w/o CancellationTokenSource, because there is nothing to cancel.
2. Switch to ValueTask from Task and avoid state machine allocations.

Downside of this approach is double invocations of `Semaphore.Wait`/`Semaphore.WaitAsync`, but it should be not so bad.

Simple low concurrency tests show small speedup(~5 percentages) and a reduction of memory allocations. Before conversion of this draft to PR, I am going to prepare all necessary benchmarks.