### PR TITLE
Stop retrying authentication failures

### DIFF
--- a/Source/EasyNetQ/Persistent/PersistentChannel.cs
+++ b/Source/EasyNetQ/Persistent/PersistentChannel.cs
@@ -202,8 +202,11 @@ public class PersistentChannel : IPersistentChannel
                 return isRequestPipeliningForbiddenException
                     ? ExceptionVerdict.SuppressAndCloseChannel
                     : ExceptionVerdict.Throw;
-            case BrokerUnreachableException:
-                return ExceptionVerdict.Suppress;
+            case BrokerUnreachableException e:
+                var isAuthenticationFailureException = e.InnerException is AuthenticationFailureException;
+                return isAuthenticationFailureException
+                    ? ExceptionVerdict.Throw
+                    : ExceptionVerdict.Suppress;
             case EasyNetQException:
                 return ExceptionVerdict.Suppress;
             default:


### PR DESCRIPTION
If login or password are invalid, the following exception is raised. 
```
RabbitMQ.Client.Exceptions.BrokerUnreachableException: None of the specified endpoints were reachable
 ---> RabbitMQ.Client.Exceptions.AuthenticationFailureException: ACCESS_REFUSED - Login was refused using authentication mechanism PLAIN. For details see the broker logfile.
   at RabbitMQ.Client.Framing.Impl.Connection.StartAndTune()
   at RabbitMQ.Client.Framing.Impl.Connection.Open(Boolean insist)
   at RabbitMQ.Client.Framing.Impl.Connection..ctor(IConnectionFactory factory, Boolean insist, IFrameHandler frameHandler, String clientProvidedName)
   at RabbitMQ.Client.Framing.Impl.Connection..ctor(IConnectionFactory factory, Boolean insist, IFrameHandler frameHandler, ArrayPool`1 memoryPool, String clientProvidedName)
   at RabbitMQ.Client.Framing.Impl.AutorecoveringConnection.Init(IFrameHandler fh)
   at RabbitMQ.Client.Framing.Impl.AutorecoveringConnection.Init(IEndpointResolver endpoints)
   at RabbitMQ.Client.ConnectionFactory.CreateConnection(IEndpointResolver endpointResolver, String clientProvidedName)
   --- End of inner exception stack trace ---
   at RabbitMQ.Client.ConnectionFactory.CreateConnection(IEndpointResolver endpointResolver, String clientProvidedName)
   at RabbitMQ.Client.ConnectionFactory.CreateConnection(IList`1 endpoints, String clientProvidedName)
   at RabbitMQ.Client.ConnectionFactory.CreateConnection(IList`1 endpoints)
   at EasyNetQ.Persistent.PersistentConnection.CreateConnection() in /Users/yurypliner/Sources/EasyNetQ/Source/EasyNetQ/Persistent/PersistentConnection.cs:line 112
   at EasyNetQ.Persistent.PersistentConnection.InitializeConnection() in /Users/yurypliner/Sources/EasyNetQ/Source/EasyNetQ/Persistent/PersistentConnection.cs:line 87
   at EasyNetQ.Persistent.PersistentConnection.CreateModel() in /Users/yurypliner/Sources/EasyNetQ/Source/EasyNetQ/Persistent/PersistentConnection.cs:line 57
   at EasyNetQ.Persistent.PersistentChannel.CreateChannel() in /Users/yurypliner/Sources/EasyNetQ/Source/EasyNetQ/Persistent/PersistentChannel.cs:line 102
   at EasyNetQ.Persistent.PersistentChannel.InvokeChannelActionAsync[TResult,TChannelAction](TChannelAction channelAction, CancellationToken cancellationToken) in /Users/yurypliner/Sources/EasyNetQ/Source/EasyNetQ/Persistent/PersistentChannel.cs:line 67
   at EasyNetQ.RabbitAdvancedBus.PublishAsync(String exchange, String routingKey, Boolean mandatory, MessageProperties properties, ReadOnlyMemory`1 body, CancellationToken cancellationToken) in /Users/yurypliner/Sources/EasyNetQ/Source/EasyNetQ/RabbitAdvancedBus.cs:line 265
```