### PR TITLE
Fix that ResponderConfiguration.WithMaxPriority is not applied to a queue

### DIFF
--- a/Source/EasyNetQ/ResponderConfiguration.cs
+++ b/Source/EasyNetQ/ResponderConfiguration.cs
@@ -88,7 +88,7 @@ internal class ResponderConfiguration : IResponderConfiguration
 
     public IResponderConfiguration WithMaxPriority(byte priority)
     {
-        MaxPriority = MaxPriority;
+        MaxPriority = priority;
         return this;
     }
 }


### PR DESCRIPTION
Fixes #1661 - ResponderConfiguration.WithMaxPriority() has no effect