### PR TITLE
allow ssl in connectionstring (also with multiple hosts)

### DIFF
--- a/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
+++ b/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
@@ -61,4 +61,24 @@ public class ConnectionStringParserTests
     {
         Assert.Throws<EasyNetQException>(() => connectionStringParser.Parse("amqp=Foo"));
     }
+
+    [Fact]
+    public void Should_correctly_parse_multiple_hosts_with_ssl()
+    {
+        var configuration = connectionStringParser.Parse("host=host1.b.com,host2.b.com,host3.b.com;sslEnabled=true");
+        configuration.Ssl.Enabled.Should().BeTrue();
+        configuration.Hosts.Count.Should().Be(3);
+
+        configuration.Hosts[0].Ssl.Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Should_correctly_parse_multiple_hosts_with_ssl_first()
+    {
+        var configuration = connectionStringParser.Parse("sslEnabled=true;host=host1.b.com,host2.b.com,host3.b.com");
+        configuration.Ssl.Enabled.Should().BeTrue();
+        configuration.Hosts.Count.Should().Be(3);
+
+        configuration.Hosts[0].Ssl.Enabled.Should().BeTrue();
+    }
 }

--- a/Source/EasyNetQ/ConnectionConfiguration.cs
+++ b/Source/EasyNetQ/ConnectionConfiguration.cs
@@ -94,6 +94,15 @@ public class ConnectionConfiguration
     public SslOption Ssl { get; }
 
     /// <summary>
+    ///     Needed for setting ssl enabled from connection string grammar.
+    /// </summary>
+    internal bool SslEnabled
+    {
+        get => Ssl.Enabled;
+        set => Ssl.Enabled = value;
+    }
+
+    /// <summary>
     ///     Operations timeout (default is 10s)
     /// </summary>
     public TimeSpan Timeout { get; set; }

--- a/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
+++ b/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
@@ -44,6 +44,7 @@ internal static class ConnectionStringGrammar
         BuildKeyValueParser("connectIntervalAttempt", TimeSpanSeconds, c => c.ConnectIntervalAttempt),
         BuildKeyValueParser("publisherConfirms", Bool, c => c.PublisherConfirms),
         BuildKeyValueParser("persistentMessages", Bool, c => c.PersistentMessages),
+        BuildKeyValueParser("sslEnabled", Bool, c => c.SslEnabled),
         BuildKeyValueParser("product", Text, c => c.Product),
         BuildKeyValueParser("platform", Text, c => c.Platform),
         BuildKeyValueParser("name", Text, c => c.Name),
@@ -91,7 +92,7 @@ internal static class ConnectionStringGrammar
         if (memberEx.Member is not PropertyInfo propertyInfo) throw new ArgumentOutOfRangeException(nameof(getter), "Member is not a property.");
         if (!propertyInfo.CanWrite) throw new ArgumentOutOfRangeException(nameof(getter), "Member is not a writeable property.");
 
-        var setMethodInfo = propertyInfo.GetSetMethod() ?? throw new ArgumentOutOfRangeException(nameof(getter), "No set method.");
+        var setMethodInfo = propertyInfo.GetSetMethod(true) ?? throw new ArgumentOutOfRangeException(nameof(getter), "No set method.");
         return (Action<TContaining, TProperty>)setMethodInfo.CreateDelegate(typeof(Action<TContaining, TProperty>));
     }
 

--- a/Source/EasyNetQ/ConnectionString/ConnectionStringParser.cs
+++ b/Source/EasyNetQ/ConnectionString/ConnectionStringParser.cs
@@ -11,13 +11,23 @@ public class ConnectionStringParser : IConnectionStringParser
         try
         {
             var updater = ConnectionStringGrammar.ParseConnectionString(connectionString);
-            return updater.Aggregate(
+            return PostProcess(updater.Aggregate(
                 new ConnectionConfiguration(), (current, updateFunction) => updateFunction(current)
-            );
+            ));
         }
         catch (ParseException parseException)
         {
             throw new EasyNetQException("Connection String {0}", parseException.Message);
         }
+    }
+
+    private ConnectionConfiguration PostProcess(ConnectionConfiguration configuration)
+    {
+        foreach (var host in configuration.Hosts)
+        {
+            host.Ssl.Enabled = configuration.Ssl.Enabled;
+        }
+
+        return configuration;
     }
 }


### PR DESCRIPTION
Adds support for "sslEnabled=true" for the connection string.

Also works with multiple hosts (ssl is enabled for all of them with the hostname given)