### PR TITLE
Allow to configure ssl in vanilla connection string

### DIFF
--- a/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
+++ b/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
@@ -14,7 +14,8 @@ public class ConnectionStringParserTests
     private const string ConnectionString =
         "virtualHost=Copa;username=Copa;host=192.168.1.1;password=abc_xyz;port=12345;" +
         "requestedHeartbeat=3;prefetchcount=2;timeout=12;publisherConfirms=true;" +
-        "name=unit-test;mandatoryPublish=true;consumerDispatcherConcurrency=1;ssl=true";
+        "name=unit-test;mandatoryPublish=true;consumerDispatcherConcurrency=1;ssl=true;" +
+        "sslServerName=serverName;sslCertificatePath=certificatePath;sslCertificatePassphrase=certificatePassphrase";
 
     [Fact]
     public void Should_correctly_parse_connection_string()
@@ -34,6 +35,9 @@ public class ConnectionStringParserTests
         configuration.MandatoryPublish.Should().BeTrue();
         configuration.ConsumerDispatcherConcurrency.Should().Be(1);
         configuration.Ssl.Enabled.Should().BeTrue();
+        configuration.Ssl.ServerName.Should().Be("serverName");
+        configuration.Ssl.CertPath.Should().Be("certificatePath");
+        configuration.Ssl.CertPassphrase.Should().Be("certificatePassphrase");
     }
 
     [Fact]

--- a/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
+++ b/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
@@ -11,15 +11,15 @@ public class ConnectionStringParserTests
 
     private readonly ConnectionStringParser connectionStringParser;
 
-    private const string connectionString =
+    private const string ConnectionString =
         "virtualHost=Copa;username=Copa;host=192.168.1.1;password=abc_xyz;port=12345;" +
         "requestedHeartbeat=3;prefetchcount=2;timeout=12;publisherConfirms=true;" +
-        "name=unit-test;mandatoryPublish=true;consumerDispatcherConcurrency=1";
+        "name=unit-test;mandatoryPublish=true;consumerDispatcherConcurrency=1;ssl=true";
 
     [Fact]
     public void Should_correctly_parse_connection_string()
     {
-        var configuration = connectionStringParser.Parse(connectionString);
+        var configuration = connectionStringParser.Parse(ConnectionString);
 
         configuration.Hosts.First().Host.Should().Be("192.168.1.1");
         configuration.VirtualHost.Should().Be("Copa");
@@ -33,15 +33,7 @@ public class ConnectionStringParserTests
         configuration.Name.Should().Be("unit-test");
         configuration.MandatoryPublish.Should().BeTrue();
         configuration.ConsumerDispatcherConcurrency.Should().Be(1);
-    }
-
-    [Fact]
-    public void Should_parse_global_timeout()
-    {
-        const string connectionStringWithTimeout = "host=localhost;timeout=13";
-        var connectionConfiguration = connectionStringParser.Parse(connectionStringWithTimeout);
-
-        connectionConfiguration.Timeout.Should().Be(TimeSpan.FromSeconds(13));
+        configuration.Ssl.Enabled.Should().BeTrue();
     }
 
     [Fact]

--- a/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
+++ b/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
@@ -14,8 +14,7 @@ public class ConnectionStringParserTests
     private const string ConnectionString =
         "virtualHost=Copa;username=Copa;host=192.168.1.1;password=abc_xyz;port=12345;" +
         "requestedHeartbeat=3;prefetchcount=2;timeout=12;publisherConfirms=true;" +
-        "name=unit-test;mandatoryPublish=true;consumerDispatcherConcurrency=1;ssl=true;" +
-        "sslCertificatePath=certificatePath;sslCertificatePassphrase=certificatePassphrase";
+        "name=unit-test;mandatoryPublish=true;consumerDispatcherConcurrency=1;ssl=true";
 
     [Fact]
     public void Should_correctly_parse_connection_string()
@@ -35,8 +34,6 @@ public class ConnectionStringParserTests
         configuration.MandatoryPublish.Should().BeTrue();
         configuration.ConsumerDispatcherConcurrency.Should().Be(1);
         configuration.Ssl.Enabled.Should().BeTrue();
-        configuration.Ssl.CertPath.Should().Be("certificatePath");
-        configuration.Ssl.CertPassphrase.Should().Be("certificatePassphrase");
     }
 
     [Fact]

--- a/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
+++ b/Source/EasyNetQ.Tests/ConnectionString/ConnectionStringParserTests.cs
@@ -15,7 +15,7 @@ public class ConnectionStringParserTests
         "virtualHost=Copa;username=Copa;host=192.168.1.1;password=abc_xyz;port=12345;" +
         "requestedHeartbeat=3;prefetchcount=2;timeout=12;publisherConfirms=true;" +
         "name=unit-test;mandatoryPublish=true;consumerDispatcherConcurrency=1;ssl=true;" +
-        "sslServerName=serverName;sslCertificatePath=certificatePath;sslCertificatePassphrase=certificatePassphrase";
+        "sslCertificatePath=certificatePath;sslCertificatePassphrase=certificatePassphrase";
 
     [Fact]
     public void Should_correctly_parse_connection_string()
@@ -35,7 +35,6 @@ public class ConnectionStringParserTests
         configuration.MandatoryPublish.Should().BeTrue();
         configuration.ConsumerDispatcherConcurrency.Should().Be(1);
         configuration.Ssl.Enabled.Should().BeTrue();
-        configuration.Ssl.ServerName.Should().Be("serverName");
         configuration.Ssl.CertPath.Should().Be("certificatePath");
         configuration.Ssl.CertPassphrase.Should().Be("certificatePassphrase");
     }

--- a/Source/EasyNetQ/ConnectionString/AmqpConnectionStringParser.cs
+++ b/Source/EasyNetQ/ConnectionString/AmqpConnectionStringParser.cs
@@ -44,7 +44,6 @@ public class AmqpConnectionStringParser : IConnectionStringParser
         if (secured)
         {
             host.Ssl.Enabled = true;
-            host.Ssl.Version = SslProtocols.None;
             host.Ssl.ServerName = host.Host;
         }
 

--- a/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
+++ b/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
@@ -48,7 +48,10 @@ internal static class ConnectionStringGrammar
         BuildKeyValueParser("platform", Text, c => c.Platform),
         BuildKeyValueParser("name", Text, c => c.Name),
         BuildKeyValueParser("mandatoryPublish", Bool, c => c.MandatoryPublish),
-        BuildKeyValueParser("ssl", Bool, c => c.Ssl.Enabled)
+        BuildKeyValueParser("ssl", Bool, c => c.Ssl.Enabled),
+        BuildKeyValueParser("sslServerName", Text, c => c.Ssl.ServerName),
+        BuildKeyValueParser("sslCertificatePath", Text, c => c.Ssl.CertPath),
+        BuildKeyValueParser("sslCertificatePassphrase", Text, c => c.Ssl.CertPassphrase)
     }.Aggregate((a, b) => a.Or(b));
 
     internal static readonly Parser<IEnumerable<UpdateConfiguration>> ConnectionStringBuilder = Part.ListDelimitedBy(';');

--- a/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
+++ b/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
@@ -47,7 +47,8 @@ internal static class ConnectionStringGrammar
         BuildKeyValueParser("product", Text, c => c.Product),
         BuildKeyValueParser("platform", Text, c => c.Platform),
         BuildKeyValueParser("name", Text, c => c.Name),
-        BuildKeyValueParser("mandatoryPublish", Bool, c => c.MandatoryPublish)
+        BuildKeyValueParser("mandatoryPublish", Bool, c => c.MandatoryPublish),
+        BuildKeyValueParser("ssl", Bool, c => c.Ssl.Enabled)
     }.Aggregate((a, b) => a.Or(b));
 
     internal static readonly Parser<IEnumerable<UpdateConfiguration>> ConnectionStringBuilder = Part.ListDelimitedBy(';');
@@ -87,12 +88,17 @@ internal static class ConnectionStringGrammar
     /// <returns></returns>
     private static Action<TContaining, TProperty> CreateSetter<TContaining, TProperty>(Expression<Func<TContaining, TProperty>> getter)
     {
-        if (getter.Body is not MemberExpression memberEx) throw new ArgumentOutOfRangeException(nameof(getter), "Body is not a member-expression.");
-        if (memberEx.Member is not PropertyInfo propertyInfo) throw new ArgumentOutOfRangeException(nameof(getter), "Member is not a property.");
-        if (!propertyInfo.CanWrite) throw new ArgumentOutOfRangeException(nameof(getter), "Member is not a writeable property.");
+        if (getter.Body is not MemberExpression memberEx)
+            throw new ArgumentOutOfRangeException(nameof(getter), "Body is not a member-expression");
+        if (memberEx.Member is not PropertyInfo propertyInfo)
+            throw new ArgumentOutOfRangeException(nameof(getter), "Member is not a property");
+        if (!propertyInfo.CanWrite)
+            throw new ArgumentOutOfRangeException(nameof(getter), "Member is not a writeable property");
 
-        var setMethodInfo = propertyInfo.GetSetMethod() ?? throw new ArgumentOutOfRangeException(nameof(getter), "No set method.");
-        return (Action<TContaining, TProperty>)setMethodInfo.CreateDelegate(typeof(Action<TContaining, TProperty>));
+        var valueParameterExpr = Expression.Parameter(typeof(TProperty), "value");
+        var setter = propertyInfo.GetSetMethod() ?? throw new ArgumentOutOfRangeException(nameof(getter), "No set method");
+        var expr = Expression.Call(memberEx.Expression, setter, valueParameterExpr);
+        return Expression.Lambda<Action<TContaining, TProperty>>(expr, getter.Parameters.Single(), valueParameterExpr).Compile();
     }
 
     private static IEnumerable<T> Cons<T>(this T head, IEnumerable<T> rest)

--- a/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
+++ b/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
@@ -78,14 +78,6 @@ internal static class ConnectionStringGrammar
         Expression<Func<ConnectionConfiguration, T>> getter
     ) => CreateSetter<ConnectionConfiguration, T>(getter);
 
-    /// <summary>
-    /// Stolen from SO:
-    /// http://stackoverflow.com/questions/4596453/create-an-actiont-to-set-a-property-when-i-am-provided-with-the-linq-expres
-    /// </summary>
-    /// <typeparam name="TContaining"></typeparam>
-    /// <typeparam name="TProperty"></typeparam>
-    /// <param name="getter"></param>
-    /// <returns></returns>
     private static Action<TContaining, TProperty> CreateSetter<TContaining, TProperty>(Expression<Func<TContaining, TProperty>> getter)
     {
         if (getter.Body is not MemberExpression memberEx)

--- a/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
+++ b/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
@@ -49,7 +49,6 @@ internal static class ConnectionStringGrammar
         BuildKeyValueParser("name", Text, c => c.Name),
         BuildKeyValueParser("mandatoryPublish", Bool, c => c.MandatoryPublish),
         BuildKeyValueParser("ssl", Bool, c => c.Ssl.Enabled),
-        BuildKeyValueParser("sslServerName", Text, c => c.Ssl.ServerName),
         BuildKeyValueParser("sslCertificatePath", Text, c => c.Ssl.CertPath),
         BuildKeyValueParser("sslCertificatePassphrase", Text, c => c.Ssl.CertPassphrase)
     }.Aggregate((a, b) => a.Or(b));

--- a/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
+++ b/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs
@@ -48,9 +48,7 @@ internal static class ConnectionStringGrammar
         BuildKeyValueParser("platform", Text, c => c.Platform),
         BuildKeyValueParser("name", Text, c => c.Name),
         BuildKeyValueParser("mandatoryPublish", Bool, c => c.MandatoryPublish),
-        BuildKeyValueParser("ssl", Bool, c => c.Ssl.Enabled),
-        BuildKeyValueParser("sslCertificatePath", Text, c => c.Ssl.CertPath),
-        BuildKeyValueParser("sslCertificatePassphrase", Text, c => c.Ssl.CertPassphrase)
+        BuildKeyValueParser("ssl", Bool, c => c.Ssl.Enabled)
     }.Aggregate((a, b) => a.Or(b));
 
     internal static readonly Parser<IEnumerable<UpdateConfiguration>> ConnectionStringBuilder = Part.ListDelimitedBy(';');
@@ -82,16 +80,16 @@ internal static class ConnectionStringGrammar
 
     private static Action<TContaining, TProperty> CreateSetter<TContaining, TProperty>(Expression<Func<TContaining, TProperty>> getter)
     {
-        if (getter.Body is not MemberExpression memberEx)
+        if (getter.Body is not MemberExpression memberExpr)
             throw new ArgumentOutOfRangeException(nameof(getter), "Body is not a member-expression");
-        if (memberEx.Member is not PropertyInfo propertyInfo)
+        if (memberExpr.Member is not PropertyInfo propertyInfo)
             throw new ArgumentOutOfRangeException(nameof(getter), "Member is not a property");
         if (!propertyInfo.CanWrite)
-            throw new ArgumentOutOfRangeException(nameof(getter), "Member is not a writeable property");
+            throw new ArgumentOutOfRangeException(nameof(getter), "Property is not writeable");
 
         var valueParameterExpr = Expression.Parameter(typeof(TProperty), "value");
         var setter = propertyInfo.GetSetMethod() ?? throw new ArgumentOutOfRangeException(nameof(getter), "No set method");
-        var expr = Expression.Call(memberEx.Expression, setter, valueParameterExpr);
+        var expr = Expression.Call(memberExpr.Expression, setter, valueParameterExpr);
         return Expression.Lambda<Action<TContaining, TProperty>>(expr, getter.Parameters.Single(), valueParameterExpr).Compile();
     }
 

--- a/Source/EasyNetQ/Persistent/PersistentConnection.cs
+++ b/Source/EasyNetQ/Persistent/PersistentConnection.cs
@@ -95,16 +95,10 @@ public class PersistentConnection : IPersistentConnection
     {
         var endpoints = configuration.Hosts.Select(x =>
         {
-            var endpoint = new AmqpTcpEndpoint(x.Host, x.Port);
-            if (x.Ssl.Enabled)
-                endpoint.Ssl = x.Ssl;
-            else if (configuration.Ssl.Enabled)
-            {
-                var ssl = Copy(configuration.Ssl);
-                ssl.ServerName = endpoint.HostName;
-                endpoint.Ssl = ssl;
-            }
-            return endpoint;
+            var ssl = !x.Ssl.Enabled && configuration.Ssl.Enabled
+                ? NewSslForHost(configuration.Ssl, x.Host)
+                : x.Ssl;
+            return new AmqpTcpEndpoint(x.Host, x.Port, ssl);
         }).ToList();
 
         if (connectionFactory.CreateConnection(endpoints) is not IAutorecoveringConnection connection)
@@ -169,10 +163,10 @@ public class PersistentConnection : IPersistentConnection
         eventBus.Publish(new ConnectionUnblockedEvent(type));
     }
 
-    private static SslOption Copy(SslOption option) =>
+    private static SslOption NewSslForHost(SslOption option, string host) =>
         new()
         {
-            Certs = option.Certs == null ? null : new X509CertificateCollection(option.Certs),
+            Certs = option.Certs,
             AcceptablePolicyErrors = option.AcceptablePolicyErrors,
             CertPassphrase = option.CertPassphrase,
             CertPath = option.CertPath,
@@ -180,7 +174,7 @@ public class PersistentConnection : IPersistentConnection
             CertificateValidationCallback = option.CertificateValidationCallback,
             CheckCertificateRevocation = option.CheckCertificateRevocation,
             Enabled = option.Enabled,
-            ServerName = option.ServerName,
+            ServerName = host,
             Version = option.Version,
         };
 }

--- a/Source/EasyNetQ/Persistent/PersistentConnection.cs
+++ b/Source/EasyNetQ/Persistent/PersistentConnection.cs
@@ -97,7 +97,7 @@ public class PersistentConnection : IPersistentConnection
         {
             var endpoint = new AmqpTcpEndpoint(x.Host, x.Port);
             if (x.Ssl.Enabled)
-                endpoint.Ssl = Copy(x.Ssl);
+                endpoint.Ssl = x.Ssl;
             else if (configuration.Ssl.Enabled)
             {
                 var ssl = Copy(configuration.Ssl);

--- a/Source/EasyNetQ/Persistent/PersistentConnection.cs
+++ b/Source/EasyNetQ/Persistent/PersistentConnection.cs
@@ -99,7 +99,11 @@ public class PersistentConnection : IPersistentConnection
             if (x.Ssl.Enabled)
                 endpoint.Ssl = Copy(x.Ssl);
             else if (configuration.Ssl.Enabled)
-                endpoint.Ssl = Copy(configuration.Ssl, serverName: endpoint.HostName);
+            {
+                var ssl = Copy(configuration.Ssl);
+                ssl.ServerName = endpoint.HostName;
+                endpoint.Ssl = ssl;
+            }
             return endpoint;
         }).ToList();
 
@@ -165,10 +169,9 @@ public class PersistentConnection : IPersistentConnection
         eventBus.Publish(new ConnectionUnblockedEvent(type));
     }
 
-    private static SslOption Copy(SslOption option, string? serverName = null) =>
+    private static SslOption Copy(SslOption option) =>
         new()
         {
-            // It is important to Certs it before CertPassphrase and CertPath, do not reorder
             Certs = option.Certs == null ? null : new X509CertificateCollection(option.Certs),
             AcceptablePolicyErrors = option.AcceptablePolicyErrors,
             CertPassphrase = option.CertPassphrase,
@@ -177,7 +180,7 @@ public class PersistentConnection : IPersistentConnection
             CertificateValidationCallback = option.CertificateValidationCallback,
             CheckCertificateRevocation = option.CheckCertificateRevocation,
             Enabled = option.Enabled,
-            ServerName = serverName ?? option.ServerName,
+            ServerName = option.ServerName,
             Version = option.Version,
         };
 }


### PR DESCRIPTION
Alternative to #1671, supports only `ssl=true` parameter.

There is no need to patch hosts because of that:

<img width="553" alt="image" src="https://github.com/EasyNetQ/EasyNetQ/assets/664889/a6568198-0a3c-4e26-aca8-849781154f8e">
