### PR TITLE
Rework queue/exchange declaration in-line with other topology methods

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -38,8 +38,8 @@ namespace EasyNetQ
         public static System.IDisposable Consume<T>(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Queue queue, System.Func<EasyNetQ.IMessage<T>, EasyNetQ.MessageReceivedInfo, System.Threading.Tasks.Task> handler, System.Action<EasyNetQ.ISimpleConsumeConfiguration> configure) { }
         public static System.IDisposable Consume<T>(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Queue queue, System.Func<EasyNetQ.IMessage<T>, EasyNetQ.MessageReceivedInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Action<EasyNetQ.ISimpleConsumeConfiguration> configure) { }
         public static EasyNetQ.Topology.Exchange ExchangeDeclare(this EasyNetQ.IAdvancedBus bus, string exchange, System.Action<EasyNetQ.IExchangeDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default) { }
-        public static EasyNetQ.Topology.Exchange ExchangeDeclare(this EasyNetQ.IAdvancedBus bus, string exchange, string type, bool durable = true, bool autoDelete = false, System.Threading.CancellationToken cancellationToken = default) { }
-        public static System.Threading.Tasks.Task<EasyNetQ.Topology.Exchange> ExchangeDeclareAsync(this EasyNetQ.IAdvancedBus bus, string exchange, string type, bool durable = true, bool autoDelete = false, System.Threading.CancellationToken cancellationToken = default) { }
+        public static EasyNetQ.Topology.Exchange ExchangeDeclare(this EasyNetQ.IAdvancedBus bus, string exchange, string type = "topic", bool durable = true, bool autoDelete = false, System.Collections.Generic.IDictionary<string, object>? arguments = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.Task<EasyNetQ.Topology.Exchange> ExchangeDeclareAsync(this EasyNetQ.IAdvancedBus bus, string exchange, System.Action<EasyNetQ.IExchangeDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default) { }
         public static void ExchangeDeclarePassive(this EasyNetQ.IAdvancedBus bus, string exchange, System.Threading.CancellationToken cancellationToken = default) { }
         public static void ExchangeDelete(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Exchange exchange, bool ifUnused = false, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task ExchangeDeleteAsync(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Exchange exchange, bool ifUnused = false, System.Threading.CancellationToken cancellationToken = default) { }
@@ -54,12 +54,9 @@ namespace EasyNetQ
         public static System.Threading.Tasks.Task PublishAsync(this EasyNetQ.IAdvancedBus bus, in EasyNetQ.Topology.Exchange exchange, string routingKey, bool? mandatory, bool? publisherConfirms, EasyNetQ.IMessage message, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task PublishAsync(this EasyNetQ.IAdvancedBus bus, in EasyNetQ.Topology.Exchange exchange, string routingKey, bool? mandatory, in EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task PublishAsync(this EasyNetQ.IAdvancedBus bus, in EasyNetQ.Topology.Exchange exchange, string routingKey, bool? mandatory, bool? publisherConfirms, in EasyNetQ.MessageProperties properties, in System.ReadOnlyMemory<byte> body, System.Threading.CancellationToken cancellationToken = default) { }
-        public static EasyNetQ.Topology.Queue QueueDeclare(this EasyNetQ.IAdvancedBus bus, System.Threading.CancellationToken cancellationToken = default) { }
-        public static EasyNetQ.Topology.Queue QueueDeclare(this EasyNetQ.IAdvancedBus bus, string queue, System.Threading.CancellationToken cancellationToken = default) { }
         public static EasyNetQ.Topology.Queue QueueDeclare(this EasyNetQ.IAdvancedBus bus, string queue, System.Action<EasyNetQ.IQueueDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default) { }
-        public static EasyNetQ.Topology.Queue QueueDeclare(this EasyNetQ.IAdvancedBus bus, string queue, bool durable, bool exclusive, bool autoDelete, System.Threading.CancellationToken cancellationToken = default) { }
-        public static System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(this EasyNetQ.IAdvancedBus bus, string queue, System.Threading.CancellationToken cancellationToken = default) { }
-        public static System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(this EasyNetQ.IAdvancedBus bus, string queue, bool durable, bool exclusive, bool autoDelete, System.Threading.CancellationToken cancellationToken = default) { }
+        public static EasyNetQ.Topology.Queue QueueDeclare(this EasyNetQ.IAdvancedBus bus, string queue, bool durable = true, bool exclusive = false, bool autoDelete = false, System.Collections.Generic.IDictionary<string, object>? arguments = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(this EasyNetQ.IAdvancedBus bus, string queue, System.Action<EasyNetQ.IQueueDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default) { }
         public static void QueueDeclarePassive(this EasyNetQ.IAdvancedBus bus, string queue, System.Threading.CancellationToken cancellationToken = default) { }
         public static void QueueDelete(this EasyNetQ.IAdvancedBus bus, string queue, bool ifUnused = false, bool ifEmpty = false, System.Threading.CancellationToken cancellationToken = default) { }
         public static void QueuePurge(this EasyNetQ.IAdvancedBus bus, string name, System.Threading.CancellationToken cancellationToken = default) { }
@@ -68,6 +65,45 @@ namespace EasyNetQ
         public static void Unbind(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Binding<EasyNetQ.Topology.Queue> binding, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task UnbindAsync(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Binding<EasyNetQ.Topology.Exchange> binding, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task UnbindAsync(this EasyNetQ.IAdvancedBus bus, EasyNetQ.Topology.Binding<EasyNetQ.Topology.Queue> binding, System.Threading.CancellationToken cancellationToken = default) { }
+    }
+    public static class Argument
+    {
+        public const string AlternateExchange = "alternate-exchange";
+        public const string DeadLetterExchange = "x-dead-letter-exchange";
+        public const string DeadLetterRoutingKey = "x-dead-letter-routing-key";
+        public const string DeadLetterStrategy = "x-dead-letter-strategy";
+        public const string DelayedType = "x-delayed-type";
+        public const string Expires = "x-expires";
+        public const string MaxLength = "x-max-length";
+        public const string MaxLengthBytes = "x-max-length-bytes";
+        public const string MaxPriority = "x-max-priority";
+        public const string MessageTtl = "x-message-ttl";
+        public const string Overflow = "x-overflow";
+        public const string QueueMasterLocator = "x-queue-master-locator";
+        public const string QueueMode = "x-queue-mode";
+        public const string QueueType = "x-queue-type";
+        public const string SingleActiveConsumer = "x-single-active-consumer";
+    }
+    public static class ArgumentsExtensions
+    {
+        public static System.Collections.Generic.IDictionary<string, object> WithAlternateExchange(this System.Collections.Generic.IDictionary<string, object> arguments, string alternateExchange) { }
+        public static System.Collections.Generic.IDictionary<string, object> WithArgument(this System.Collections.Generic.IDictionary<string, object> arguments, string name, object value) { }
+        public static System.Collections.Generic.IDictionary<string, object> WithDeadLetterExchange(this System.Collections.Generic.IDictionary<string, object> arguments, string deadLetterExchange) { }
+        public static System.Collections.Generic.IDictionary<string, object> WithDeadLetterRoutingKey(this System.Collections.Generic.IDictionary<string, object> arguments, string deadLetterRoutingKey) { }
+        public static System.Collections.Generic.IDictionary<string, object> WithDeadLetterStrategy(this System.Collections.Generic.IDictionary<string, object> arguments, string deadLetterStrategy) { }
+        public static System.Collections.Generic.IDictionary<string, object> WithDelayedType(this System.Collections.Generic.IDictionary<string, object> arguments, string delayedType) { }
+        public static System.Collections.Generic.IDictionary<string, object> WithExpires(this System.Collections.Generic.IDictionary<string, object> arguments, int expiresMs) { }
+        public static System.Collections.Generic.IDictionary<string, object> WithExpires(this System.Collections.Generic.IDictionary<string, object> arguments, System.TimeSpan expires) { }
+        public static System.Collections.Generic.IDictionary<string, object> WithMaxLength(this System.Collections.Generic.IDictionary<string, object> arguments, int maxLength) { }
+        public static System.Collections.Generic.IDictionary<string, object> WithMaxLengthBytes(this System.Collections.Generic.IDictionary<string, object> arguments, int maxLengthBytes) { }
+        public static System.Collections.Generic.IDictionary<string, object> WithMaxPriority(this System.Collections.Generic.IDictionary<string, object> arguments, byte maxPriority) { }
+        public static System.Collections.Generic.IDictionary<string, object> WithMessageTtl(this System.Collections.Generic.IDictionary<string, object> arguments, int messageTtlMs) { }
+        public static System.Collections.Generic.IDictionary<string, object> WithMessageTtl(this System.Collections.Generic.IDictionary<string, object> arguments, System.TimeSpan messageTtl) { }
+        public static System.Collections.Generic.IDictionary<string, object> WithOverflowType(this System.Collections.Generic.IDictionary<string, object> arguments, string overflowType) { }
+        public static System.Collections.Generic.IDictionary<string, object> WithQueueMasterLocator(this System.Collections.Generic.IDictionary<string, object> arguments, string queueMasterLocator) { }
+        public static System.Collections.Generic.IDictionary<string, object> WithQueueMode(this System.Collections.Generic.IDictionary<string, object> arguments, string queueMode) { }
+        public static System.Collections.Generic.IDictionary<string, object> WithQueueType(this System.Collections.Generic.IDictionary<string, object> arguments, string queueType) { }
+        public static System.Collections.Generic.IDictionary<string, object> WithSingleActiveConsumer(this System.Collections.Generic.IDictionary<string, object> arguments, bool singleActiveConsumer = true) { }
     }
     public class BlockedEventArgs : System.EventArgs
     {
@@ -294,6 +330,7 @@ namespace EasyNetQ
     public delegate string ExchangeNameConvention(System.Type messageType);
     public static class ExchangeType
     {
+        public const string DelayedMessage = "x-delayed-message";
         public const string Direct = "direct";
         public const string Fanout = "fanout";
         public const string Header = "headers";
@@ -318,21 +355,20 @@ namespace EasyNetQ
         System.IDisposable Consume(System.Action<EasyNetQ.IConsumeConfiguration> configure);
         EasyNetQ.IPullingConsumer<EasyNetQ.PullResult> CreatePullingConsumer(in EasyNetQ.Topology.Queue queue, bool autoAck = true);
         EasyNetQ.IPullingConsumer<EasyNetQ.PullResult<T>> CreatePullingConsumer<T>(in EasyNetQ.Topology.Queue queue, bool autoAck = true);
-        System.Threading.Tasks.Task ExchangeBindAsync(string destinationExchange, string sourceExchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.Task<EasyNetQ.Topology.Exchange> ExchangeDeclareAsync(string exchange, System.Action<EasyNetQ.IExchangeDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task ExchangeBindAsync(string destinationExchange, string sourceExchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments = null, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<EasyNetQ.Topology.Exchange> ExchangeDeclareAsync(string exchange, string type = "topic", bool durable = true, bool autoDelete = false, System.Collections.Generic.IDictionary<string, object>? arguments = null, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task ExchangeDeclarePassiveAsync(string exchange, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task ExchangeDeleteAsync(string exchange, bool ifUnused = false, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.Task ExchangeUnbindAsync(string destinationExchange, string sourceExchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task ExchangeUnbindAsync(string destinationExchange, string sourceExchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments = null, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<EasyNetQ.QueueStats> GetQueueStatsAsync(string queue, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task PublishAsync(string exchange, string routingKey, bool? mandatory, bool? publisherConfirms, EasyNetQ.IMessage message, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task PublishAsync(string exchange, string routingKey, bool? mandatory, bool? publisherConfirms, EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.Task QueueBindAsync(string queue, string exchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(string queue, System.Action<EasyNetQ.IQueueDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task QueueBindAsync(string queue, string exchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments = null, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(string queue, bool durable = true, bool exclusive = false, bool autoDelete = false, System.Collections.Generic.IDictionary<string, object>? arguments = null, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task QueueDeclarePassiveAsync(string queue, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task QueueDeleteAsync(string queue, bool ifUnused = false, bool ifEmpty = false, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task QueuePurgeAsync(string queue, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.Task QueueUnbindAsync(string queue, string exchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task QueueUnbindAsync(string queue, string exchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments = null, System.Threading.CancellationToken cancellationToken = default);
     }
     public interface IBus
     {
@@ -489,7 +525,7 @@ namespace EasyNetQ
     public interface IResponderConfiguration
     {
         EasyNetQ.IResponderConfiguration WithDurable(bool durable = true);
-        EasyNetQ.IResponderConfiguration WithExpires(System.TimeSpan expires);
+        EasyNetQ.IResponderConfiguration WithExpires(int expires);
         EasyNetQ.IResponderConfiguration WithMaxPriority(byte priority);
         EasyNetQ.IResponderConfiguration WithPrefetchCount(ushort prefetchCount);
         EasyNetQ.IResponderConfiguration WithQueueName(string queueName);
@@ -802,7 +838,7 @@ namespace EasyNetQ
         public static EasyNetQ.IQueueDeclareConfiguration WithExpires(this EasyNetQ.IQueueDeclareConfiguration configuration, System.TimeSpan expires) { }
         public static EasyNetQ.IQueueDeclareConfiguration WithMaxLength(this EasyNetQ.IQueueDeclareConfiguration configuration, int maxLength) { }
         public static EasyNetQ.IQueueDeclareConfiguration WithMaxLengthBytes(this EasyNetQ.IQueueDeclareConfiguration configuration, int maxLengthBytes) { }
-        public static EasyNetQ.IQueueDeclareConfiguration WithMaxPriority(this EasyNetQ.IQueueDeclareConfiguration configuration, int maxPriority) { }
+        public static EasyNetQ.IQueueDeclareConfiguration WithMaxPriority(this EasyNetQ.IQueueDeclareConfiguration configuration, byte maxPriority) { }
         public static EasyNetQ.IQueueDeclareConfiguration WithMessageTtl(this EasyNetQ.IQueueDeclareConfiguration configuration, System.TimeSpan messageTtl) { }
         public static EasyNetQ.IQueueDeclareConfiguration WithOverflowType(this EasyNetQ.IQueueDeclareConfiguration configuration, string overflowType = "drop-head") { }
         public static EasyNetQ.IQueueDeclareConfiguration WithQueueMasterLocator(this EasyNetQ.IQueueDeclareConfiguration configuration, string queueMasterLocator = "min-masters") { }
@@ -850,7 +886,7 @@ namespace EasyNetQ
         public EasyNetQ.IPullingConsumer<EasyNetQ.PullResult<T>> CreatePullingConsumer<T>(in EasyNetQ.Topology.Queue queue, bool autoAck = true) { }
         public virtual void Dispose() { }
         public virtual System.Threading.Tasks.Task ExchangeBindAsync(string destinationExchange, string sourceExchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken) { }
-        public System.Threading.Tasks.Task<EasyNetQ.Topology.Exchange> ExchangeDeclareAsync(string exchange, System.Action<EasyNetQ.IExchangeDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<EasyNetQ.Topology.Exchange> ExchangeDeclareAsync(string exchange, string type, bool durable, bool autoDelete, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task ExchangeDeclarePassiveAsync(string exchange, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.Task ExchangeDeleteAsync(string exchange, bool ifUnused = false, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.Task ExchangeUnbindAsync(string destinationExchange, string sourceExchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken) { }
@@ -858,8 +894,7 @@ namespace EasyNetQ
         public virtual System.Threading.Tasks.Task PublishAsync(string exchange, string routingKey, bool? mandatory, bool? publisherConfirms, EasyNetQ.IMessage message, System.Threading.CancellationToken cancellationToken) { }
         public virtual System.Threading.Tasks.Task PublishAsync(string exchange, string routingKey, bool? mandatory, bool? publisherConfirms, EasyNetQ.MessageProperties properties, System.ReadOnlyMemory<byte> body, System.Threading.CancellationToken cancellationToken) { }
         public virtual System.Threading.Tasks.Task QueueBindAsync(string queue, string exchange, string routingKey, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken) { }
-        public System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(System.Threading.CancellationToken cancellationToken) { }
-        public System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(string queue, System.Action<EasyNetQ.IQueueDeclareConfiguration> configure, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<EasyNetQ.Topology.Queue> QueueDeclareAsync(string queue, bool durable, bool exclusive, bool autoDelete, System.Collections.Generic.IDictionary<string, object>? arguments, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task QueueDeclarePassiveAsync(string queue, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.Task QueueDeleteAsync(string queue, bool ifUnused = false, bool ifEmpty = false, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.Task QueuePurgeAsync(string queue, System.Threading.CancellationToken cancellationToken) { }

--- a/Source/EasyNetQ.Examples.DlxRetry/EntryPoint.cs
+++ b/Source/EasyNetQ.Examples.DlxRetry/EntryPoint.cs
@@ -14,19 +14,21 @@ using var bus = RabbitHutch.CreateBus(
 );
 
 await bus.Advanced.QueueDeclareAsync(
-    "Events:Failed",
-    c => c.WithQueueType(QueueType.Quorum)
-        .WithDeadLetterExchange(Exchange.Default)
+    queue: "Events:Failed",
+    arguments: new Dictionary<string, object>()
+        .WithQueueType(QueueType.Quorum)
+        .WithDeadLetterExchange(Exchange.DefaultName)
         .WithDeadLetterRoutingKey("Events")
-        .WithMessageTtl(TimeSpan.FromSeconds(5)) // A fixed delay between retry attempts
+        .WithMessageTtl(TimeSpan.FromSeconds(5))
         .WithOverflowType(OverflowType.RejectPublish)
         .WithDeadLetterStrategy(DeadLetterStrategy.AtLeastOnce)
 );
 
 var eventQueue = await bus.Advanced.QueueDeclareAsync(
-    "Events",
-    c => c.WithQueueType(QueueType.Quorum)
-        .WithDeadLetterExchange(Exchange.Default)
+    queue: "Events",
+    arguments: new Dictionary<string, object>()
+        .WithQueueType(QueueType.Quorum)
+        .WithDeadLetterExchange(Exchange.DefaultName)
         .WithDeadLetterRoutingKey("Events:Failed")
         .WithOverflowType(OverflowType.RejectPublish)
         .WithDeadLetterStrategy(DeadLetterStrategy.AtLeastOnce)

--- a/Source/EasyNetQ.Examples.PubSubWithAdvancedApi/EntryPoint.cs
+++ b/Source/EasyNetQ.Examples.PubSubWithAdvancedApi/EntryPoint.cs
@@ -12,10 +12,11 @@ using var bus = RabbitHutch.CreateBus(
 );
 
 var eventQueue = await bus.Advanced.QueueDeclareAsync(
-    "Events",
-    c => c.WithQueueType(QueueType.Quorum)
+    queue: "Events",
+    arguments: new Dictionary<string, object>()
+        .WithQueueType(QueueType.Quorum)
         .WithOverflowType(OverflowType.RejectPublish),
-    cts.Token
+    cancellationToken: cts.Token
 );
 
 using var eventsConsumer = bus.Advanced.Consume(eventQueue, (_, _, _) => { });

--- a/Source/EasyNetQ.IntegrationTests/Advanced/When_connected_event_raised.cs
+++ b/Source/EasyNetQ.IntegrationTests/Advanced/When_connected_event_raised.cs
@@ -20,9 +20,7 @@ public class When_connected_event_raised : IDisposable
         var mre = new ManualResetEventSlim(false);
         bus.Advanced.Connected += (_, _) => mre.Set();
 
-        await bus.Advanced.ExchangeDeclareAsync(
-            Guid.NewGuid().ToString("N"), c => c.WithType(ExchangeType.Topic), cts.Token
-        );
+        await bus.Advanced.ExchangeDeclareAsync(Guid.NewGuid().ToString("N"), cancellationToken: cts.Token);
 
         mre.Wait(cts.Token);
     }

--- a/Source/EasyNetQ.IntegrationTests/Advanced/When_consumer_with_auto_ack.cs
+++ b/Source/EasyNetQ.IntegrationTests/Advanced/When_consumer_with_auto_ack.cs
@@ -19,7 +19,7 @@ public class When_consumer_with_auto_ack : IDisposable
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
         var queueName = Guid.NewGuid().ToString();
-        var queue = await bus.Advanced.QueueDeclareAsync(queueName, cts.Token);
+        var queue = await bus.Advanced.QueueDeclareAsync(queueName, cancellationToken: cts.Token);
 
         var allMessagesReceived = new AsyncCountdownEvent();
 

--- a/Source/EasyNetQ.IntegrationTests/Advanced/When_declare_a_queue.cs
+++ b/Source/EasyNetQ.IntegrationTests/Advanced/When_declare_a_queue.cs
@@ -21,7 +21,9 @@ public class When_declare_a_queue : IDisposable
         foreach (var queueMode in queuesModes)
         {
             await bus.Advanced.QueueDeclareAsync(
-                Guid.NewGuid().ToString("N"), c => c.WithQueueMode(queueMode), cts.Token
+                queue: Guid.NewGuid().ToString("N"),
+                arguments: new Dictionary<string, object>().WithQueueMode(queueMode),
+                cancellationToken: cts.Token
             );
         }
 
@@ -29,7 +31,9 @@ public class When_declare_a_queue : IDisposable
         foreach (var queueType in queuesTypes)
         {
             await bus.Advanced.QueueDeclareAsync(
-                Guid.NewGuid().ToString("N"), c => c.WithQueueType(queueType), cts.Token
+                queue: Guid.NewGuid().ToString("N"),
+                arguments: new Dictionary<string, object>().WithQueueType(queueType),
+                cancellationToken: cts.Token
             );
         }
     }

--- a/Source/EasyNetQ.IntegrationTests/Advanced/When_delete_a_queue_with_name.cs
+++ b/Source/EasyNetQ.IntegrationTests/Advanced/When_delete_a_queue_with_name.cs
@@ -18,7 +18,7 @@ public class When_delete_a_queue_with_name : IDisposable
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
         var queueName = Guid.NewGuid().ToString();
-        var queue = await bus.Advanced.QueueDeclareAsync(queueName, cts.Token);
+        var queue = await bus.Advanced.QueueDeclareAsync(queue: queueName, cancellationToken: cts.Token);
 
         await bus.Advanced.QueueDeclarePassiveAsync(queueName, cts.Token);
         await bus.Advanced.QueueDeleteAsync(queueName, cancellationToken: cts.Token);

--- a/Source/EasyNetQ.IntegrationTests/Advanced/When_pull_messages.cs
+++ b/Source/EasyNetQ.IntegrationTests/Advanced/When_pull_messages.cs
@@ -23,7 +23,7 @@ public class When_pull_messages : IDisposable
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
         var queue = await bus.Advanced.QueueDeclareAsync(
-            Guid.NewGuid().ToString("N"), cts.Token
+            queue: Guid.NewGuid().ToString("N"), cancellationToken: cts.Token
         );
         await bus.Advanced.PublishAsync(
             Exchange.Default, queue.Name, false, true, MessageProperties.Empty, Array.Empty<byte>(), cts.Token
@@ -51,7 +51,7 @@ public class When_pull_messages : IDisposable
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
         var queue = await bus.Advanced.QueueDeclareAsync(
-            Guid.NewGuid().ToString("N"), cts.Token
+            queue: Guid.NewGuid().ToString("N"), cancellationToken: cts.Token
         );
         await bus.Advanced.PublishAsync(
             Exchange.Default, queue.Name, false, false, MessageProperties.Empty, Array.Empty<byte>(), cts.Token
@@ -79,7 +79,7 @@ public class When_pull_messages : IDisposable
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
         var queue = await bus.Advanced.QueueDeclareAsync(
-            Guid.NewGuid().ToString("N"), cts.Token
+            queue: Guid.NewGuid().ToString("N"), cancellationToken: cts.Token
         );
         await bus.Advanced.PublishAsync(
             Exchange.Default, queue.Name, false, false, MessageProperties.Empty, Array.Empty<byte>(), cts.Token
@@ -107,7 +107,7 @@ public class When_pull_messages : IDisposable
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
         var queue = await bus.Advanced.QueueDeclareAsync(
-            Guid.NewGuid().ToString("N"), cts.Token
+            queue: Guid.NewGuid().ToString("N"), cancellationToken: cts.Token
         );
         await bus.Advanced.PublishAsync(
             Exchange.Default, queue.Name, false, false, MessageProperties.Empty, Array.Empty<byte>(), cts.Token

--- a/Source/EasyNetQ.IntegrationTests/Advanced/When_pull_messages_batch.cs
+++ b/Source/EasyNetQ.IntegrationTests/Advanced/When_pull_messages_batch.cs
@@ -23,7 +23,7 @@ public class When_pull_messages_batch : IDisposable
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
         var queue = await bus.Advanced.QueueDeclareAsync(
-            Guid.NewGuid().ToString("N"), cts.Token
+            queue: Guid.NewGuid().ToString("N"), cancellationToken: cts.Token
         );
         await bus.Advanced.PublishAsync(
             Exchange.Default, queue.Name, false, true, MessageProperties.Empty, Array.Empty<byte>(), cts.Token
@@ -54,7 +54,7 @@ public class When_pull_messages_batch : IDisposable
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
         var queue = await bus.Advanced.QueueDeclareAsync(
-            Guid.NewGuid().ToString("N"), cts.Token
+            queue: Guid.NewGuid().ToString("N"), cancellationToken: cts.Token
         );
         await bus.Advanced.PublishAsync(
             Exchange.Default, queue.Name, false, true, MessageProperties.Empty, Array.Empty<byte>(), cts.Token
@@ -85,7 +85,7 @@ public class When_pull_messages_batch : IDisposable
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
         var queue = await bus.Advanced.QueueDeclareAsync(
-            Guid.NewGuid().ToString("N"), cts.Token
+            queue: Guid.NewGuid().ToString("N"), cancellationToken: cts.Token
         );
         await bus.Advanced.PublishAsync(
             Exchange.Default, queue.Name, false, true, MessageProperties.Empty, Array.Empty<byte>(), cts.Token
@@ -116,7 +116,7 @@ public class When_pull_messages_batch : IDisposable
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
         var queue = await bus.Advanced.QueueDeclareAsync(
-            Guid.NewGuid().ToString("N"), cts.Token
+            queue: Guid.NewGuid().ToString("N"), cancellationToken: cts.Token
         );
         await bus.Advanced.PublishAsync(
             Exchange.Default, queue.Name, false, true, MessageProperties.Empty, Array.Empty<byte>(), cts.Token

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_auto_subscribing_async_with_subscription_configuration.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_auto_subscribing_async_with_subscription_configuration.cs
@@ -47,9 +47,9 @@ public class When_auto_subscribing_async_with_subscription_configuration_attribu
         capturedAction(subscriptionConfiguration);
 
         subscriptionConfiguration.AutoDelete.Should().BeTrue();
-        subscriptionConfiguration.Expires.Should().Be(10);
-        subscriptionConfiguration.PrefetchCount.Should().Be((ushort)10);
+        subscriptionConfiguration.PrefetchCount.Should().Be(10);
         subscriptionConfiguration.Priority.Should().Be(10);
+        subscriptionConfiguration.QueueArguments.Should().BeEquivalentTo(new Dictionary<string, object> { { "x-expires", 10 } });
     }
 
     // Discovered by reflection over test assembly, do not remove.
@@ -112,9 +112,9 @@ public class When_auto_subscribing_async_explicit_implementation_with_subscripti
         capturedAction(subscriptionConfiguration);
 
         subscriptionConfiguration.AutoDelete.Should().BeTrue();
-        subscriptionConfiguration.Expires.Should().Be(10);
         subscriptionConfiguration.PrefetchCount.Should().Be(10);
         subscriptionConfiguration.Priority.Should().Be(10);
+        subscriptionConfiguration.QueueArguments.Should().BeEquivalentTo(new Dictionary<string, object> { { "x-expires", 10 } });
     }
 
     // Discovered by reflection over test assembly, do not remove.

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_auto_subscribing_async_with_subscription_configuration_action.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_auto_subscribing_async_with_subscription_configuration_action.cs
@@ -55,9 +55,9 @@ public class When_auto_subscribing_async_with_subscription_configuration_action
         capturedAction(subscriptionConfiguration);
 
         subscriptionConfiguration.AutoDelete.Should().BeTrue();
-        subscriptionConfiguration.Expires.Should().Be(10);
         subscriptionConfiguration.PrefetchCount.Should().Be(10);
         subscriptionConfiguration.Priority.Should().Be(10);
+        subscriptionConfiguration.QueueArguments.Should().BeEquivalentTo(new Dictionary<string, object> { { "x-expires", 10 } });
     }
 
     // Discovered by reflection over test assembly, do not remove.

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_auto_subscribing_async_with_subscription_configuration_action_and_attribute.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_auto_subscribing_async_with_subscription_configuration_action_and_attribute.cs
@@ -55,9 +55,9 @@ public class When_auto_subscribing_async_with_subscription_configuration_action_
         capturedAction(subscriptionConfiguration);
 
         subscriptionConfiguration.AutoDelete.Should().BeTrue();
-        subscriptionConfiguration.Expires.Should().Be(10);
         subscriptionConfiguration.PrefetchCount.Should().Be(10);
         subscriptionConfiguration.Priority.Should().Be(10);
+        subscriptionConfiguration.QueueArguments.Should().BeEquivalentTo(new Dictionary<string, object> { { "x-expires", 10 } });
     }
 
     // Discovered by reflection over test assembly, do not remove.

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_auto_subscribing_with_subscription_configuration.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_auto_subscribing_with_subscription_configuration.cs
@@ -46,9 +46,9 @@ public class When_auto_subscribing_with_subscription_configuration_attribute
         capturedAction(subscriptionConfiguration);
 
         subscriptionConfiguration.AutoDelete.Should().BeTrue();
-        subscriptionConfiguration.Expires.Should().Be(10);
         subscriptionConfiguration.PrefetchCount.Should().Be(10);
         subscriptionConfiguration.Priority.Should().Be(10);
+        subscriptionConfiguration.QueueArguments.Should().BeEquivalentTo(new Dictionary<string, object> { { "x-expires", 10 } });
     }
 
     // Discovered by reflection over test assembly, do not remove.

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_auto_subscribing_with_subscription_configuration_action.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_auto_subscribing_with_subscription_configuration_action.cs
@@ -53,9 +53,9 @@ public class When_auto_subscribing_with_subscription_configuration_action
         capturedAction(subscriptionConfiguration);
 
         subscriptionConfiguration.AutoDelete.Should().BeTrue();
-        subscriptionConfiguration.Expires.Should().Be(10);
         subscriptionConfiguration.PrefetchCount.Should().Be(10);
         subscriptionConfiguration.Priority.Should().Be(10);
+        subscriptionConfiguration.QueueArguments.Should().BeEquivalentTo(new Dictionary<string, object> { { "x-expires", 10 } });
     }
 
     // Discovered by reflection over test assembly, do not remove.

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_auto_subscribing_with_subscription_configuration_action_and_attribute.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_auto_subscribing_with_subscription_configuration_action_and_attribute.cs
@@ -53,9 +53,9 @@ public class When_auto_subscribing_with_subscription_configuration_action_and_at
         capturedAction(subscriptionConfiguration);
 
         subscriptionConfiguration.AutoDelete.Should().BeTrue();
-        subscriptionConfiguration.Expires.Should().Be(10);
         subscriptionConfiguration.PrefetchCount.Should().Be(10);
         subscriptionConfiguration.Priority.Should().Be(10);
+        subscriptionConfiguration.QueueArguments.Should().BeEquivalentTo(new Dictionary<string, object> { { "x-expires", 10 } });
     }
 
     // Discovered by reflection over test assembly, do not remove.

--- a/Source/EasyNetQ.Tests/AutoSubscriberTests/When_auto_subscribing_with_subscription_configuration_attribute_no_expires.cs
+++ b/Source/EasyNetQ.Tests/AutoSubscriberTests/When_auto_subscribing_with_subscription_configuration_attribute_no_expires.cs
@@ -46,9 +46,9 @@ public class When_auto_subscribing_with_subscription_configuration_attribute_no_
         capturedAction(subscriptionConfiguration);
 
         subscriptionConfiguration.AutoDelete.Should().BeTrue();
-        subscriptionConfiguration.Expires.Should().Be(null);
         subscriptionConfiguration.PrefetchCount.Should().Be(10);
         subscriptionConfiguration.Priority.Should().Be(10);
+        subscriptionConfiguration.QueueArguments.Should().BeNull();
     }
 
     // Discovered by reflection over test assembly, do not remove.

--- a/Source/EasyNetQ.Tests/ConnectionStringTests.cs
+++ b/Source/EasyNetQ.Tests/ConnectionStringTests.cs
@@ -39,7 +39,7 @@ public class ConnectionStringTests
     [Fact]
     public void Should_parse_seond_port()
     {
-        connectionString.Hosts.Last().Port.Should().Be((ushort)1002);
+        connectionString.Hosts.Last().Port.Should().Be(1002);
     }
 
     [Fact]

--- a/Source/EasyNetQ.Tests/ExchangeQueueBindingTests.cs
+++ b/Source/EasyNetQ.Tests/ExchangeQueueBindingTests.cs
@@ -12,10 +12,11 @@ public class When_a_queue_is_declared : IDisposable
         mockBuilder = new MockBuilder();
 
         queue = mockBuilder.Bus.Advanced.QueueDeclare(
-            "my_queue",
-            c => c.AsDurable(false)
-                .AsExclusive(true)
-                .AsAutoDelete(true)
+            queue: "my_queue",
+            durable: false,
+            exclusive: true,
+            autoDelete: true,
+            arguments: new Dictionary<string, object>()
                 .WithMessageTtl(TimeSpan.FromSeconds(1))
                 .WithExpires(TimeSpan.FromSeconds(2))
                 .WithMaxPriority(10)
@@ -38,10 +39,12 @@ public class When_a_queue_is_declared : IDisposable
             Arg.Is(false),
             Arg.Is(true),
             Arg.Is(true),
-            Arg.Is<IDictionary<string, object>>(args =>
-                (int)args["x-message-ttl"] == 1000 &&
-                (int)args["x-expires"] == 2000 &&
-                (int)args["x-max-priority"] == 10));
+            Arg.Is<IDictionary<string, object>>(
+                args => (int)args["x-message-ttl"] == 1000 &&
+                        (int)args["x-expires"] == 2000 &&
+                        (byte)args["x-max-priority"] == 10
+            )
+        );
     }
 
     [Fact]
@@ -60,14 +63,15 @@ public class When_a_queue_is_declared_With_NonEmptyDeadLetterExchange : IDisposa
 
         var advancedBus = mockBuilder.Bus.Advanced;
         queue = advancedBus.QueueDeclare(
-            "my_queue",
-            c => c.AsDurable(false)
-                .AsExclusive(true)
-                .AsAutoDelete(true)
+            queue: "my_queue",
+            durable: false,
+            exclusive: true,
+            autoDelete: true,
+            arguments: new Dictionary<string, object>()
                 .WithMessageTtl(TimeSpan.FromSeconds(1))
                 .WithExpires(TimeSpan.FromSeconds(2))
                 .WithMaxPriority(10)
-                .WithDeadLetterExchange(new Exchange("my_exchange"))
+                .WithDeadLetterExchange("my_exchange")
                 .WithDeadLetterRoutingKey("my_routing_key")
         );
     }
@@ -88,12 +92,14 @@ public class When_a_queue_is_declared_With_NonEmptyDeadLetterExchange : IDisposa
             Arg.Is(false),
             Arg.Is(true),
             Arg.Is(true),
-            Arg.Is<IDictionary<string, object>>(args =>
-                (int)args["x-message-ttl"] == 1000 &&
-                (int)args["x-expires"] == 2000 &&
-                (int)args["x-max-priority"] == 10 &&
-                (string)args["x-dead-letter-exchange"] == "my_exchange" &&
-                (string)args["x-dead-letter-routing-key"] == "my_routing_key"));
+            Arg.Is<IDictionary<string, object>>(
+                args => (int)args["x-message-ttl"] == 1000 &&
+                        (int)args["x-expires"] == 2000 &&
+                        (byte)args["x-max-priority"] == 10 &&
+                        (string)args["x-dead-letter-exchange"] == "my_exchange" &&
+                        (string)args["x-dead-letter-routing-key"] == "my_routing_key"
+            )
+        );
     }
 
     [Fact]
@@ -111,14 +117,15 @@ public class When_a_queue_is_declared_With_EmptyDeadLetterExchange : IDisposable
         mockBuilder = new MockBuilder();
 
         queue = mockBuilder.Bus.Advanced.QueueDeclare(
-            "my_queue",
-            c => c.AsDurable(false)
-                .AsExclusive(true)
-                .AsAutoDelete(true)
+            queue: "my_queue",
+            durable: false,
+            exclusive: true,
+            autoDelete: true,
+            arguments: new Dictionary<string, object>()
                 .WithMessageTtl(TimeSpan.FromSeconds(1))
                 .WithExpires(TimeSpan.FromSeconds(2))
                 .WithMaxPriority(10)
-                .WithDeadLetterExchange(Exchange.Default)
+                .WithDeadLetterExchange(Exchange.DefaultName)
                 .WithDeadLetterRoutingKey("my_queue2")
         );
     }
@@ -139,12 +146,14 @@ public class When_a_queue_is_declared_With_EmptyDeadLetterExchange : IDisposable
             Arg.Is(false),
             Arg.Is(true),
             Arg.Is(true),
-            Arg.Is<IDictionary<string, object>>(args =>
-                (int)args["x-message-ttl"] == 1000 &&
-                (int)args["x-expires"] == 2000 &&
-                (int)args["x-max-priority"] == 10 &&
-                (string)args["x-dead-letter-exchange"] == "" &&
-                (string)args["x-dead-letter-routing-key"] == "my_queue2"));
+            Arg.Is<IDictionary<string, object>>(
+                args => (int)args["x-message-ttl"] == 1000 &&
+                        (int)args["x-expires"] == 2000 &&
+                        (byte)args["x-max-priority"] == 10 &&
+                        (string)args["x-dead-letter-exchange"] == "" &&
+                        (string)args["x-dead-letter-routing-key"] == "my_queue2"
+            )
+        );
     }
 
     [Fact]
@@ -207,15 +216,12 @@ public class When_an_exchange_is_declared : IDisposable
     {
         mockBuilder = new MockBuilder();
 
-        mockBuilder.NextModel.WhenForAnyArgs(x => x.ExchangeDeclare(null, null, false, false, null))
-            .Do(x => { arguments = x[4] as IDictionary; });
-
         exchange = mockBuilder.Bus.Advanced.ExchangeDeclare(
             "my_exchange",
-            c => c.WithType(ExchangeType.Direct)
-                .AsDurable(false)
-                .AsAutoDelete(true)
-                .WithAlternateExchange(new Exchange("my.alternate.exchange"))
+            type: ExchangeType.Direct,
+            durable: false,
+            autoDelete: true,
+            arguments: new Dictionary<string, object>().WithAlternateExchange("my.alternate.exchange")
         );
     }
 
@@ -226,14 +232,6 @@ public class When_an_exchange_is_declared : IDisposable
 
     private readonly MockBuilder mockBuilder;
     private readonly Exchange exchange;
-    private IDictionary arguments;
-
-    [Fact]
-    public void Should_add_correct_arguments()
-    {
-        arguments.Should().NotBeNull();
-        arguments["alternate-exchange"].Should().Be("my.alternate.exchange");
-    }
 
     [Fact]
     public void Should_declare_an_exchange()
@@ -243,7 +241,8 @@ public class When_an_exchange_is_declared : IDisposable
             Arg.Is("direct"),
             Arg.Is(false),
             Arg.Is(true),
-            Arg.Any<IDictionary<string, object>>());
+            Arg.Is<IDictionary<string, object>>(c => (string)c["alternate-exchange"] == "my.alternate.exchange")
+        );
     }
 
     [Fact]

--- a/Source/EasyNetQ.Tests/FluentConfiguration/SubscriptionConfigurationTests.cs
+++ b/Source/EasyNetQ.Tests/FluentConfiguration/SubscriptionConfigurationTests.cs
@@ -13,20 +13,15 @@ public class SubscriptionConfigurationTests
         Assert.False(configuration.IsExclusive);
         Assert.True(configuration.Durable);
         Assert.Null(configuration.QueueName);
-        Assert.Null(configuration.MaxLength);
-        Assert.Null(configuration.MaxLengthBytes);
-        Assert.Null(configuration.QueueMode);
-        Assert.Null(configuration.QueueType);
+        Assert.Null(configuration.QueueArguments);
     }
 
     [Fact]
     public void WithQueueType_default_is_classic()
     {
         var configuration = new SubscriptionConfiguration(99);
-
         configuration.WithQueueType();
-
-        Assert.Equal(QueueType.Classic, configuration.QueueType);
+        configuration.QueueArguments.Should().BeEquivalentTo(new Dictionary<string, object> { { "x-queue-type", "classic" } });
     }
 
     [Theory]
@@ -35,9 +30,7 @@ public class SubscriptionConfigurationTests
     public void WithQueueType_sets_correct_queueType(string queueType)
     {
         var configuration = new SubscriptionConfiguration(99);
-
         configuration.WithQueueType(queueType);
-
-        Assert.Equal(queueType, configuration.QueueType);
+        configuration.QueueArguments.Should().BeEquivalentTo(new Dictionary<string, object> { { "x-queue-type", queueType } });
     }
 }

--- a/Source/EasyNetQ.Tests/MessageVersioningTests/VersionedExchangeDeclareStrategyTests.cs
+++ b/Source/EasyNetQ.Tests/MessageVersioningTests/VersionedExchangeDeclareStrategyTests.cs
@@ -14,7 +14,7 @@ public class VersionedExchangeDeclareStrategyTests
         var advancedBus = Substitute.For<IAdvancedBus>();
         var exchange = new Exchange(exchangeName);
 
-        advancedBus.ExchangeDeclareAsync(exchangeName, Arg.Any<Action<IExchangeDeclareConfiguration>>()).Returns(
+        advancedBus.ExchangeDeclareAsync(exchangeName).Returns(
             _ => Task.FromException(new Exception()),
             _ =>
             {
@@ -35,7 +35,7 @@ public class VersionedExchangeDeclareStrategyTests
         }
 
         var declaredExchange = exchangeDeclareStrategy.DeclareExchange(exchangeName, ExchangeType.Topic);
-        advancedBus.Received(2).ExchangeDeclareAsync(exchangeName, Arg.Any<Action<IExchangeDeclareConfiguration>>());
+        advancedBus.Received(2).ExchangeDeclareAsync(exchangeName);
         declaredExchange.Should().BeEquivalentTo(exchange);
         exchangeDeclareCount.Should().Be(1);
     }
@@ -48,7 +48,7 @@ public class VersionedExchangeDeclareStrategyTests
         var exchanges = new List<Exchange>();
         var boundExchanges = new Dictionary<string, string>();
         var advancedBus = Substitute.For<IAdvancedBus>();
-        advancedBus.ExchangeDeclareAsync(Arg.Any<string>(), Arg.Any<Action<IExchangeDeclareConfiguration>>())
+        advancedBus.ExchangeDeclareAsync(Arg.Any<string>())
             .ReturnsForAnyArgs(mi =>
             {
                 var exchange = new Exchange((string)mi[0]);
@@ -83,7 +83,7 @@ public class VersionedExchangeDeclareStrategyTests
         var exchanges = new List<string>();
         var boundExchanges = new Dictionary<string, string>();
         var advancedBus = Substitute.For<IAdvancedBus>();
-        advancedBus.ExchangeDeclareAsync(Arg.Any<string>(), Arg.Any<Action<IExchangeDeclareConfiguration>>())
+        advancedBus.ExchangeDeclareAsync(Arg.Any<string>())
             .ReturnsForAnyArgs(mi =>
             {
                 var exchange = (string)mi[0];

--- a/Source/EasyNetQ.Tests/ProducerTests/PublishExchangeDeclareStrategyTests.cs
+++ b/Source/EasyNetQ.Tests/ProducerTests/PublishExchangeDeclareStrategyTests.cs
@@ -15,7 +15,7 @@ public class ExchangeDeclareStrategyTests
         var advancedBus = Substitute.For<IAdvancedBus>();
         var exchange = new Exchange(exchangeName);
 
-        advancedBus.ExchangeDeclareAsync(exchangeName, Arg.Any<Action<IExchangeDeclareConfiguration>>()).Returns(
+        advancedBus.ExchangeDeclareAsync(exchangeName).Returns(
             _ => Task.FromException(new Exception()),
             _ =>
             {
@@ -33,7 +33,7 @@ public class ExchangeDeclareStrategyTests
         }
 
         var declaredExchange = exchangeDeclareStrategy.DeclareExchange(exchangeName, ExchangeType.Topic);
-        advancedBus.Received(2).ExchangeDeclareAsync(exchangeName, Arg.Any<Action<IExchangeDeclareConfiguration>>());
+        advancedBus.Received(2).ExchangeDeclareAsync(exchangeName);
         declaredExchange.Should().BeEquivalentTo(exchange);
         exchangeDeclareCount.Should().Be(1);
     }
@@ -44,7 +44,7 @@ public class ExchangeDeclareStrategyTests
         var exchangeDeclareCount = 0;
         var advancedBus = Substitute.For<IAdvancedBus>();
         var exchange = new Exchange(exchangeName);
-        advancedBus.ExchangeDeclareAsync(exchangeName, Arg.Any<Action<IExchangeDeclareConfiguration>>())
+        advancedBus.ExchangeDeclareAsync(exchangeName)
             .Returns(_ =>
             {
                 exchangeDeclareCount++;
@@ -55,7 +55,7 @@ public class ExchangeDeclareStrategyTests
 
         var declaredExchange = publishExchangeDeclareStrategy.DeclareExchange(exchangeName, ExchangeType.Topic);
 
-        advancedBus.Received().ExchangeDeclareAsync(exchangeName, Arg.Any<Action<IExchangeDeclareConfiguration>>());
+        advancedBus.Received().ExchangeDeclareAsync(exchangeName);
         declaredExchange.Should().BeEquivalentTo(exchange);
         exchangeDeclareCount.Should().Be(1);
     }
@@ -66,7 +66,7 @@ public class ExchangeDeclareStrategyTests
         var exchangeDeclareCount = 0;
         var advancedBus = Substitute.For<IAdvancedBus>();
         var exchange = new Exchange(exchangeName);
-        advancedBus.ExchangeDeclareAsync(exchangeName, Arg.Any<Action<IExchangeDeclareConfiguration>>()).Returns(_ =>
+        advancedBus.ExchangeDeclareAsync(exchangeName).Returns(_ =>
         {
             exchangeDeclareCount++;
             return Task.FromResult(exchange);
@@ -77,7 +77,7 @@ public class ExchangeDeclareStrategyTests
         var _ = exchangeDeclareStrategy.DeclareExchange(exchangeName, ExchangeType.Topic);
         var declaredExchange = exchangeDeclareStrategy.DeclareExchange(exchangeName, ExchangeType.Topic);
 
-        advancedBus.Received().ExchangeDeclareAsync(exchangeName, Arg.Any<Action<IExchangeDeclareConfiguration>>());
+        advancedBus.Received().ExchangeDeclareAsync(exchangeName);
         declaredExchange.Should().BeEquivalentTo(exchange);
         exchangeDeclareCount.Should().Be(1);
     }

--- a/Source/EasyNetQ.Tests/SubscribeTests.cs
+++ b/Source/EasyNetQ.Tests/SubscribeTests.cs
@@ -180,11 +180,10 @@ public class When_subscribe_with_configuration_is_called
             Arg.Is(false),
             Arg.Is(autoDelete),
             Arg.Is<IDictionary<string, object>>(
-                x =>
-                    (!expires.HasValue || expires.Value == (int)x["x-expires"]) &&
-                    (!maxPriority.HasValue || maxPriority.Value == (int)x["x-max-priority"]) &&
-                    (!maxLength.HasValue || maxLength.Value == (int)x["x-max-length"]) &&
-                    (!maxLengthBytes.HasValue || maxLengthBytes.Value == (int)x["x-max-length-bytes"])
+                x => (!expires.HasValue || expires.Value == (int)x["x-expires"]) &&
+                     (!maxPriority.HasValue || maxPriority.Value == (byte)x["x-max-priority"]) &&
+                     (!maxLength.HasValue || maxLength.Value == (int)x["x-max-length"]) &&
+                     (!maxLengthBytes.HasValue || maxLengthBytes.Value == (int)x["x-max-length-bytes"])
             )
         );
 
@@ -207,7 +206,8 @@ public class When_subscribe_with_configuration_is_called
             Arg.Is(queueName),
             Arg.Is("EasyNetQ.Tests.MyMessage, EasyNetQ.Tests"),
             Arg.Is(topic ?? "#"),
-            Arg.Is((IDictionary<string, object>)null));
+            Arg.Is((IDictionary<string, object>)null)
+        );
     }
 }
 

--- a/Source/EasyNetQ/AdvancedBusExtensions.FluentTopology.cs
+++ b/Source/EasyNetQ/AdvancedBusExtensions.FluentTopology.cs
@@ -1,0 +1,110 @@
+using EasyNetQ.Topology;
+
+namespace EasyNetQ;
+
+/// <summary>
+///     Various extensions for <see cref="IAdvancedBus"/>
+/// </summary>
+public static partial class AdvancedBusExtensions
+{
+    /// <summary>
+    /// Declare a queue. If the queue already exists this method does nothing
+    /// </summary>
+    /// <param name="bus">The bus instance</param>
+    /// <param name="queue">The name of the queue</param>
+    /// <param name="configure">Delegate to configure the queue</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <returns>
+    /// The queue
+    /// </returns>
+    public static Task<Queue> QueueDeclareAsync(
+        this IAdvancedBus bus,
+        string queue,
+        Action<IQueueDeclareConfiguration> configure,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var queueDeclareConfiguration = new QueueDeclareConfiguration();
+        configure(queueDeclareConfiguration);
+
+        return bus.QueueDeclareAsync(
+            queue: queue,
+            durable: queueDeclareConfiguration.IsDurable,
+            exclusive: queueDeclareConfiguration.IsExclusive,
+            autoDelete: queueDeclareConfiguration.IsAutoDelete,
+            arguments: queueDeclareConfiguration.Arguments,
+            cancellationToken: cancellationToken
+        );
+    }
+
+
+    /// <summary>
+    /// Declare a queue. If the queue already exists this method does nothing
+    /// </summary>
+    /// <param name="bus">The bus instance</param>
+    /// <param name="queue">The name of the queue</param>
+    /// <param name="configure">Delegate to configure the queue</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <returns>
+    /// The queue
+    /// </returns>
+    public static Queue QueueDeclare(
+        this IAdvancedBus bus,
+        string queue,
+        Action<IQueueDeclareConfiguration> configure,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return bus.QueueDeclareAsync(queue, configure, cancellationToken)
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    /// <summary>
+    /// Declare an exchange
+    /// </summary>
+    /// <param name="bus">The bus instance</param>
+    /// <param name="exchange">The exchange name</param>
+    /// <param name="configure">The configuration of exchange</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <returns>The exchange</returns>
+    public static Task<Exchange> ExchangeDeclareAsync(
+        this IAdvancedBus bus,
+        string exchange,
+        Action<IExchangeDeclareConfiguration> configure,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var exchangeDeclareConfiguration = new ExchangeDeclareConfiguration();
+        configure(exchangeDeclareConfiguration);
+
+        return bus.ExchangeDeclareAsync(
+            exchange: exchange,
+            type: exchangeDeclareConfiguration.Type,
+            durable: exchangeDeclareConfiguration.IsDurable,
+            autoDelete: exchangeDeclareConfiguration.IsAutoDelete,
+            arguments: exchangeDeclareConfiguration.Arguments,
+            cancellationToken: cancellationToken
+        );
+    }
+
+    /// <summary>
+    /// Declare an exchange
+    /// </summary>
+    /// <param name="bus">The bus instance</param>
+    /// <param name="exchange">The exchange name</param>
+    /// <param name="configure">The configuration of exchange</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <returns>The exchange</returns>
+    public static Exchange ExchangeDeclare(
+        this IAdvancedBus bus,
+        string exchange,
+        Action<IExchangeDeclareConfiguration> configure,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return bus.ExchangeDeclareAsync(exchange, configure, cancellationToken)
+            .GetAwaiter()
+            .GetResult();
+    }
+}

--- a/Source/EasyNetQ/AdvancedBusExtensions.Topology.cs
+++ b/Source/EasyNetQ/AdvancedBusExtensions.Topology.cs
@@ -24,58 +24,6 @@ public static partial class AdvancedBusExtensions
     }
 
     /// <summary>
-    /// Declare a transient server named queue. Note, this queue will only last for duration of the
-    /// connection. If there is a connection outage, EasyNetQ will not attempt to recreate
-    /// consumers.
-    /// </summary>
-    /// <param name="bus">The bus instance</param>
-    /// <param name="cancellationToken">The cancellation token</param>
-    /// <returns>The queue</returns>
-    public static Queue QueueDeclare(this IAdvancedBus bus, CancellationToken cancellationToken = default)
-    {
-        return bus.QueueDeclareAsync(cancellationToken)
-            .GetAwaiter()
-            .GetResult();
-    }
-
-    /// <summary>
-    /// Declare a queue. If the queue already exists this method does nothing
-    /// </summary>
-    /// <param name="bus">The bus instance</param>
-    /// <param name="queue">The name of the queue</param>
-    /// <param name="configure">Delegate to configure the queue</param>
-    /// <param name="cancellationToken">The cancellation token</param>
-    /// <returns>
-    /// The queue
-    /// </returns>
-    public static Queue QueueDeclare(
-        this IAdvancedBus bus,
-        string queue,
-        Action<IQueueDeclareConfiguration> configure,
-        CancellationToken cancellationToken = default
-    )
-    {
-        return bus.QueueDeclareAsync(queue, configure, cancellationToken)
-            .GetAwaiter()
-            .GetResult();
-    }
-
-    /// <summary>
-    /// Declare a queue. If the queue already exists this method does nothing
-    /// </summary>
-    /// <param name="bus">The bus instance</param>
-    /// <param name="queue">The name of the queue</param>
-    /// <param name="cancellationToken">The cancellation token</param>
-    /// <returns>
-    /// The queue
-    /// </returns>
-    public static Task<Queue> QueueDeclareAsync(
-        this IAdvancedBus bus,
-        string queue,
-        CancellationToken cancellationToken = default
-    ) => bus.QueueDeclareAsync(queue, _ => { }, cancellationToken);
-
-    /// <summary>
     /// Declare a queue. If the queue already exists this method does nothing
     /// </summary>
     /// <param name="bus">The bus instance</param>
@@ -83,36 +31,7 @@ public static partial class AdvancedBusExtensions
     /// <param name="durable">Durable queues remain active when a server restarts.</param>
     /// <param name="exclusive">Exclusive queues may only be accessed by the current connection, and are deleted when that connection closes.</param>
     /// <param name="autoDelete">If set, the queue is deleted when all consumers have finished using it.</param>
-    /// <param name="cancellationToken">The cancellation token</param>
-    /// <returns>
-    /// The queue
-    /// </returns>
-    public static Task<Queue> QueueDeclareAsync(
-        this IAdvancedBus bus,
-        string queue,
-        bool durable,
-        bool exclusive,
-        bool autoDelete,
-        CancellationToken cancellationToken = default
-    )
-    {
-        return bus.QueueDeclareAsync(
-            queue,
-            c => c.AsDurable(durable)
-                .AsExclusive(exclusive)
-                .AsAutoDelete(autoDelete),
-            cancellationToken
-        );
-    }
-
-    /// <summary>
-    /// Declare a queue. If the queue already exists this method does nothing
-    /// </summary>
-    /// <param name="bus">The bus instance</param>
-    /// <param name="queue">The name of the queue</param>
-    /// <param name="durable">Durable queues remain active when a server restarts.</param>
-    /// <param name="exclusive">Exclusive queues may only be accessed by the current connection, and are deleted when that connection closes.</param>
-    /// <param name="autoDelete">If set, the queue is deleted when all consumers have finished using it.</param>
+    /// <param name="arguments"></param>
     /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>
     /// The queue
@@ -120,33 +39,14 @@ public static partial class AdvancedBusExtensions
     public static Queue QueueDeclare(
         this IAdvancedBus bus,
         string queue,
-        bool durable,
-        bool exclusive,
-        bool autoDelete,
+        bool durable = true,
+        bool exclusive = false,
+        bool autoDelete = false,
+        IDictionary<string, object>? arguments = null,
         CancellationToken cancellationToken = default
     )
     {
-        return bus.QueueDeclareAsync(queue, durable, exclusive, autoDelete, cancellationToken)
-            .GetAwaiter()
-            .GetResult();
-    }
-
-    /// <summary>
-    /// Declare a queue. If the queue already exists this method does nothing
-    /// </summary>
-    /// <param name="bus">The bus instance</param>
-    /// <param name="queue">The name of the queue</param>
-    /// <param name="cancellationToken">The cancellation token</param>
-    /// <returns>
-    /// The queue
-    /// </returns>
-    public static Queue QueueDeclare(
-        this IAdvancedBus bus,
-        string queue,
-        CancellationToken cancellationToken = default
-    )
-    {
-        return bus.QueueDeclareAsync(queue, cancellationToken)
+        return bus.QueueDeclareAsync(queue, durable, exclusive, autoDelete, arguments, cancellationToken)
             .GetAwaiter()
             .GetResult();
     }
@@ -336,25 +236,6 @@ public static partial class AdvancedBusExtensions
     }
 
     /// <summary>
-    /// Declare an exchange
-    /// </summary>
-    /// <param name="bus">The bus instance</param>
-    /// <param name="exchange">The exchange name</param>
-    /// <param name="type">The type of exchange</param>
-    /// <param name="durable">Durable exchanges remain active when a server restarts.</param>
-    /// <param name="autoDelete">If set, the exchange is deleted when all queues have finished using it.</param>
-    /// <param name="cancellationToken">The cancellation token</param>
-    /// <returns>The exchange</returns>
-    public static Task<Exchange> ExchangeDeclareAsync(
-        this IAdvancedBus bus,
-        string exchange,
-        string type,
-        bool durable = true,
-        bool autoDelete = false,
-        CancellationToken cancellationToken = default
-    ) => bus.ExchangeDeclareAsync(exchange, c => c.AsDurable(durable).AsAutoDelete(autoDelete).WithType(type), cancellationToken);
-
-    /// <summary>
     /// Declare a exchange passively. Throw an exception rather than create the exchange if it doesn't exist
     /// </summary>
     /// <param name="bus">The bus instance</param>
@@ -379,38 +260,20 @@ public static partial class AdvancedBusExtensions
     /// <param name="type">The type of exchange</param>
     /// <param name="durable">Durable exchanges remain active when a server restarts.</param>
     /// <param name="autoDelete">If set, the exchange is deleted when all queues have finished using it.</param>
+    /// <param name="arguments"></param>
     /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>The exchange</returns>
     public static Exchange ExchangeDeclare(
         this IAdvancedBus bus,
         string exchange,
-        string type,
+        string type = ExchangeType.Topic,
         bool durable = true,
         bool autoDelete = false,
+        IDictionary<string, object>? arguments = null,
         CancellationToken cancellationToken = default
     )
     {
-        return bus.ExchangeDeclareAsync(exchange, type, durable, autoDelete, cancellationToken)
-            .GetAwaiter()
-            .GetResult();
-    }
-
-    /// <summary>
-    /// Declare an exchange
-    /// </summary>
-    /// <param name="bus">The bus instance</param>
-    /// <param name="exchange">The exchange name</param>
-    /// <param name="configure">The configuration of exchange</param>
-    /// <param name="cancellationToken">The cancellation token</param>
-    /// <returns>The exchange</returns>
-    public static Exchange ExchangeDeclare(
-        this IAdvancedBus bus,
-        string exchange,
-        Action<IExchangeDeclareConfiguration> configure,
-        CancellationToken cancellationToken = default
-    )
-    {
-        return bus.ExchangeDeclareAsync(exchange, configure, cancellationToken)
+        return bus.ExchangeDeclareAsync(exchange, type, durable, autoDelete, arguments, cancellationToken)
             .GetAwaiter()
             .GetResult();
     }

--- a/Source/EasyNetQ/Argument.cs
+++ b/Source/EasyNetQ/Argument.cs
@@ -1,0 +1,29 @@
+namespace EasyNetQ;
+
+public static class Argument
+{
+    # region Queue
+
+    public const string QueueType = "x-queue-type";
+    public const string QueueMode = "x-queue-mode";
+    public const string Expires = "x-expires";
+    public const string MaxPriority = "x-max-priority";
+    public const string MaxLength = "x-max-length";
+    public const string MaxLengthBytes = "x-max-length-bytes";
+    public const string SingleActiveConsumer = "x-single-active-consumer";
+    public const string DeadLetterExchange = "x-dead-letter-exchange";
+    public const string DeadLetterRoutingKey = "x-dead-letter-routing-key";
+    public const string MessageTtl = "x-message-ttl";
+    public const string QueueMasterLocator = "x-queue-master-locator";
+    public const string DeadLetterStrategy = "x-dead-letter-strategy";
+    public const string Overflow = "x-overflow";
+
+    # endregion Queue
+
+    #region Exchange
+
+    public const string AlternateExchange = "alternate-exchange";
+    public const string DelayedType = "x-delayed-type";
+
+    #endregion
+}

--- a/Source/EasyNetQ/ArgumentsExtensions.cs
+++ b/Source/EasyNetQ/ArgumentsExtensions.cs
@@ -1,0 +1,177 @@
+namespace EasyNetQ;
+
+public static class ArgumentsExtensions
+{
+    # region Queue
+
+    /// <summary>
+    ///     Sets queue type.
+    ///     Valid types are classic and quorum, see <see cref="QueueType"/>.
+    /// </summary>
+    /// <param name="arguments">The queue arguments</param>
+    /// <param name="queueType">The queue type to set</param>
+    /// <returns>The same <paramref name="arguments"/></returns>
+    public static IDictionary<string, object> WithQueueType(this IDictionary<string, object> arguments, string queueType) =>
+        arguments.WithArgument(Argument.QueueType, queueType);
+
+    /// <summary>
+    ///     Sets queue mode.
+    ///     Valid modes are default and lazy, see <see cref="QueueMode"/>.
+    /// </summary>
+    /// <param name="arguments">The queue arguments</param>
+    /// <param name="queueMode">The queue mode to set</param>
+    /// <returns>The same <paramref name="arguments"/></returns>
+    public static IDictionary<string, object> WithQueueMode(this IDictionary<string, object> arguments, string queueMode) =>
+        arguments.WithArgument(Argument.QueueMode, queueMode);
+
+    /// <summary>
+    ///     Sets expires of the queue.
+    ///     Determines how long a queue can remain unused before it is automatically deleted by the server.
+    /// </summary>
+    /// <param name="arguments">The queue arguments</param>
+    /// <param name="expiresMs">The expires to set</param>
+    /// <returns>The same <paramref name="arguments"/></returns>
+    public static IDictionary<string, object> WithExpires(this IDictionary<string, object> arguments, int expiresMs) =>
+        arguments.WithArgument(Argument.Expires, expiresMs);
+
+    /// <summary>
+    ///     Sets expires of the queue.
+    ///     Determines how long a queue can remain unused before it is automatically deleted by the server.
+    /// </summary>
+    /// <param name="arguments">The queue arguments</param>
+    /// <param name="expires">The expires to set</param>
+    /// <returns>The same <paramref name="arguments"/></returns>
+    public static IDictionary<string, object> WithExpires(this IDictionary<string, object> arguments, TimeSpan expires) =>
+        arguments.WithArgument(Argument.Expires, (int)expires.TotalMilliseconds);
+
+    /// <summary>
+    ///     Sets maximum priority the queue should support.
+    /// </summary>
+    /// <param name="arguments">The queue arguments</param>
+    /// <param name="maxPriority">The maximum priority to set, should be a positive integer between 1 and 255</param>
+    /// <returns>The same <paramref name="arguments"/></returns>
+    public static IDictionary<string, object> WithMaxPriority(this IDictionary<string, object> arguments, byte maxPriority) =>
+        arguments.WithArgument(Argument.MaxPriority, maxPriority);
+
+    /// <summary>
+    ///     Sets maximum queue length. The maximum number of ready messages that may exist on the queue.
+    ///     Messages will be dropped or dead-lettered from the front of the queue to make room for new
+    ///     messages once the limit is reached.
+    /// </summary>
+    /// <param name="arguments">The queue arguments</param>
+    /// <param name="maxLength">The maximum length to set</param>
+    /// <returns>The same <paramref name="arguments"/></returns>
+    public static IDictionary<string, object> WithMaxLength(this IDictionary<string, object> arguments, int maxLength) =>
+        arguments.WithArgument(Argument.MaxLength, maxLength);
+
+    /// <summary>
+    ///     Sets maximum queue length in bytes. The maximum size of the queue in bytes.
+    ///     Messages will be dropped or dead-lettered from the front of the queue to make room
+    ///     for new messages once the limit is reached.
+    /// </summary>
+    /// <param name="arguments">The queue arguments</param>
+    /// <param name="maxLengthBytes">The maximum queue length to set</param>
+    /// <returns>The same <paramref name="arguments"/></returns>
+    public static IDictionary<string, object> WithMaxLengthBytes(this IDictionary<string, object> arguments, int maxLengthBytes) =>
+        arguments.WithArgument(Argument.MaxLengthBytes, maxLengthBytes);
+
+    /// <summary>
+    ///     Enables single active consumer.
+    ///     If set, makes sure only one consumer at a time consumes from the queue and fails
+    ///     over to another registered consumer in case the active one is cancelled or dies.
+    /// </summary>
+    /// <param name="arguments">The configuration instance</param>
+    /// <param name="singleActiveConsumer"><see langword="true"/> if a queue has a single active consumer</param>
+    /// <returns>The same <paramref name="arguments"/></returns>
+    public static IDictionary<string, object> WithSingleActiveConsumer(this IDictionary<string, object> arguments, bool singleActiveConsumer = true) =>
+        arguments.WithArgument(Argument.SingleActiveConsumer, singleActiveConsumer);
+
+    /// <summary>
+    ///     Sets message TTL.
+    ///     Determines how long a message published to a queue can live before it is discarded by the server.
+    /// </summary>
+    /// <param name="arguments">The configuration instance</param>
+    /// <param name="messageTtlMs">The message TTL to set</param>
+    /// <returns>The same <paramref name="arguments"/></returns>
+    public static IDictionary<string, object> WithMessageTtl(this IDictionary<string, object> arguments, int messageTtlMs) =>
+        arguments.WithArgument(Argument.MessageTtl, messageTtlMs);
+
+    /// <summary>
+    ///     Sets message TTL.
+    ///     Determines how long a message published to a queue can live before it is discarded by the server.
+    /// </summary>
+    /// <param name="arguments">The configuration instance</param>
+    /// <param name="messageTtl">The message TTL to set</param>
+    /// <returns>The same <paramref name="arguments"/></returns>
+    public static IDictionary<string, object> WithMessageTtl(this IDictionary<string, object> arguments, TimeSpan messageTtl) =>
+        arguments.WithArgument(Argument.MessageTtl, (int)messageTtl.TotalMilliseconds);
+
+    /// <summary>
+    ///     Sets dead letter exchange for queue.
+    ///     An exchange to which messages will be republished if they are rejected or expire.
+    /// </summary>
+    /// <param name="arguments">The configuration instance</param>
+    /// <param name="deadLetterExchange">The dead letter exchange to set</param>
+    /// <returns>The same <paramref name="arguments"/></returns>
+    public static IDictionary<string, object> WithDeadLetterExchange(this IDictionary<string, object> arguments, string deadLetterExchange) =>
+        arguments.WithArgument(Argument.DeadLetterExchange, deadLetterExchange);
+
+    /// <summary>
+    ///     Sets dead letter routing key.
+    ///     If set, will route message when this message is dead-lettered with the routing key specified.
+    ///     If not set, message will be routed with the same routing keys they were originally published with.
+    /// </summary>
+    /// <param name="arguments">The configuration instance</param>
+    /// <param name="deadLetterRoutingKey">The dead letter routing key to set</param>
+    /// <returns>The same <paramref name="arguments"/></returns>
+    public static IDictionary<string, object> WithDeadLetterRoutingKey(this IDictionary<string, object> arguments, string deadLetterRoutingKey) =>
+        arguments.WithArgument(Argument.DeadLetterRoutingKey, deadLetterRoutingKey);
+
+    /// <summary>
+    ///     Sets queue master locator.
+    ///     Valid types are min-masters, client-local and random, see <see cref="QueueMasterLocator"/>.
+    /// </summary>
+    /// <param name="arguments">The configuration instance</param>
+    /// <param name="queueMasterLocator">The queue master locator to set</param>
+    /// <returns>The same <paramref name="arguments"/></returns>
+    public static IDictionary<string, object> WithQueueMasterLocator(this IDictionary<string, object> arguments, string queueMasterLocator) =>
+        arguments.WithArgument(Argument.QueueMasterLocator, queueMasterLocator);
+
+    /// <summary>
+    ///     Sets dead letter strategy.
+    ///     Valid types are at-least-once and at-most-once, see <see cref="DeadLetterStrategy"/>.
+    /// </summary>
+    /// <param name="arguments">The configuration instance</param>
+    /// <param name="deadLetterStrategy">The dead letter strategy to set</param>
+    /// <returns>The same <paramref name="arguments"/></returns>
+    public static IDictionary<string, object> WithDeadLetterStrategy(this IDictionary<string, object> arguments, string deadLetterStrategy) =>
+        arguments.WithArgument(Argument.DeadLetterStrategy, deadLetterStrategy);
+
+    /// <summary>
+    ///     Sets overflow type to configure overflow behaviour.
+    ///     Valid types are drop-head, reject-publish and reject-publish-dlx, see <see cref="OverflowType"/>.
+    /// </summary>
+    /// <param name="arguments">The configuration instance</param>
+    /// <param name="overflowType">The overflow type to set</param>
+    /// <returns>The same <paramref name="arguments"/></returns>
+    public static IDictionary<string, object> WithOverflowType(this IDictionary<string, object> arguments, string overflowType) =>
+        arguments.WithArgument(Argument.Overflow, overflowType);
+
+    # endregion
+
+    # region Exchange
+
+    public static IDictionary<string, object> WithAlternateExchange(this IDictionary<string, object> arguments, string alternateExchange) =>
+        arguments.WithArgument(Argument.AlternateExchange, alternateExchange);
+
+    public static IDictionary<string, object> WithDelayedType(this IDictionary<string, object> arguments, string delayedType) =>
+        arguments.WithArgument(Argument.DelayedType, delayedType);
+
+    # endregion
+
+    public static IDictionary<string, object> WithArgument(this IDictionary<string, object> arguments, string name, object value)
+    {
+        arguments[name] = value;
+        return arguments;
+    }
+}

--- a/Source/EasyNetQ/DeadLetterExchangeAndMessageTtlScheduler.cs
+++ b/Source/EasyNetQ/DeadLetterExchangeAndMessageTtlScheduler.cs
@@ -64,13 +64,11 @@ public class DeadLetterExchangeAndMessageTtlScheduler : IScheduler
         ).ConfigureAwait(false);
 
         var futureQueue = await advancedBus.QueueDeclareAsync(
-            conventions.QueueNamingConvention(typeof(T), delayString),
-            c =>
-            {
-                c.WithMessageTtl(delay);
-                c.WithDeadLetterExchange(exchange);
-            },
-            cts.Token
+            queue: conventions.QueueNamingConvention(typeof(T), delayString),
+            arguments: new Dictionary<string, object>()
+                .WithMessageTtl(delay)
+                .WithDeadLetterExchange(exchange.Name),
+            cancellationToken: cts.Token
         ).ConfigureAwait(false);
 
         await advancedBus.BindAsync(futureExchange, futureQueue, topic, cts.Token).ConfigureAwait(false);
@@ -78,7 +76,7 @@ public class DeadLetterExchangeAndMessageTtlScheduler : IScheduler
         var properties = new MessageProperties
         {
             Priority = publishConfiguration.Priority ?? 0,
-            Headers = publishConfiguration.Headers == null ? null : new Dictionary<string, object?>(publishConfiguration.Headers),
+            Headers = publishConfiguration.MessageHeaders,
             DeliveryMode = messageDeliveryModeStrategy.GetDeliveryMode(typeof(T)),
         };
         var advancedMessage = new Message<T>(message, properties);

--- a/Source/EasyNetQ/DefaultRpc.cs
+++ b/Source/EasyNetQ/DefaultRpc.cs
@@ -81,7 +81,7 @@ public class DefaultRpc : IRpc, IDisposable
         var routingKey = requestConfiguration.QueueName;
         var expiration = requestConfiguration.Expiration;
         var priority = requestConfiguration.Priority;
-        var headers = requestConfiguration.Headers;
+        var headers = requestConfiguration.MessageHeaders;
         await RequestPublishAsync(
             request,
             routingKey,
@@ -194,8 +194,10 @@ public class DefaultRpc : IRpc, IDisposable
 
         var queue = await advancedBus.QueueDeclareAsync(
             conventions.RpcReturnQueueNamingConvention(responseType),
-            c => c.AsDurable(false).AsExclusive(true).AsAutoDelete(true),
-            cancellationToken
+            durable: false,
+            exclusive: true,
+            autoDelete: true,
+            cancellationToken: cancellationToken
         ).ConfigureAwait(false);
 
         var exchangeName = conventions.RpcResponseExchangeNamingConvention(responseType);
@@ -247,7 +249,7 @@ public class DefaultRpc : IRpc, IDisposable
             ReplyTo = returnQueueName,
             CorrelationId = correlationId,
             Priority = priority ?? 0,
-            Headers = headers == null ? null : new Dictionary<string, object?>(headers),
+            Headers = headers,
             DeliveryMode = messageDeliveryModeStrategy.GetDeliveryMode(requestType),
             Expiration = expiration == Timeout.InfiniteTimeSpan ? null : expiration
         };
@@ -271,22 +273,18 @@ public class DefaultRpc : IRpc, IDisposable
         var routingKey = responderConfiguration.QueueName ?? conventions.RpcRoutingKeyNamingConvention(requestType);
 
         var exchange = await advancedBus.ExchangeDeclareAsync(
-            conventions.RpcRequestExchangeNamingConvention(requestType),
-            ExchangeType.Direct,
+            exchange: conventions.RpcRequestExchangeNamingConvention(requestType),
+            type: ExchangeType.Direct,
             cancellationToken: cancellationToken
         ).ConfigureAwait(false);
+
         var queue = await advancedBus.QueueDeclareAsync(
-            routingKey,
-            c =>
-            {
-                c.AsDurable(responderConfiguration.Durable);
-                if (responderConfiguration.Expires != null)
-                    c.WithExpires(responderConfiguration.Expires.Value);
-                if (responderConfiguration.MaxPriority.HasValue)
-                    c.WithMaxPriority(responderConfiguration.MaxPriority.Value);
-            },
-            cancellationToken
+            queue: routingKey,
+            durable: responderConfiguration.Durable,
+            arguments: responderConfiguration.QueueArguments,
+            cancellationToken: cancellationToken
         ).ConfigureAwait(false);
+
         await advancedBus.BindAsync(exchange, queue, routingKey, cancellationToken).ConfigureAwait(false);
 
         return advancedBus.Consume<TRequest>(

--- a/Source/EasyNetQ/DelayedExchangeScheduler.cs
+++ b/Source/EasyNetQ/DelayedExchangeScheduler.cs
@@ -49,22 +49,22 @@ public class DelayedExchangeScheduler : IScheduler
         var exchangeName = conventions.ExchangeNamingConvention(typeof(T));
         var futureExchangeName = exchangeName + "_delayed";
         var futureExchange = await advancedBus.ExchangeDeclareAsync(
-            futureExchangeName,
-            c => c.AsDelayedExchange(ExchangeType.Topic),
-            cts.Token
+            exchange: futureExchangeName,
+            type: ExchangeType.DelayedMessage,
+            arguments: new Dictionary<string, object>().WithDelayedType(ExchangeType.Topic),
+            cancellationToken: cts.Token
         ).ConfigureAwait(false);
 
         var exchange = await advancedBus.ExchangeDeclareAsync(
-            exchangeName,
-            c => c.WithType(ExchangeType.Topic),
-            cts.Token
+            exchange: exchangeName,
+            cancellationToken: cts.Token
         ).ConfigureAwait(false);
         await advancedBus.BindAsync(futureExchange, exchange, topic, cts.Token).ConfigureAwait(false);
 
         var properties = new MessageProperties
         {
             Priority = publishConfiguration.Priority ?? 0,
-            Headers = publishConfiguration.Headers == null ? null : new Dictionary<string, object?>(publishConfiguration.Headers),
+            Headers = publishConfiguration.MessageHeaders,
             DeliveryMode = messageDeliveryModeStrategy.GetDeliveryMode(typeof(T))
         }.WithDelay(delay);
 

--- a/Source/EasyNetQ/ExchangeDeclareConfigurationExtensions.cs
+++ b/Source/EasyNetQ/ExchangeDeclareConfigurationExtensions.cs
@@ -13,7 +13,6 @@ public static class ExchangeDeclareConfigurationExtensions
     /// <param name="configuration">The configuration instance</param>
     /// <param name="alternateExchange">The alternate exchange to set</param>
     /// <returns>The same <paramref name="configuration"/></returns>
-    public static IExchangeDeclareConfiguration WithAlternateExchange(
-        this IExchangeDeclareConfiguration configuration, in Exchange alternateExchange
-    ) => configuration.WithArgument("alternate-exchange", alternateExchange.Name);
+    public static IExchangeDeclareConfiguration WithAlternateExchange(this IExchangeDeclareConfiguration configuration, in Exchange alternateExchange) =>
+        configuration.WithArgument(Argument.AlternateExchange, alternateExchange.Name);
 }

--- a/Source/EasyNetQ/ExchangeType.cs
+++ b/Source/EasyNetQ/ExchangeType.cs
@@ -6,4 +6,5 @@ public static class ExchangeType
     public const string Topic = "topic";
     public const string Fanout = "fanout";
     public const string Header = "headers";
+    public const string DelayedMessage = "x-delayed-message";
 }

--- a/Source/EasyNetQ/FuturePublishConfiguration.cs
+++ b/Source/EasyNetQ/FuturePublishConfiguration.cs
@@ -45,7 +45,7 @@ internal class FuturePublishConfiguration : IFuturePublishConfiguration
 
     public byte? Priority { get; private set; }
     public string Topic { get; private set; }
-    public IDictionary<string, object?>? Headers { get; private set; }
+    public IDictionary<string, object?>? MessageHeaders { get; private set; }
     public bool PublisherConfirms { get; private set; }
 
     public IFuturePublishConfiguration WithPriority(byte priority)
@@ -62,7 +62,8 @@ internal class FuturePublishConfiguration : IFuturePublishConfiguration
 
     public IFuturePublishConfiguration WithHeaders(IDictionary<string, object?> headers)
     {
-        Headers = headers;
+        foreach (var kvp in headers)
+            (MessageHeaders ??= new Dictionary<string, object?>()).Add(kvp.Key, kvp.Value);
         return this;
     }
 

--- a/Source/EasyNetQ/IAdvancedBus.cs
+++ b/Source/EasyNetQ/IAdvancedBus.cs
@@ -95,23 +95,20 @@ public interface IAdvancedBus
     /// Declare a queue. If the queue already exists this method does nothing
     /// </summary>
     /// <param name="queue">The name of the queue</param>
-    /// <param name="configure">Delegate to configure queue declaration</param>
+    /// <param name="durable"></param>
+    /// <param name="exclusive"></param>
+    /// <param name="autoDelete"></param>
+    /// <param name="arguments"></param>
     /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>The queue</returns>
     Task<Queue> QueueDeclareAsync(
         string queue,
-        Action<IQueueDeclareConfiguration> configure,
+        bool durable = true,
+        bool exclusive = false,
+        bool autoDelete = false,
+        IDictionary<string, object>? arguments = null,
         CancellationToken cancellationToken = default
     );
-
-    /// <summary>
-    /// Declare a transient server named queue. Note, this queue will only last for duration of the
-    /// connection. If there is a connection outage, EasyNetQ will not attempt to recreate
-    /// consumers.
-    /// </summary>
-    /// <param name="cancellationToken">The cancellation token</param>
-    /// <returns>The queue</returns>
-    Task<Queue> QueueDeclareAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Declare a queue passively. Throw an exception rather than create the queue if it doesn't exist
@@ -152,12 +149,18 @@ public interface IAdvancedBus
     /// Declare an exchange
     /// </summary>
     /// <param name="exchange">The exchange name</param>
-    /// <param name="configure">Delegate to configure exchange declaration</param>
+    /// <param name="arguments"></param>
     /// <param name="cancellationToken">The cancellation token</param>
+    /// <param name="type"></param>
+    /// <param name="durable"></param>
+    /// <param name="autoDelete"></param>
     /// <returns>The exchange</returns>
     Task<Exchange> ExchangeDeclareAsync(
         string exchange,
-        Action<IExchangeDeclareConfiguration> configure,
+        string type = ExchangeType.Topic,
+        bool durable = true,
+        bool autoDelete = false,
+        IDictionary<string, object>? arguments = null,
         CancellationToken cancellationToken = default
     );
 
@@ -180,7 +183,7 @@ public interface IAdvancedBus
         string queue,
         string exchange,
         string routingKey,
-        IDictionary<string, object>? arguments,
+        IDictionary<string, object>? arguments = null,
         CancellationToken cancellationToken = default
     );
 
@@ -191,7 +194,7 @@ public interface IAdvancedBus
         string queue,
         string exchange,
         string routingKey,
-        IDictionary<string, object>? arguments,
+        IDictionary<string, object>? arguments = null,
         CancellationToken cancellationToken = default
     );
 
@@ -202,7 +205,7 @@ public interface IAdvancedBus
         string destinationExchange,
         string sourceExchange,
         string routingKey,
-        IDictionary<string, object>? arguments,
+        IDictionary<string, object>? arguments = null,
         CancellationToken cancellationToken = default
     );
 
@@ -213,7 +216,7 @@ public interface IAdvancedBus
         string destinationExchange,
         string sourceExchange,
         string routingKey,
-        IDictionary<string, object>? arguments,
+        IDictionary<string, object>? arguments = null,
         CancellationToken cancellationToken = default
     );
 

--- a/Source/EasyNetQ/PublishConfiguration.cs
+++ b/Source/EasyNetQ/PublishConfiguration.cs
@@ -71,7 +71,8 @@ internal class PublishConfiguration : IPublishConfiguration
 
     public IPublishConfiguration WithHeaders(IDictionary<string, object?> headers)
     {
-        Headers = headers;
+        foreach (var kvp in headers)
+            (MessageHeaders ??= new Dictionary<string, object?>()).Add(kvp.Key, kvp.Value);
         return this;
     }
 
@@ -84,6 +85,6 @@ internal class PublishConfiguration : IPublishConfiguration
     public byte? Priority { get; private set; }
     public string Topic { get; private set; }
     public TimeSpan? Expires { get; private set; }
-    public IDictionary<string, object?>? Headers { get; private set; }
+    public IDictionary<string, object?>? MessageHeaders { get; private set; }
     public bool PublisherConfirms { get; private set; }
 }

--- a/Source/EasyNetQ/QueueDeclareConfigurationExtensions.cs
+++ b/Source/EasyNetQ/QueueDeclareConfigurationExtensions.cs
@@ -13,8 +13,8 @@ public static class QueueDeclareConfigurationExtensions
     /// <param name="configuration">The configuration instance</param>
     /// <param name="maxPriority">The maximum priority to set, should be a positive integer between 1 and 255</param>
     /// <returns>The same <paramref name="configuration"/></returns>
-    public static IQueueDeclareConfiguration WithMaxPriority(this IQueueDeclareConfiguration configuration, int maxPriority)
-        => configuration.WithArgument("x-max-priority", maxPriority);
+    public static IQueueDeclareConfiguration WithMaxPriority(this IQueueDeclareConfiguration configuration, byte maxPriority) =>
+        configuration.WithArgument(Argument.MaxPriority, maxPriority);
 
     /// <summary>
     ///     Sets maximum queue length. The maximum number of ready messages that may exist on the queue.
@@ -25,7 +25,7 @@ public static class QueueDeclareConfigurationExtensions
     /// <param name="maxLength">The maximum length to set</param>
     /// <returns>The same <paramref name="configuration"/></returns>
     public static IQueueDeclareConfiguration WithMaxLength(this IQueueDeclareConfiguration configuration, int maxLength)
-        => configuration.WithArgument("x-max-length", maxLength);
+        => configuration.WithArgument(Argument.MaxLength, maxLength);
 
     /// <summary>
     ///     Sets maximum queue length in bytes. The maximum size of the queue in bytes.
@@ -35,8 +35,8 @@ public static class QueueDeclareConfigurationExtensions
     /// <param name="configuration">The configuration instance</param>
     /// <param name="maxLengthBytes">The maximum queue length to set</param>
     /// <returns>The same <paramref name="configuration"/></returns>
-    public static IQueueDeclareConfiguration WithMaxLengthBytes(this IQueueDeclareConfiguration configuration, int maxLengthBytes)
-        => configuration.WithArgument("x-max-length-bytes", maxLengthBytes);
+    public static IQueueDeclareConfiguration WithMaxLengthBytes(this IQueueDeclareConfiguration configuration, int maxLengthBytes) =>
+        configuration.WithArgument(Argument.MaxLengthBytes, maxLengthBytes);
 
     /// <summary>
     ///     Sets overflow type to configure overflow behaviour.
@@ -45,8 +45,8 @@ public static class QueueDeclareConfigurationExtensions
     /// <param name="configuration">The configuration instance</param>
     /// <param name="overflowType">The overflow type to set</param>
     /// <returns>The same <paramref name="configuration"/></returns>
-    public static IQueueDeclareConfiguration WithOverflowType(this IQueueDeclareConfiguration configuration, string overflowType = OverflowType.DropHead)
-        => configuration.WithArgument("x-overflow", overflowType);
+    public static IQueueDeclareConfiguration WithOverflowType(this IQueueDeclareConfiguration configuration, string overflowType = OverflowType.DropHead) =>
+        configuration.WithArgument(Argument.Overflow, overflowType);
 
     /// <summary>
     ///     Sets expires of the queue.
@@ -55,8 +55,8 @@ public static class QueueDeclareConfigurationExtensions
     /// <param name="configuration">The configuration instance</param>
     /// <param name="expires">The expires to set</param>
     /// <returns>The same <paramref name="configuration"/></returns>
-    public static IQueueDeclareConfiguration WithExpires(this IQueueDeclareConfiguration configuration, TimeSpan expires)
-        => configuration.WithArgument("x-expires", (int)expires.TotalMilliseconds);
+    public static IQueueDeclareConfiguration WithExpires(this IQueueDeclareConfiguration configuration, TimeSpan expires) =>
+        configuration.WithArgument(Argument.Expires, (int)expires.TotalMilliseconds);
 
     /// <summary>
     ///     Sets message TTL.
@@ -65,8 +65,8 @@ public static class QueueDeclareConfigurationExtensions
     /// <param name="configuration">The configuration instance</param>
     /// <param name="messageTtl">The message TTL to set</param>
     /// <returns>The same <paramref name="configuration"/></returns>
-    public static IQueueDeclareConfiguration WithMessageTtl(this IQueueDeclareConfiguration configuration, TimeSpan messageTtl)
-        => configuration.WithArgument("x-message-ttl", (int)messageTtl.TotalMilliseconds);
+    public static IQueueDeclareConfiguration WithMessageTtl(this IQueueDeclareConfiguration configuration, TimeSpan messageTtl) =>
+        configuration.WithArgument(Argument.MessageTtl, (int)messageTtl.TotalMilliseconds);
 
     /// <summary>
     ///     Sets dead letter exchange for queue.
@@ -75,8 +75,8 @@ public static class QueueDeclareConfigurationExtensions
     /// <param name="configuration">The configuration instance</param>
     /// <param name="deadLetterExchange">The dead letter exchange to set</param>
     /// <returns>The same <paramref name="configuration"/></returns>
-    public static IQueueDeclareConfiguration WithDeadLetterExchange(this IQueueDeclareConfiguration configuration, Exchange deadLetterExchange)
-        => configuration.WithArgument("x-dead-letter-exchange", deadLetterExchange.Name);
+    public static IQueueDeclareConfiguration WithDeadLetterExchange(this IQueueDeclareConfiguration configuration, Exchange deadLetterExchange) =>
+        configuration.WithArgument(Argument.DeadLetterExchange, deadLetterExchange.Name);
 
     /// <summary>
     ///     Sets dead letter routing key.
@@ -86,8 +86,8 @@ public static class QueueDeclareConfigurationExtensions
     /// <param name="configuration">The configuration instance</param>
     /// <param name="deadLetterRoutingKey">The dead letter routing key to set</param>
     /// <returns>The same <paramref name="configuration"/></returns>
-    public static IQueueDeclareConfiguration WithDeadLetterRoutingKey(this IQueueDeclareConfiguration configuration, string deadLetterRoutingKey)
-        => configuration.WithArgument("x-dead-letter-routing-key", deadLetterRoutingKey);
+    public static IQueueDeclareConfiguration WithDeadLetterRoutingKey(this IQueueDeclareConfiguration configuration, string deadLetterRoutingKey) =>
+        configuration.WithArgument(Argument.DeadLetterRoutingKey, deadLetterRoutingKey);
 
     /// <summary>
     ///     Sets queue mode.
@@ -96,8 +96,8 @@ public static class QueueDeclareConfigurationExtensions
     /// <param name="configuration">The configuration instance</param>
     /// <param name="queueMode">The queue mode to set</param>
     /// <returns>The same <paramref name="configuration"/></returns>
-    public static IQueueDeclareConfiguration WithQueueMode(this IQueueDeclareConfiguration configuration, string queueMode = QueueMode.Default)
-        => configuration.WithArgument("x-queue-mode", queueMode);
+    public static IQueueDeclareConfiguration WithQueueMode(this IQueueDeclareConfiguration configuration, string queueMode = QueueMode.Default) =>
+        configuration.WithArgument(Argument.QueueMode, queueMode);
 
     /// <summary>
     ///     Sets queue type.
@@ -106,8 +106,8 @@ public static class QueueDeclareConfigurationExtensions
     /// <param name="configuration">The configuration instance</param>
     /// <param name="queueType">The queue type to set</param>
     /// <returns>The same <paramref name="configuration"/></returns>
-    public static IQueueDeclareConfiguration WithQueueType(this IQueueDeclareConfiguration configuration, string queueType = QueueType.Classic)
-        => configuration.WithArgument("x-queue-type", queueType);
+    public static IQueueDeclareConfiguration WithQueueType(this IQueueDeclareConfiguration configuration, string queueType = QueueType.Classic) =>
+        configuration.WithArgument(Argument.QueueType, queueType);
 
     /// <summary>
     ///     Enables single active consumer.
@@ -117,9 +117,8 @@ public static class QueueDeclareConfigurationExtensions
     /// <param name="configuration">The configuration instance</param>
     /// <param name="singleActiveConsumer"><see langword="true"/> if a queue has a single active consumer</param>
     /// <returns>The same <paramref name="configuration"/></returns>
-    public static IQueueDeclareConfiguration WithSingleActiveConsumer(
-        this IQueueDeclareConfiguration configuration, bool singleActiveConsumer = true
-    ) => configuration.WithArgument("x-single-active-consumer", singleActiveConsumer);
+    public static IQueueDeclareConfiguration WithSingleActiveConsumer(this IQueueDeclareConfiguration configuration, bool singleActiveConsumer = true) =>
+        configuration.WithArgument(Argument.SingleActiveConsumer, singleActiveConsumer);
 
     /// <summary>
     ///     Sets queue master locator.
@@ -128,9 +127,8 @@ public static class QueueDeclareConfigurationExtensions
     /// <param name="configuration">The configuration instance</param>
     /// <param name="queueMasterLocator">The queue master locator to set</param>
     /// <returns>The same <paramref name="configuration"/></returns>
-    public static IQueueDeclareConfiguration WithQueueMasterLocator(
-        this IQueueDeclareConfiguration configuration, string queueMasterLocator = QueueMasterLocator.MinMasters
-    ) => configuration.WithArgument("x-queue-master-locator", queueMasterLocator);
+    public static IQueueDeclareConfiguration WithQueueMasterLocator(this IQueueDeclareConfiguration configuration, string queueMasterLocator = QueueMasterLocator.MinMasters) =>
+        configuration.WithArgument(Argument.QueueMasterLocator, queueMasterLocator);
 
     /// <summary>
     ///     Sets dead letter strategy.
@@ -139,7 +137,6 @@ public static class QueueDeclareConfigurationExtensions
     /// <param name="configuration">The configuration instance</param>
     /// <param name="deadLetterStrategy">The dead letter strategy to set</param>
     /// <returns>The same <paramref name="configuration"/></returns>
-    public static IQueueDeclareConfiguration WithDeadLetterStrategy(
-        this IQueueDeclareConfiguration configuration, string deadLetterStrategy = DeadLetterStrategy.AtMostOnce
-    ) => configuration.WithArgument("x-dead-letter-strategy", deadLetterStrategy);
+    public static IQueueDeclareConfiguration WithDeadLetterStrategy(this IQueueDeclareConfiguration configuration, string deadLetterStrategy = DeadLetterStrategy.AtMostOnce) =>
+        configuration.WithArgument(Argument.DeadLetterStrategy, deadLetterStrategy);
 }

--- a/Source/EasyNetQ/ReceiveConfiguration.cs
+++ b/Source/EasyNetQ/ReceiveConfiguration.cs
@@ -106,15 +106,10 @@ internal class ReceiveConfiguration : IReceiveConfiguration
     public bool AutoDelete { get; private set; }
     public int Priority { get; private set; }
     public ushort PrefetchCount { get; private set; }
-    public int? Expires { get; private set; }
     public bool IsExclusive { get; private set; }
-    public byte? MaxPriority { get; private set; }
     public bool Durable { get; private set; }
-    public int? MaxLength { get; private set; }
-    public int? MaxLengthBytes { get; private set; }
-    public string? QueueMode { get; private set; }
-    public string? QueueType { get; private set; }
-    public bool SingleActiveConsumer { get; private set; }
+
+    public IDictionary<string, object>? QueueArguments { get; private set; }
 
     public ReceiveConfiguration(ushort defaultPrefetchCount)
     {
@@ -123,7 +118,6 @@ internal class ReceiveConfiguration : IReceiveConfiguration
         PrefetchCount = defaultPrefetchCount;
         IsExclusive = false;
         Durable = true;
-        SingleActiveConsumer = false;
     }
 
     public IReceiveConfiguration WithAutoDelete(bool autoDelete = true)
@@ -153,7 +147,7 @@ internal class ReceiveConfiguration : IReceiveConfiguration
 
     public IReceiveConfiguration WithExpires(int expires)
     {
-        Expires = expires;
+        InitializedQueueArguments.WithExpires(expires);
         return this;
     }
 
@@ -165,37 +159,39 @@ internal class ReceiveConfiguration : IReceiveConfiguration
 
     public IReceiveConfiguration WithMaxPriority(byte priority)
     {
-        MaxPriority = priority;
+        InitializedQueueArguments.WithMaxPriority(priority);
         return this;
     }
 
     public IReceiveConfiguration WithMaxLength(int maxLength)
     {
-        MaxLength = maxLength;
+        InitializedQueueArguments.WithMaxLength(maxLength);
         return this;
     }
 
     public IReceiveConfiguration WithMaxLengthBytes(int maxLengthBytes)
     {
-        MaxLengthBytes = maxLengthBytes;
+        InitializedQueueArguments.WithMaxLengthBytes(maxLengthBytes);
         return this;
     }
 
     public IReceiveConfiguration WithQueueMode(string queueMode)
     {
-        QueueMode = queueMode;
+        InitializedQueueArguments.WithQueueMode(queueMode);
         return this;
     }
 
-    public IReceiveConfiguration WithQueueType(string queueType = EasyNetQ.QueueType.Classic)
+    public IReceiveConfiguration WithQueueType(string queueType = QueueType.Classic)
     {
-        QueueType = queueType;
+        InitializedQueueArguments.WithQueueType(queueType);
         return this;
     }
 
     public IReceiveConfiguration WithSingleActiveConsumer(bool singleActiveConsumer = true)
     {
-        SingleActiveConsumer = singleActiveConsumer;
+        InitializedQueueArguments.WithSingleActiveConsumer(singleActiveConsumer);
         return this;
     }
+
+    private IDictionary<string, object> InitializedQueueArguments => QueueArguments ??= new Dictionary<string, object>();
 }

--- a/Source/EasyNetQ/RequestConfiguration.cs
+++ b/Source/EasyNetQ/RequestConfiguration.cs
@@ -55,7 +55,7 @@ internal class RequestConfiguration : IRequestConfiguration
     public string QueueName { get; private set; }
     public TimeSpan Expiration { get; private set; }
     public byte? Priority { get; private set; }
-    public IDictionary<string, object?>? Headers { get; private set; }
+    public IDictionary<string, object?>? MessageHeaders { get; private set; }
     public bool PublisherConfirms { get; private set; }
 
     public IRequestConfiguration WithPriority(byte priority)
@@ -78,7 +78,8 @@ internal class RequestConfiguration : IRequestConfiguration
 
     public IRequestConfiguration WithHeaders(IDictionary<string, object?> headers)
     {
-        Headers = headers;
+        foreach (var kvp in headers)
+            (MessageHeaders ??= new Dictionary<string, object?>()).Add(kvp.Key, kvp.Value);
         return this;
     }
 

--- a/Source/EasyNetQ/ResponderConfiguration.cs
+++ b/Source/EasyNetQ/ResponderConfiguration.cs
@@ -39,7 +39,7 @@ public interface IResponderConfiguration
     /// </summary>
     /// <param name="expires">The value of the x-expires argument or expires policy describes the expiration period and is subject to the same constraints as x-message-ttl and cannot be zero. Thus a value of 1 means a queue which is unused for 1 second will be deleted.</param>
     /// <returns>Reference to the same <see cref="IResponderConfiguration"/> to allow methods chaining</returns>
-    IResponderConfiguration WithExpires(TimeSpan expires);
+    IResponderConfiguration WithExpires(int expires);
 
     /// <summary>
     /// Configures the queue's maxPriority
@@ -59,8 +59,8 @@ internal class ResponderConfiguration : IResponderConfiguration
     public ushort PrefetchCount { get; private set; }
     public string? QueueName { get; private set; }
     public bool Durable { get; private set; } = true;
-    public TimeSpan? Expires { get; private set; }
-    public byte? MaxPriority { get; private set; }
+
+    public IDictionary<string, object>? QueueArguments { get; private set; }
 
     public IResponderConfiguration WithPrefetchCount(ushort prefetchCount)
     {
@@ -80,15 +80,17 @@ internal class ResponderConfiguration : IResponderConfiguration
         return this;
     }
 
-    public IResponderConfiguration WithExpires(TimeSpan expires)
+    public IResponderConfiguration WithExpires(int expires)
     {
-        Expires = expires;
+        InitializedQueueArguments.WithExpires(expires);
         return this;
     }
 
     public IResponderConfiguration WithMaxPriority(byte priority)
     {
-        MaxPriority = priority;
+        InitializedQueueArguments.WithMaxPriority(priority);
         return this;
     }
+
+    private IDictionary<string, object> InitializedQueueArguments => QueueArguments ??= new Dictionary<string, object>();
 }

--- a/Source/EasyNetQ/SendConfiguration.cs
+++ b/Source/EasyNetQ/SendConfiguration.cs
@@ -32,7 +32,7 @@ public interface ISendConfiguration
 internal class SendConfiguration : ISendConfiguration
 {
     public byte? Priority { get; private set; }
-    public IDictionary<string, object?>? Headers { get; private set; }
+    public IDictionary<string, object?>? MessageHeaders { get; private set; }
     public bool PublisherConfirms { get; private set; }
 
 
@@ -44,7 +44,8 @@ internal class SendConfiguration : ISendConfiguration
 
     public ISendConfiguration WithHeaders(IDictionary<string, object?> headers)
     {
-        Headers = headers;
+        foreach (var kvp in headers)
+            (MessageHeaders ??= new Dictionary<string, object?>()).Add(kvp.Key, kvp.Value);
         return this;
     }
 

--- a/Source/EasyNetQ/SubscriptionConfiguration.cs
+++ b/Source/EasyNetQ/SubscriptionConfiguration.cs
@@ -135,20 +135,14 @@ internal class SubscriptionConfiguration : ISubscriptionConfiguration
     public bool AutoDelete { get; private set; }
     public int Priority { get; private set; }
     public ushort PrefetchCount { get; private set; }
-    public int? Expires { get; private set; }
     public bool IsExclusive { get; private set; }
-    public byte? MaxPriority { get; private set; }
     public bool Durable { get; private set; }
     public string? QueueName { get; private set; }
-    public int? MaxLength { get; private set; }
-    public int? MaxLengthBytes { get; private set; }
-    public string? QueueMode { get; private set; }
-    public string? QueueType { get; private set; }
     public string ExchangeType { get; private set; } = EasyNetQ.ExchangeType.Topic;
-    public string? AlternateExchange { get; private set; }
-    public bool SingleActiveConsumer { get; private set; }
+    public IDictionary<string, object>? QueueArguments { get; private set; }
+    public IDictionary<string, object>? ExchangeArguments { get; private set; }
 
-    public SubscriptionConfiguration(ushort defaultPrefetchCount)
+    public SubscriptionConfiguration(ushort defaultPrefetchCount, string? queueType = null)
     {
         Topics = new List<string>();
         AutoDelete = false;
@@ -156,7 +150,8 @@ internal class SubscriptionConfiguration : ISubscriptionConfiguration
         PrefetchCount = defaultPrefetchCount;
         IsExclusive = false;
         Durable = true;
-        SingleActiveConsumer = false;
+        if (queueType != null)
+            QueueArguments = new Dictionary<string, object> { { Argument.QueueType, queueType } };
     }
 
     public ISubscriptionConfiguration WithTopic(string topic)
@@ -193,7 +188,7 @@ internal class SubscriptionConfiguration : ISubscriptionConfiguration
 
     public ISubscriptionConfiguration WithExpires(int expires)
     {
-        Expires = expires;
+        InitializedQueueArguments.WithExpires(expires);
         return this;
     }
 
@@ -205,7 +200,7 @@ internal class SubscriptionConfiguration : ISubscriptionConfiguration
 
     public ISubscriptionConfiguration WithMaxPriority(byte priority)
     {
-        MaxPriority = priority;
+        InitializedQueueArguments.WithMaxPriority(priority);
         return this;
     }
 
@@ -217,25 +212,25 @@ internal class SubscriptionConfiguration : ISubscriptionConfiguration
 
     public ISubscriptionConfiguration WithMaxLength(int maxLength)
     {
-        MaxLength = maxLength;
+        InitializedQueueArguments.WithMaxLength(maxLength);
         return this;
     }
 
     public ISubscriptionConfiguration WithMaxLengthBytes(int maxLengthBytes)
     {
-        MaxLengthBytes = maxLengthBytes;
+        InitializedQueueArguments.WithMaxLengthBytes(maxLengthBytes);
         return this;
     }
 
-    public ISubscriptionConfiguration WithQueueMode(string queueMode = EasyNetQ.QueueMode.Default)
+    public ISubscriptionConfiguration WithQueueMode(string queueMode = QueueMode.Default)
     {
-        QueueMode = queueMode;
+        InitializedQueueArguments.WithQueueMode(queueMode);
         return this;
     }
 
-    public ISubscriptionConfiguration WithQueueType(string queueType = EasyNetQ.QueueType.Classic)
+    public ISubscriptionConfiguration WithQueueType(string queueType = QueueType.Classic)
     {
-        QueueType = queueType;
+        InitializedQueueArguments.WithQueueType(queueType);
         return this;
     }
 
@@ -247,13 +242,23 @@ internal class SubscriptionConfiguration : ISubscriptionConfiguration
 
     public ISubscriptionConfiguration WithAlternateExchange(string alternateExchange)
     {
-        AlternateExchange = alternateExchange;
+        InitializedExchangeArguments.WithAlternateExchange(alternateExchange);
         return this;
     }
 
     public ISubscriptionConfiguration WithSingleActiveConsumer(bool singleActiveConsumer = true)
     {
-        SingleActiveConsumer = singleActiveConsumer;
+        InitializedQueueArguments.WithSingleActiveConsumer(singleActiveConsumer);
         return this;
     }
+
+    public ISubscriptionConfiguration WithQueueArguments(IDictionary<string, object> arguments)
+    {
+        foreach (var kvp in arguments)
+            InitializedQueueArguments[kvp.Key] = kvp.Value;
+        return this;
+    }
+
+    private IDictionary<string, object> InitializedQueueArguments => QueueArguments ??= new Dictionary<string, object>();
+    private IDictionary<string, object> InitializedExchangeArguments => ExchangeArguments ??= new Dictionary<string, object>();
 }


### PR DESCRIPTION
It is now in-line with other topology methods, fluent interface is moved to extensions.

Fixes #1208 as helps to construct a queue/exchange object.

PR introduces extension methods on a Dictionary<string, object>, for the exchange and the queue arguments respectively.