### PR TITLE
Extend ISubscriptionConfiguration to support per queue message ttl

### DIFF
--- a/Source/EasyNetQ.Tests/SubscribeTests.cs
+++ b/Source/EasyNetQ.Tests/SubscribeTests.cs
@@ -124,8 +124,8 @@ public class When_subscribe_is_called : IDisposable
 
 public class When_subscribe_with_configuration_is_called
 {
-    [InlineData("ttt", true, 99, 999, 10, true, (byte)11, false, "qqq", 1001, 10001)]
-    [InlineData(null, false, 0, 0, null, false, null, true, "qqq", null, null)]
+    [InlineData("ttt", true, 99, 999, 10, true, (byte)11, false, "qqq", 1001, 10001, 6000)]
+    [InlineData(null, false, 0, 0, null, false, null, true, "qqq", null, null, null)]
     [Theory]
     public void Queue_should_be_declared_with_correct_options(
         string topic,
@@ -138,7 +138,8 @@ public class When_subscribe_with_configuration_is_called
         bool durable,
         string queueName,
         int? maxLength,
-        int? maxLengthBytes
+        int? maxLengthBytes,
+        int? perQueueMessageTtlInMs
     )
     {
         var mockBuilder = new MockBuilder();
@@ -181,6 +182,11 @@ public class When_subscribe_with_configuration_is_called
                     {
                         c.WithMaxLengthBytes(maxLengthBytes.Value);
                     }
+
+                    if (perQueueMessageTtlInMs.HasValue)
+                    {
+                        c.WithPerQueueMessageTTl(TimeSpan.FromMilliseconds(perQueueMessageTtlInMs.Value));
+                    }
                 }
             );
         }
@@ -196,9 +202,11 @@ public class When_subscribe_with_configuration_is_called
                     (!expires.HasValue || expires.Value == (int)x["x-expires"]) &&
                     (!maxPriority.HasValue || maxPriority.Value == (int)x["x-max-priority"]) &&
                     (!maxLength.HasValue || maxLength.Value == (int)x["x-max-length"]) &&
-                    (!maxLengthBytes.HasValue || maxLengthBytes.Value == (int)x["x-max-length-bytes"])
+                    (!maxLengthBytes.HasValue || maxLengthBytes.Value == (int)x["x-max-length-bytes"]) &&
+                    (!perQueueMessageTtlInMs.HasValue || perQueueMessageTtlInMs.Value == (int)x["x-message-ttl"])
             )
         );
+
 
         // Assert that consumer was created correctly
         mockBuilder.Channels[2].Received().BasicConsume(

--- a/Source/EasyNetQ/DefaultPubSub.cs
+++ b/Source/EasyNetQ/DefaultPubSub.cs
@@ -139,6 +139,9 @@ public class DefaultPubSub : IPubSub
                     c.WithQueueType(subscriptionConfiguration.QueueType);
                 if (subscriptionConfiguration.SingleActiveConsumer)
                     c.WithSingleActiveConsumer();
+                if (subscriptionConfiguration.PerQueueMessageTTl.HasValue)
+                    c.WithArgument("x-message-ttl",
+                        (int)subscriptionConfiguration.PerQueueMessageTTl.Value.TotalMilliseconds);
             },
             cts.Token
         ).ConfigureAwait(false);

--- a/Source/EasyNetQ/SubscriptionConfiguration.cs
+++ b/Source/EasyNetQ/SubscriptionConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace EasyNetQ;
@@ -129,6 +130,15 @@ public interface ISubscriptionConfiguration
     /// <param name="singleActiveConsumer">Queue's single-active-consumer flag</param>
     /// <returns>Returns a reference to itself</returns>
     ISubscriptionConfiguration WithSingleActiveConsumer(bool singleActiveConsumer = true);
+
+
+    /// <summary>
+    /// Configure the message TTL for the queue.
+    /// A message that has been in the queue for longer than the configured TTL is said to be dead.
+    /// </summary>
+    /// <param name="ttl">The message ttl</param>
+    /// <returns>Returns a reference to itself</returns>
+    ISubscriptionConfiguration WithPerQueueMessageTTl(TimeSpan ttl);
 }
 
 internal class SubscriptionConfiguration : ISubscriptionConfiguration
@@ -149,7 +159,7 @@ internal class SubscriptionConfiguration : ISubscriptionConfiguration
     public string ExchangeType { get; private set; } = Topology.ExchangeType.Topic;
     public string AlternateExchange { get; private set; }
     public bool SingleActiveConsumer { get; private set; }
-
+    public TimeSpan? PerQueueMessageTTl { get; set; }
     public SubscriptionConfiguration(ushort defaultPrefetchCount)
     {
         Topics = new List<string>();
@@ -256,6 +266,12 @@ internal class SubscriptionConfiguration : ISubscriptionConfiguration
     public ISubscriptionConfiguration WithSingleActiveConsumer(bool singleActiveConsumer = true)
     {
         SingleActiveConsumer = singleActiveConsumer;
+        return this;
+    }
+
+    public ISubscriptionConfiguration WithPerQueueMessageTTl(TimeSpan ttl)
+    {
+        PerQueueMessageTTl = ttl;
         return this;
     }
 }


### PR DESCRIPTION
Using IPubSub, this extension is the only way to configure the queue with a message ttl.
https://www.rabbitmq.com/ttl.html#per-queue-message-ttl