### PR TITLE
Make Castle Windsor integration compatible with Castle.Windsor >= 5.1

### DIFF
--- a/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
+++ b/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="RabbitMQ.Client" Version="6.5.*" />
     <PackageReference Include="Autofac" Version="4.9.3" />
     <PackageReference Include="Castle.Core" Version="4.4.1" />
-    <PackageReference Include="Castle.Windsor" Version="5.0.0" />
+    <PackageReference Include="Castle.Windsor" Version="5.1.1" />
     <PackageReference Include="Ninject" Version="3.3.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />

--- a/Source/EasyNetQ.DI.Windsor/EasyNetQ.DI.Windsor.csproj
+++ b/Source/EasyNetQ.DI.Windsor/EasyNetQ.DI.Windsor.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.1" />
-    <PackageReference Include="Castle.Windsor" Version="5.0.0" />
+    <PackageReference Include="Castle.Windsor" Version="5.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Fixes https://github.com/EasyNetQ/EasyNetQ/issues/1700
See also https://github.com/EasyNetQ/EasyNetQ/pull/1702

Bump `Castle.Windsor` dependency to `5.1.1` (not `5.1.0` due to this issue: https://github.com/castleproject/Windsor/pull/569) to make it compatible with more recent versions of the container.

I am actually in doubts whether it should be contributed to both 7.x and 8.x or to 8.x only. Obviously, it's a breaking change (as we increase the dependency version) for 7.x. But after thinking decided to push it to both 7.x and 8.x for the following motivation:
-  In our project we want to use 7.x (as the release date of 8.x is unclear) and that's where I observed the issue. So to use 7.x I need to push it there 😄 
- There is a bug in existing version and it can drive you nuts to investigate it. Took me time to realize that it fails because the type has changed. So it's better to fix the existing version even though it implies a breaking change.
-  I would also say that `Castle.Windsor 5.1.1` is quite old, so it should be OK to upgrade to that, as most likely people use the more recent version.

If you don't agree to push it back to 7.x, then you should update the 7.x and add `Castle.Windsor` package version constrain to be `[5.0.0;5.1.0)`