### PR TITLE
Make Castle Windsor integration compatible with Castle.Windsor >= 5.1

### DIFF
--- a/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
+++ b/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="RabbitMQ.Client" Version="6.5.*" />
     <PackageReference Include="Autofac" Version="4.9.3" />
     <PackageReference Include="Castle.Core" Version="4.4.1" />
-    <PackageReference Include="Castle.Windsor" Version="5.0.0" />
+    <PackageReference Include="Castle.Windsor" Version="5.1.1" />
     <PackageReference Include="Ninject" Version="3.3.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />

--- a/Source/EasyNetQ.DI.Windsor/EasyNetQ.DI.Windsor.csproj
+++ b/Source/EasyNetQ.DI.Windsor/EasyNetQ.DI.Windsor.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.1" />
-    <PackageReference Include="Castle.Windsor" Version="5.0.0" />
+    <PackageReference Include="Castle.Windsor" Version="5.1.1" />
     <PackageReference Include="Fody" Version="6.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Fixes #1700
See also: https://github.com/EasyNetQ/EasyNetQ/pull/1701

Bump `Castle.Windsor` dependency to `5.1.1` (not `5.1.0` due to this issue: https://github.com/castleproject/Windsor/pull/569) to make it compatible with more recent versions of the container.

Here we cherry-pick #1701 to 8.x