### PR TITLE
Allow to resolve empty collections in Castle.Windsor

### DIFF
--- a/Source/EasyNetQ.DI.Tests/BusCreationTest.cs
+++ b/Source/EasyNetQ.DI.Tests/BusCreationTest.cs
@@ -1,0 +1,32 @@
+using Castle.Windsor;
+using FluentAssertions;
+using Xunit;
+
+namespace EasyNetQ.DI.Tests;
+
+public class BusCreationTest
+{
+    [Fact]
+    public void ShouldCreateBusForCastleWindsor()
+    {
+        // arrange
+        var container = new WindsorContainer();
+
+        // act
+        container.RegisterEasyNetQ(
+            connectionConfigurationFactory: serviceResolver =>
+            {
+                var connection = new ConnectionConfiguration();
+                connection.Hosts.Add(new HostConfiguration("localhost", 1));
+
+                return connection;
+            },
+            services => { }
+        );
+
+        var bus = container.Resolve<IBus>();
+
+        // assert
+        bus.Should().NotBeNull();
+    }
+}

--- a/Source/EasyNetQ.DI.Windsor/WindsorAdapter.cs
+++ b/Source/EasyNetQ.DI.Windsor/WindsorAdapter.cs
@@ -29,7 +29,7 @@ public class WindsorAdapter : IServiceRegister
     /// </summary>
     protected virtual void ConfigureContainer(IWindsorContainer container)
     {
-        container.Kernel.Resolver.AddSubResolver(new Castle.MicroKernel.Resolvers.SpecializedResolvers.CollectionResolver(container.Kernel));
+        container.Kernel.Resolver.AddSubResolver(new Castle.MicroKernel.Resolvers.SpecializedResolvers.CollectionResolver(container.Kernel, allowEmptyCollections: true));
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Fixes #1703

Allow to resolve empty collections, so that if extensibility is not registered - we just have an empty collection of things.

See also #1704 