### PR TITLE
Add ability to specify queue type for RPC-style request queue

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -529,6 +529,7 @@ namespace EasyNetQ
         EasyNetQ.IResponderConfiguration WithMaxPriority(byte priority);
         EasyNetQ.IResponderConfiguration WithPrefetchCount(ushort prefetchCount);
         EasyNetQ.IResponderConfiguration WithQueueName(string queueName);
+        EasyNetQ.IResponderConfiguration WithQueueType(string queueType = "classic");
     }
     public interface IRpc
     {

--- a/Source/EasyNetQ/DefaultRpc.cs
+++ b/Source/EasyNetQ/DefaultRpc.cs
@@ -267,7 +267,7 @@ public class DefaultRpc : IRpc, IDisposable
     {
         var requestType = typeof(TRequest);
 
-        var responderConfiguration = new ResponderConfiguration(configuration.PrefetchCount);
+        var responderConfiguration = new ResponderConfiguration(configuration.PrefetchCount, conventions.QueueTypeConvention(typeof(TRequest)));
         configure(responderConfiguration);
 
         var routingKey = responderConfiguration.QueueName ?? conventions.RpcRoutingKeyNamingConvention(requestType);

--- a/Source/EasyNetQ/ResponderConfiguration.cs
+++ b/Source/EasyNetQ/ResponderConfiguration.cs
@@ -47,13 +47,23 @@ public interface IResponderConfiguration
     /// <param name="priority">Queue's maxPriority value</param>
     /// <returns>Reference to the same <see cref="IResponderConfiguration"/> to allow methods chaining</returns>
     IResponderConfiguration WithMaxPriority(byte priority);
+
+    /// <summary>
+    /// Sets the queue type. Valid types are "classic" and "quorum". Works with RabbitMQ version 3.8+.
+    /// </summary>
+    /// <param name="queueType">Desired queue type.</param>
+    /// <returns>Returns a reference to itself</returns>
+    IResponderConfiguration WithQueueType(string queueType = QueueType.Classic);
 }
 
 internal class ResponderConfiguration : IResponderConfiguration
 {
-    public ResponderConfiguration(ushort defaultPrefetchCount)
+    public ResponderConfiguration(ushort defaultPrefetchCount, string? queueType = null)
     {
         PrefetchCount = defaultPrefetchCount;
+
+        if (queueType != null)
+            QueueArguments = new Dictionary<string, object> { { Argument.QueueType, queueType } };
     }
 
     public ushort PrefetchCount { get; private set; }
@@ -89,6 +99,12 @@ internal class ResponderConfiguration : IResponderConfiguration
     public IResponderConfiguration WithMaxPriority(byte priority)
     {
         InitializedQueueArguments.WithMaxPriority(priority);
+        return this;
+    }
+
+    public IResponderConfiguration WithQueueType(string queueType = QueueType.Classic)
+    {
+        InitializedQueueArguments.WithQueueType(queueType);
         return this;
     }
 


### PR DESCRIPTION
Classic mirrored queues are not working that well in high load clusters. It would be nice to have option to create request queues as quorum queues. 