### PR TITLE
Rename JsonSerialiaser to ReflectionBasedNewtonsoftJsonSerializer

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -588,12 +588,6 @@ namespace EasyNetQ
         System.Type Deserialize(string typeName);
         string Serialize(System.Type type);
     }
-    public class JsonSerializer : EasyNetQ.ISerializer
-    {
-        public JsonSerializer(object? serializerSettings = null) { }
-        public object BytesToMessage(System.Type messageType, in System.ReadOnlyMemory<byte> bytes) { }
-        public System.Buffers.IMemoryOwner<byte> MessageToBytes(System.Type messageType, object message) { }
-    }
     public class LegacyRpcConventions : EasyNetQ.Conventions
     {
         public LegacyRpcConventions(EasyNetQ.ITypeNameSerializer typeNameSerializer) { }
@@ -923,6 +917,12 @@ namespace EasyNetQ
     {
         public static EasyNetQ.IReceiveRegistration Add<T>(this EasyNetQ.IReceiveRegistration receiveRegistration, System.Action<T> onMessage) { }
         public static EasyNetQ.IReceiveRegistration Add<T>(this EasyNetQ.IReceiveRegistration receiveRegistration, System.Func<T, System.Threading.Tasks.Task> onMessage) { }
+    }
+    public sealed class ReflectionBasedNewtonsoftJsonSerializer : EasyNetQ.ISerializer
+    {
+        public ReflectionBasedNewtonsoftJsonSerializer(object? serializerSettings = null) { }
+        public object BytesToMessage(System.Type messageType, in System.ReadOnlyMemory<byte> bytes) { }
+        public System.Buffers.IMemoryOwner<byte> MessageToBytes(System.Type messageType, object message) { }
     }
     public delegate string RpcExchangeNameConvention(System.Type messageType);
     public static class RpcExtensions

--- a/Source/EasyNetQ.Hosepipe.Tests/ErrorMessageRepublishSpike.cs
+++ b/Source/EasyNetQ.Hosepipe.Tests/ErrorMessageRepublishSpike.cs
@@ -10,7 +10,7 @@ namespace EasyNetQ.Hosepipe.Tests;
 public class ErrorMessageRepublishSpike
 {
     private readonly ITestOutputHelper testOutputHelper;
-    private readonly ISerializer serializer = new JsonSerializer();
+    private readonly ISerializer serializer = new ReflectionBasedNewtonsoftJsonSerializer();
 
     public ErrorMessageRepublishSpike(ITestOutputHelper testOutputHelper)
     {

--- a/Source/EasyNetQ.Hosepipe.Tests/ErrorRetryTests.cs
+++ b/Source/EasyNetQ.Hosepipe.Tests/ErrorRetryTests.cs
@@ -13,7 +13,7 @@ public class ErrorRetryTests
     {
         var typeNameSerializer = new LegacyTypeNameSerializer();
         conventions = new Conventions(typeNameSerializer);
-        errorRetry = new ErrorRetry(new JsonSerializer(), new DefaultErrorMessageSerializer());
+        errorRetry = new ErrorRetry(new ReflectionBasedNewtonsoftJsonSerializer(), new DefaultErrorMessageSerializer());
     }
 
     [Fact]

--- a/Source/EasyNetQ.Hosepipe/Program.cs
+++ b/Source/EasyNetQ.Hosepipe/Program.cs
@@ -68,7 +68,7 @@ public class Program
             new FileMessageWriter(),
             new MessageReader(),
             new QueueInsertion(errorMessageSerializer),
-            new ErrorRetry(new JsonSerializer(), errorMessageSerializer),
+            new ErrorRetry(new ReflectionBasedNewtonsoftJsonSerializer(), errorMessageSerializer),
             new Conventions(typeNameSerializer)
         );
         program.Start(args);

--- a/Source/EasyNetQ.Serialization.Tests/SerializerTests.cs
+++ b/Source/EasyNetQ.Serialization.Tests/SerializerTests.cs
@@ -132,7 +132,7 @@ public class SerializerTests
     public static IEnumerable<object[]> GetSerializers()
     {
         yield return new object[] { "Newtonsoft", new NewtonsoftJsonSerializer() };
-        yield return new object[] { "Default", new JsonSerializer() };
+        yield return new object[] { "Default", new ReflectionBasedNewtonsoftJsonSerializer() };
         yield return new object[] { "SystemTextJson", new SystemTextJsonSerializer() };
         yield return new object[] { "SystemTextJsonV2", new SystemTextJsonSerializerV2() };
     }

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_has_multiple_handlers.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_consumer_has_multiple_handlers.cs
@@ -53,7 +53,7 @@ public class When_a_consumer_has_multiple_handlers : IDisposable
 
     private void Deliver<T>(T message) where T : class
     {
-        using var serializedMessage = new JsonSerializer().MessageToBytes(typeof(T), message);
+        using var serializedMessage = new ReflectionBasedNewtonsoftJsonSerializer().MessageToBytes(typeof(T), message);
         var properties = new BasicProperties
         {
             Type = new DefaultTypeNameSerializer().Serialize(typeof(T))

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_polymorphic_message_is_delivered_to_the_consumer.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_polymorphic_message_is_delivered_to_the_consumer.cs
@@ -17,7 +17,7 @@ public class When_a_polymorphic_message_is_delivered_to_the_consumer : IDisposab
         mockBuilder.Bus.Advanced.Consume<ITestMessageInterface>(queue, (message, _) => receivedMessage = message.Body);
 
         var publishedMessage = new Implementation { Text = "Hello Polymorphs!" };
-        var serializedMessage = new JsonSerializer().MessageToBytes(typeof(Implementation), publishedMessage);
+        var serializedMessage = new ReflectionBasedNewtonsoftJsonSerializer().MessageToBytes(typeof(Implementation), publishedMessage);
         var properties = new BasicProperties
         {
             Type = new DefaultTypeNameSerializer().Serialize(typeof(Implementation))

--- a/Source/EasyNetQ.Tests/DefaultMessageSerializationStrategyTests.cs
+++ b/Source/EasyNetQ.Tests/DefaultMessageSerializationStrategyTests.cs
@@ -63,7 +63,7 @@ public class DefaultMessageSerializationStrategyTests
     public void When_using_the_default_serialization_strategy_messages_are_correctly_round_tripped()
     {
         var typeNameSerializer = new DefaultTypeNameSerializer();
-        var serializer = new JsonSerializer();
+        var serializer = new ReflectionBasedNewtonsoftJsonSerializer();
         const string correlationId = "CorrelationId";
 
         var serializationStrategy =
@@ -82,7 +82,7 @@ public class DefaultMessageSerializationStrategyTests
     public void When_using_the_default_serialization_strategy_messages_are_correctly_round_tripped_when_null()
     {
         var typeNameSerializer = new DefaultTypeNameSerializer();
-        var serializer = new JsonSerializer();
+        var serializer = new ReflectionBasedNewtonsoftJsonSerializer();
         const string correlationId = "CorrelationId";
 
         var serializationStrategy =

--- a/Source/EasyNetQ.Tests/MessageVersioningTests/VersionedMessageSerializationStrategyTests.cs
+++ b/Source/EasyNetQ.Tests/MessageVersioningTests/VersionedMessageSerializationStrategyTests.cs
@@ -81,7 +81,7 @@ public class VersionedMessageSerializationStrategyTests
     public void When_using_the_versioned_serialization_strategy_messages_are_correctly_round_tripped()
     {
         var typeNameSerializer = new DefaultTypeNameSerializer();
-        var serializer = new JsonSerializer();
+        var serializer = new ReflectionBasedNewtonsoftJsonSerializer();
 
         const string correlationId = "CorrelationId";
 
@@ -190,7 +190,7 @@ public class VersionedMessageSerializationStrategyTests
     public void When_using_the_versioned_serialization_strategy_versioned_messages_are_correctly_round_tripped()
     {
         var typeNameSerializer = new DefaultTypeNameSerializer();
-        var serializer = new JsonSerializer();
+        var serializer = new ReflectionBasedNewtonsoftJsonSerializer();
         const string correlationId = "CorrelationId";
 
         var serializationStrategy =
@@ -211,7 +211,7 @@ public class VersionedMessageSerializationStrategyTests
     public void When_deserializing_versioned_message_use_first_available_message_type()
     {
         var typeNameSerializer = new DefaultTypeNameSerializer();
-        var serializer = new JsonSerializer();
+        var serializer = new ReflectionBasedNewtonsoftJsonSerializer();
         const string correlationId = "CorrelationId";
 
         var serializationStrategy =

--- a/Source/EasyNetQ.Tests/SubscribeTests.cs
+++ b/Source/EasyNetQ.Tests/SubscribeTests.cs
@@ -236,7 +236,7 @@ public class When_a_message_is_delivered : IDisposable
         const string text = "Hello there, I am the text!";
         originalMessage = new MyMessage { Text = text };
 
-        using var serializedMessage = new JsonSerializer().MessageToBytes(typeof(MyMessage), originalMessage);
+        using var serializedMessage = new ReflectionBasedNewtonsoftJsonSerializer().MessageToBytes(typeof(MyMessage), originalMessage);
 
         // deliver a message
         mockBuilder.Consumers[0].HandleBasicDeliver(
@@ -322,7 +322,7 @@ public class When_the_handler_throws_an_exception : IDisposable
         const string text = "Hello there, I am the text!";
         originalMessage = new MyMessage { Text = text };
 
-        using var serializedMessage = new JsonSerializer().MessageToBytes(typeof(MyMessage), originalMessage);
+        using var serializedMessage = new ReflectionBasedNewtonsoftJsonSerializer().MessageToBytes(typeof(MyMessage), originalMessage);
 
         // deliver a message
         mockBuilder.Consumers[0].HandleBasicDeliver(

--- a/Source/EasyNetQ/ReflectionBasedNewtonsoftJsonSerializer.cs
+++ b/Source/EasyNetQ/ReflectionBasedNewtonsoftJsonSerializer.cs
@@ -9,7 +9,7 @@ namespace EasyNetQ;
 /// <summary>
 ///     JsonSerializer based on Newtonsoft.Json which uses it dynamically
 /// </summary>
-public class JsonSerializer : ISerializer
+public sealed class ReflectionBasedNewtonsoftJsonSerializer : ISerializer
 {
     private static readonly Encoding Encoding = new UTF8Encoding(false);
 
@@ -23,7 +23,7 @@ public class JsonSerializer : ISerializer
     /// <summary>
     ///     Creates JsonSerializer
     /// </summary>
-    public JsonSerializer(object? serializerSettings = null)
+    public ReflectionBasedNewtonsoftJsonSerializer(object? serializerSettings = null)
     {
         var jsonSerializerType = TryGetType("Newtonsoft.Json.JsonSerializer", "Newtonsoft.Json");
         if (jsonSerializerType == null)

--- a/Source/EasyNetQ/ServiceRegisterExtensions.cs
+++ b/Source/EasyNetQ/ServiceRegisterExtensions.cs
@@ -35,7 +35,7 @@ public static class ServiceRegisterExtensions
             .TryRegister<IConnectionStringParser>(
                 _ => new CompositeConnectionStringParser(new AmqpConnectionStringParser(), new ConnectionStringParser())
             )
-            .TryRegister<ISerializer>(_ => new JsonSerializer())
+            .TryRegister<ISerializer>(_ => new ReflectionBasedNewtonsoftJsonSerializer())
             .TryRegister<IConventions, Conventions>()
             .TryRegister<IEventBus, EventBus>()
             .TryRegister<ITypeNameSerializer, DefaultTypeNameSerializer>()


### PR DESCRIPTION
This name reflects what is going on under the hood better. Also, its usage is not expected and [EasyNetQ.Serialization.SystemTextJson](https://www.nuget.org/packages/EasyNetQ.Serialization.SystemTextJson) or [EasyNetQ.Serialization.NewtonsoftJson](https://www.nuget.org/packages/EasyNetQ.Serialization.NewtonsoftJson) should be used instead.

Also, it removes a name collision with System.Text.Json.JsonSerialiser. 