### PR TITLE
Cancellation should be respected in RPC responder

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -1562,7 +1562,7 @@ namespace EasyNetQ.Internals
     }
     public sealed class AsyncCountdownEvent : System.IDisposable
     {
-        public AsyncCountdownEvent() { }
+        public AsyncCountdownEvent(long initialCount = 0) { }
         public void Decrement() { }
         public void Dispose() { }
         public void Increment() { }

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
@@ -1,5 +1,4 @@
-using System.Text;
-using EasyNetQ.Events;
+using EasyNetQ.Internals;
 using EasyNetQ.Tests.Mocking;
 
 namespace EasyNetQ.Tests.ConsumeTests;
@@ -7,68 +6,50 @@ namespace EasyNetQ.Tests.ConsumeTests;
 public class When_a_responder_is_cancelled : IDisposable
 {
     private readonly MockBuilder mockBuilder;
-    private PublishedMessageEvent publishedMessage;
-    private AckEvent ackEvent;
-
-    private readonly IConventions conventions;
-    private readonly ITypeNameSerializer typeNameSerializer;
-    private readonly ISerializer serializer;
 
     public When_a_responder_is_cancelled()
     {
         mockBuilder = new MockBuilder();
 
-        conventions = mockBuilder.Conventions;
-        typeNameSerializer = mockBuilder.TypeNameSerializer;
-        serializer = mockBuilder.Serializer;
+        var cde = new AsyncCountdownEvent(1);
 
-        mockBuilder.Rpc.Respond<RpcRequest, RpcResponse>(_ =>
-        {
-            var tcs = new TaskCompletionSource<RpcResponse>();
-            tcs.SetCanceled();
-            return tcs.Task;
-        });
+        var responder = mockBuilder.Rpc.Respond<RpcRequest, RpcResponse>(
+            async (_, ct) =>
+            {
+                cde.Decrement();
+                await Task.Delay(-1, ct);
+                return new RpcResponse();
+            },
+            _ => { }
+        );
 
-        DeliverMessage(new RpcRequest { Value = 42 });
+        var deliverTask = DeliverMessageAsync(new RpcRequest());
+        cde.WaitAsync().GetAwaiter().GetResult();
+
+        responder.Dispose();
+        deliverTask.GetAwaiter().GetResult();
     }
 
-    public void Dispose()
-    {
-        mockBuilder.Dispose();
-    }
+    public void Dispose() => mockBuilder.Dispose();
 
     [Fact]
-    public void Should_ACK_with_faulted_response()
+    public void Should_NACK_with_cancelled_response()
     {
-        Assert.True((bool)publishedMessage.Properties.Headers["IsFaulted"]);
-        Assert.Equal("A task was canceled.", Encoding.UTF8.GetString((byte[])publishedMessage.Properties.Headers["ExceptionMessage"]));
-        Assert.Equal(AckResult.Ack, ackEvent.AckResult);
+        mockBuilder.Channels[2].Received().BasicNack(0, false, true);
     }
 
-    private void DeliverMessage(RpcRequest request)
+    private Task DeliverMessageAsync(RpcRequest request)
     {
         var properties = new BasicProperties
         {
-            Type = typeNameSerializer.Serialize(typeof(RpcRequest)),
+            Type = mockBuilder.TypeNameSerializer.Serialize(typeof(RpcRequest)),
             CorrelationId = "the_correlation_id",
-            ReplyTo = conventions.RpcReturnQueueNamingConvention(typeof(RpcResponse))
+            ReplyTo = mockBuilder.Conventions.RpcReturnQueueNamingConvention(typeof(RpcResponse))
         };
 
-        var serializedMessage = serializer.MessageToBytes(typeof(RpcRequest), request);
+        var serializedMessage = mockBuilder.Serializer.MessageToBytes(typeof(RpcRequest), request);
 
-        var waiter = new CountdownEvent(2);
-        mockBuilder.EventBus.Subscribe((in PublishedMessageEvent x) =>
-        {
-            publishedMessage = x;
-            waiter.Signal();
-        });
-        mockBuilder.EventBus.Subscribe((in AckEvent x) =>
-        {
-            ackEvent = x;
-            waiter.Signal();
-        });
-
-        mockBuilder.Consumers[0].HandleBasicDeliver(
+        return mockBuilder.Consumers[0].HandleBasicDeliver(
             "consumer tag",
             0,
             false,
@@ -76,18 +57,10 @@ public class When_a_responder_is_cancelled : IDisposable
             "the_routing_key",
             properties,
             serializedMessage.Memory
-        ).GetAwaiter().GetResult();
-
-        if (!waiter.Wait(5000))
-            throw new TimeoutException();
+        );
     }
 
-    private class RpcRequest
-    {
-        public int Value { get; set; }
-    }
+    private record RpcRequest;
 
-    private class RpcResponse
-    {
-    }
+    private record RpcResponse;
 }

--- a/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
+++ b/Source/EasyNetQ.Tests/ConsumeTests/When_a_responder_is_cancelled.cs
@@ -33,7 +33,7 @@ public class When_a_responder_is_cancelled : IDisposable
     public void Dispose() => mockBuilder.Dispose();
 
     [Fact]
-    public void Should_NACK_with_cancelled_response()
+    public void Should_NACK_with_requeue()
     {
         mockBuilder.Channels[2].Received().BasicNack(0, false, true);
     }

--- a/Source/EasyNetQ/Consumer/AckStrategies.cs
+++ b/Source/EasyNetQ/Consumer/AckStrategies.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using EasyNetQ.Events;
 using RabbitMQ.Client;
 

--- a/Source/EasyNetQ/DefaultRpc.cs
+++ b/Source/EasyNetQ/DefaultRpc.cs
@@ -330,6 +330,10 @@ public class DefaultRpc : IRpc, IDisposable
                 cancellationToken
             ).ConfigureAwait(false);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception exception)
         {
             var responseMessage = new Message<TResponse>(

--- a/Source/EasyNetQ/Internals/AsyncCountdownEvent.cs
+++ b/Source/EasyNetQ/Internals/AsyncCountdownEvent.cs
@@ -12,6 +12,14 @@ public sealed class AsyncCountdownEvent : IDisposable
     private readonly Queue<TaskCompletionSource<bool>> waiters = new();
     private long count;
 
+    public AsyncCountdownEvent(long initialCount = 0)
+    {
+        if (initialCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(initialCount), "Initial count cannot be negative");
+
+        count = initialCount;
+    }
+
     /// <inheritdoc />
     public void Dispose()
     {
@@ -69,6 +77,7 @@ public sealed class AsyncCountdownEvent : IDisposable
             waiter = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             waiters.Enqueue(waiter);
         }
+
         waiter.AttachCancellation(cancellationToken);
         return waiter.Task;
     }

--- a/Source/EasyNetQ/Persistent/PersistentChannel.cs
+++ b/Source/EasyNetQ/Persistent/PersistentChannel.cs
@@ -54,8 +54,6 @@ public class PersistentChannel : IPersistentChannel
         if (disposed)
             throw new ObjectDisposedException(nameof(PersistentChannel));
 
-        cancellationToken.ThrowIfCancellationRequested();
-
         return TryInvokeChannelActionFast<TResult, TChannelAction>(channelAction, out var result)
             ? new ValueTask<TResult>(result)
             : new ValueTask<TResult>(InvokeChannelActionSlowAsync<TResult, TChannelAction>(channelAction, cancellationToken));


### PR DESCRIPTION
It is useless trying to publish an error message back because it will be cancelled.

Continues #1752.