### PR TITLE
upgrade microsoft extensions package to 6.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,17 +38,13 @@ updates:
     versions:
     - ">= 6.a"
     - "< 8"
-  - dependency-name: Microsoft.Extensions.Configuration
-    versions:
-    - ">= 5.a"
-    - "< 8"
   - dependency-name: Microsoft.Extensions.DependencyInjection
     versions:
-    - ">= 5.a"
+    - ">= 6.a"
     - "< 8"
   - dependency-name: Microsoft.Extensions.Logging.Abstractions
     versions:
-    - ">= 5.a"
+    - ">= 6.a"
     - "< 8"
   - dependency-name: Serilog
     versions:

--- a/Source/EasyNetQ.DI.Microsoft/EasyNetQ.DI.Microsoft.csproj
+++ b/Source/EasyNetQ.DI.Microsoft/EasyNetQ.DI.Microsoft.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="NullGuard.Fody" Version="3.1.1" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
+++ b/Source/EasyNetQ.DI.Tests/EasyNetQ.DI.Tests.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="Castle.Core" Version="4.4.1" />
     <PackageReference Include="Castle.Windsor" Version="5.1.1" />
     <PackageReference Include="Ninject" Version="3.3.5" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.6.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">

--- a/Source/EasyNetQ.Logging.Microsoft/EasyNetQ.Logging.Microsoft.csproj
+++ b/Source/EasyNetQ.Logging.Microsoft/EasyNetQ.Logging.Microsoft.csproj
@@ -13,7 +13,7 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
       <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
       <PackageReference Include="MinVer" Version="4.3.0">
         <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
- Upgrade Microsoft extensions package to `6.0` since `5.0` had been out of support
- Remove unnecessary `Microsoft.Extensions.DependencyInjection` reference
- Remove unused configuration package in dependabot

fixes #1760 