### PR TITLE
Set license expression rather than a file

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -4,7 +4,7 @@
     <PackageProduct>EasyNetQ</PackageProduct>
     <PackageIcon>EasyNetQ.png</PackageIcon>
     <PackageProjectUrl>https://github.com/EasyNetQ/EasyNetQ</PackageProjectUrl>
-    <PackageLicenseFile>licence.txt</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>RabbitMQ;Messaging;AMQP;C#</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>See https://github.com/EasyNetQ/EasyNetQ/releases</PackageReleaseNotes>
@@ -27,7 +27,6 @@
 
   <ItemGroup Condition="'$(IsPackable)' == 'true'">
     <None Include="..\..\Assets\EasyNetQ.png" Pack="true" PackagePath="" />
-    <None Include="..\..\licence.txt" Pack="true" PackagePath="" />
     <None Include="..\..\README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This moves the package to be using a license expression rather than including a license file

Closes #1784