### PR TITLE
Split configuration for routing key from queue name configuration for default RPC

### DIFF
--- a/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
+++ b/Source/EasyNetQ.ApprovalTests/EasyNetQ.approved.txt
@@ -177,6 +177,7 @@ namespace EasyNetQ
         public EasyNetQ.QueueNameConvention QueueNamingConvention { get; set; }
         public EasyNetQ.QueueTypeConvention QueueTypeConvention { get; set; }
         public EasyNetQ.RpcExchangeNameConvention RpcRequestExchangeNamingConvention { get; set; }
+        public EasyNetQ.RpcRequestQueueNameNamingConvention RpcRequestQueueNamingConvention { get; set; }
         public EasyNetQ.RpcExchangeNameConvention RpcResponseExchangeNamingConvention { get; set; }
         public EasyNetQ.RpcReturnQueueNamingConvention RpcReturnQueueNamingConvention { get; set; }
         public EasyNetQ.RpcRoutingKeyNamingConvention RpcRoutingKeyNamingConvention { get; set; }
@@ -419,6 +420,7 @@ namespace EasyNetQ
         EasyNetQ.QueueNameConvention QueueNamingConvention { get; }
         EasyNetQ.QueueTypeConvention QueueTypeConvention { get; }
         EasyNetQ.RpcExchangeNameConvention RpcRequestExchangeNamingConvention { get; }
+        EasyNetQ.RpcRequestQueueNameNamingConvention RpcRequestQueueNamingConvention { get; }
         EasyNetQ.RpcExchangeNameConvention RpcResponseExchangeNamingConvention { get; }
         EasyNetQ.RpcReturnQueueNamingConvention RpcReturnQueueNamingConvention { get; }
         EasyNetQ.RpcRoutingKeyNamingConvention RpcRoutingKeyNamingConvention { get; }
@@ -547,7 +549,7 @@ namespace EasyNetQ
         EasyNetQ.IRequestConfiguration WithHeaders(System.Collections.Generic.IDictionary<string, object?> headers);
         EasyNetQ.IRequestConfiguration WithPriority(byte priority);
         EasyNetQ.IRequestConfiguration WithPublisherConfirms(bool publisherConfirms);
-        EasyNetQ.IRequestConfiguration WithQueueName(string queueName);
+        EasyNetQ.IRequestConfiguration WithRoutingKey(string routingKey);
     }
     public interface IResponderConfiguration
     {
@@ -557,6 +559,7 @@ namespace EasyNetQ
         EasyNetQ.IResponderConfiguration WithPrefetchCount(ushort prefetchCount);
         EasyNetQ.IResponderConfiguration WithQueueName(string queueName);
         EasyNetQ.IResponderConfiguration WithQueueType(string queueType = "classic");
+        EasyNetQ.IResponderConfiguration WithRoutingKey(string routingKey);
     }
     public interface IRpc
     {
@@ -968,6 +971,7 @@ namespace EasyNetQ
         public static System.Threading.Tasks.Task<System.IDisposable> RespondAsync<TRequest, TResponse>(this EasyNetQ.IRpc rpc, System.Func<TRequest, System.Threading.Tasks.Task<TResponse>> responder, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task<System.IDisposable> RespondAsync<TRequest, TResponse>(this EasyNetQ.IRpc rpc, System.Func<TRequest, TResponse> responder, System.Threading.CancellationToken cancellationToken = default) { }
     }
+    public delegate string RpcRequestQueueNameNamingConvention(System.Type messageType, string? routingKey);
     public delegate string RpcReturnQueueNamingConvention(System.Type messageType);
     public delegate string RpcRoutingKeyNamingConvention(System.Type messageType);
     public static class SchedulerExtensions

--- a/Source/EasyNetQ.Tests/ConventionsTests.cs
+++ b/Source/EasyNetQ.Tests/ConventionsTests.cs
@@ -212,7 +212,8 @@ public class When_registering_response_handler : IDisposable
         var customConventions = new Conventions(new DefaultTypeNameSerializer())
         {
             RpcRequestExchangeNamingConvention = _ => "CustomRpcExchangeName",
-            RpcRoutingKeyNamingConvention = _ => "CustomRpcRoutingKeyName"
+            RpcRoutingKeyNamingConvention = _ => "CustomRpcRoutingKeyName",
+            RpcRequestQueueNamingConvention = (_,_) => "CustomRpcRoutingKeyName",
         };
 
         mockBuilder = new MockBuilder(x => x.AddSingleton<IConventions>(customConventions));

--- a/Source/EasyNetQ/Conventions.cs
+++ b/Source/EasyNetQ/Conventions.cs
@@ -54,6 +54,11 @@ public delegate string ErrorExchangeRoutingKeyConvention(MessageReceivedInfo rec
 public delegate string RpcRoutingKeyNamingConvention(Type messageType);
 
 /// <summary>
+///     Convention for rpc routing key naming
+/// </summary>
+public delegate string RpcRequestQueueNameNamingConvention(Type messageType, string? routingKey);
+
+/// <summary>
 ///     Convention for RPC exchange naming
 /// </summary>
 public delegate string RpcExchangeNameConvention(Type messageType);
@@ -97,6 +102,11 @@ public interface IConventions
     ///     Convention for RPC routing key naming
     /// </summary>
     RpcRoutingKeyNamingConvention RpcRoutingKeyNamingConvention { get; }
+
+    /// <summary>
+    ///     Convention for RPC request queue naming
+    /// </summary>
+    RpcRequestQueueNameNamingConvention RpcRequestQueueNamingConvention { get; }
 
     /// <summary>
     ///     Convention for RPC request exchange naming
@@ -184,6 +194,14 @@ public class Conventions : IConventions
                 : $"{attr.Name}_{subscriptionId}";
         };
         RpcRoutingKeyNamingConvention = typeNameSerializer.Serialize;
+        RpcRequestQueueNamingConvention = (type, routingKey) =>
+        {
+            var typeName = typeNameSerializer.Serialize(type);
+
+            return string.IsNullOrEmpty(routingKey)
+                ? typeName
+                : $"{typeName}_{routingKey}";
+        };
 
         ErrorQueueNamingConvention = _ => "EasyNetQ_Default_Error_Queue";
         ErrorExchangeNamingConvention = receivedInfo => "ErrorExchange_" + receivedInfo.RoutingKey;
@@ -222,6 +240,8 @@ public class Conventions : IConventions
 
     /// <inheritdoc />
     public RpcRoutingKeyNamingConvention RpcRoutingKeyNamingConvention { get; set; }
+
+    public RpcRequestQueueNameNamingConvention RpcRequestQueueNamingConvention { get; set; }
 
     /// <inheritdoc />
     public ErrorQueueNameConvention ErrorQueueNamingConvention { get; set; }

--- a/Source/EasyNetQ/RequestConfiguration.cs
+++ b/Source/EasyNetQ/RequestConfiguration.cs
@@ -25,9 +25,9 @@ public interface IRequestConfiguration
     /// <summary>
     /// Sets the queue name to publish to
     /// </summary>
-    /// <param name="queueName">The queue name to set</param>
+    /// <param name="routingKey">The queue name to set</param>
     /// <returns>Returns a reference to itself</returns>
-    IRequestConfiguration WithQueueName(string queueName);
+    IRequestConfiguration WithRoutingKey(string routingKey);
 
     /// <summary>
     /// Sets headers
@@ -46,13 +46,13 @@ public interface IRequestConfiguration
 
 internal class RequestConfiguration : IRequestConfiguration
 {
-    public RequestConfiguration(string queueName, TimeSpan expiration)
+    public RequestConfiguration(string routingKey, TimeSpan expiration)
     {
-        QueueName = queueName;
+        RoutingKey = routingKey;
         Expiration = expiration;
     }
 
-    public string QueueName { get; private set; }
+    public string RoutingKey { get; private set; }
     public TimeSpan Expiration { get; private set; }
     public byte? Priority { get; private set; }
     public IDictionary<string, object?>? MessageHeaders { get; private set; }
@@ -70,9 +70,9 @@ internal class RequestConfiguration : IRequestConfiguration
         return this;
     }
 
-    public IRequestConfiguration WithQueueName(string queueName)
+    public IRequestConfiguration WithRoutingKey(string routingKey)
     {
-        QueueName = queueName;
+        RoutingKey = routingKey;
         return this;
     }
 

--- a/Source/EasyNetQ/ResponderConfiguration.cs
+++ b/Source/EasyNetQ/ResponderConfiguration.cs
@@ -23,6 +23,13 @@ public interface IResponderConfiguration
     IResponderConfiguration WithQueueName(string queueName);
 
     /// <summary>
+    /// Sets the routing key
+    /// </summary>
+    /// <param name="routingKey"></param>
+    /// <returns>Reference to the same <see cref="IResponderConfiguration"/> to allow methods chaining</returns>
+    IResponderConfiguration WithRoutingKey(string routingKey);
+
+    /// <summary>
     /// Configures the queue's durability
     /// </summary>
     /// <returns>Reference to the same <see cref="IResponderConfiguration"/> to allow methods chaining</returns>
@@ -68,6 +75,7 @@ internal class ResponderConfiguration : IResponderConfiguration
 
     public ushort PrefetchCount { get; private set; }
     public string? QueueName { get; private set; }
+    public string? RoutingKey { get; private set; }
     public bool Durable { get; private set; } = true;
 
     public IDictionary<string, object>? QueueArguments { get; private set; }
@@ -81,6 +89,12 @@ internal class ResponderConfiguration : IResponderConfiguration
     public IResponderConfiguration WithQueueName(string queueName)
     {
         QueueName = queueName;
+        return this;
+    }
+
+    public IResponderConfiguration WithRoutingKey(string routingKey)
+    {
+        RoutingKey = routingKey;
         return this;
     }
 


### PR DESCRIPTION
Current configuration is a little confusing as for request it proposes to configure queue only, which is in fact used by responder only. Proposed changes are to have a separate configuration for RPC queue name and use current one for routing key only