### PR TITLE
fix for serialisation issues with System.Private.CoreLib/mscorlib types

### DIFF
--- a/Source/EasyNetQ.Serialization.NewtonsoftJson/NetCoreSerializationBinder.cs
+++ b/Source/EasyNetQ.Serialization.NewtonsoftJson/NetCoreSerializationBinder.cs
@@ -1,0 +1,34 @@
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json.Serialization;
+
+namespace EasyNetQ.Serialization.NewtonsoftJson;
+
+internal sealed class NetCoreSerializationBinder : DefaultSerializationBinder
+{
+    private static readonly Regex Regex = new(
+        @"System\.Private\.CoreLib(, Version=[\d\.]+)?(, Culture=[\w-]+)(, PublicKeyToken=[\w\d]+)?");
+
+    private static readonly ConcurrentDictionary<Type, (string? assembly, string? type)> Cache = new();
+
+    public override void BindToName(Type serializedType, out string? assemblyName, out string? typeName)
+    {
+        base.BindToName(serializedType, out assemblyName, out typeName);
+
+        if (Cache.TryGetValue(serializedType, out var name))
+        {
+            assemblyName = name.assembly;
+            typeName = name.type;
+        }
+        else
+        {
+            if (assemblyName?.StartsWith("System.Private.CoreLib") ?? false)
+                assemblyName = Regex.Replace(assemblyName, "mscorlib");
+
+            if (typeName?.Contains("System.Private.CoreLib") ?? false)
+                typeName = Regex.Replace(typeName, "mscorlib");
+
+            Cache.TryAdd(serializedType, (assemblyName, typeName));
+        }
+    }
+}

--- a/Source/EasyNetQ.Serialization.NewtonsoftJson/NewtonsoftJsonSerializer.cs
+++ b/Source/EasyNetQ.Serialization.NewtonsoftJson/NewtonsoftJsonSerializer.cs
@@ -14,7 +14,8 @@ public sealed class NewtonsoftJsonSerializer : ISerializer
     private static readonly Newtonsoft.Json.JsonSerializerSettings DefaultSerializerSettings =
         new()
         {
-            TypeNameHandling = Newtonsoft.Json.TypeNameHandling.Auto
+            TypeNameHandling = Newtonsoft.Json.TypeNameHandling.Auto,
+            SerializationBinder = new NetCoreSerializationBinder()
         };
 
     private const int DefaultBufferSize = 1024;


### PR DESCRIPTION
When messages are sent from .Net Framework to .Net Core or vice versa library can throw an exception for deserialisation framework types from mscorelib/System.Private.CoreLib. The root cause is that some types are in other assembly. This is PR to replace assembly when such scenario is detected

fix for https://github.com/EasyNetQ/EasyNetQ/issues/1334
https://github.com/EasyNetQ/EasyNetQ/issues/1217