### PR TITLE
Fix ambiguous Split method

### DIFF
--- a/Source/EasyNetQ/Internals/UriExtensions.cs
+++ b/Source/EasyNetQ/Internals/UriExtensions.cs
@@ -23,10 +23,10 @@ public static class UriExtensions
             queryString = queryString.Substring(1);
 
         var query = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
-        var keyValues = queryString.Split(['&'], StringSplitOptions.RemoveEmptyEntries);
+        var keyValues = queryString.Split(new char[] { '&' }, StringSplitOptions.RemoveEmptyEntries);
         foreach (var keyValue in keyValues)
         {
-            var keyValueParts = keyValue.Split(['='], StringSplitOptions.RemoveEmptyEntries);
+            var keyValueParts = keyValue.Split(new char[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
             if (keyValueParts.Length == 2)
                 query.Add(Uri.UnescapeDataString(keyValueParts[0]), Uri.UnescapeDataString(keyValueParts[1]));
         }


### PR DESCRIPTION
Fix ambiguous Split method calls in UriExtensions.cs for .NET 6 compatibility