### PR TITLE
Avoid closures in IPubSub.PublishAsync and .SubscribeAsync 

### DIFF
--- a/Source/EasyNetQ/IPubSub.cs
+++ b/Source/EasyNetQ/IPubSub.cs
@@ -24,6 +24,27 @@ public interface IPubSub
     );
 
     /// <summary>
+    /// Publishes a message.
+    /// When used with publisher confirms the task completes when the publish is confirmed.
+    /// Task will throw an exception if the confirm is NACK'd or times out.
+    /// </summary>
+    /// <typeparam name="T">The message type</typeparam>
+    /// <typeparam name="TData">Type of data to pass to the configuration callback</typeparam>
+    /// <param name="message">The message to publish</param>
+    /// <param name="data">Data to pass to the configuration callback</param>
+    /// <param name="configure">
+    /// Fluent configuration e.g. x => x.WithTopic("*.brighton").WithPriority(2)
+    /// </param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <returns></returns>
+    Task PublishAsync<T, TData>(
+        T message,
+        TData data,
+        Action<IPublishConfiguration, TData> configure,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
     /// Subscribes to a stream of messages that match a .NET type.
     /// </summary>
     /// <typeparam name="T">The type to subscribe to</typeparam>
@@ -50,5 +71,39 @@ public interface IPubSub
         Func<T, CancellationToken, Task> onMessage,
         Action<ISubscriptionConfiguration> configure,
         CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Subscribes to a stream of messages that match a .NET type.
+    /// </summary>
+    /// <typeparam name="T">The type to subscribe to</typeparam>
+    /// <typeparam name="TData">Type of data to pass to the configuration callback</typeparam>
+    /// <param name="subscriptionId">
+    /// A unique identifier for the subscription. Two subscriptions with the same subscriptionId
+    /// and type will get messages delivered in turn. This is useful if you want multiple subscribers
+    /// to load balance a subscription in a round-robin fashion.
+    /// </param>
+    /// <param name="onMessage">
+    /// The action to run when a message arrives. onMessage can immediately return a Task and
+    /// then continue processing asynchronously. When the Task completes the message will be
+    /// Ack'd.
+    /// </param>
+    /// <param name="configureData">
+    /// Data to pass to the configuration callback.
+    /// </param>
+    /// <param name="configure">
+    /// Fluent configuration e.g. x => x.WithTopic("uk.london").WithArgument("x-message-ttl", "60")
+    /// </param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <returns>
+    /// An <see cref="SubscriptionResult"/>
+    /// Call Dispose on it to cancel the subscription.
+    /// </returns>
+    Task<SubscriptionResult> SubscribeAsync<T, TData>(
+        string subscriptionId,
+        Func<T, CancellationToken, Task> onMessage,
+        TData configureData,
+        Action<ISubscriptionConfiguration, TData> configure,
+        CancellationToken cancellationToken
     );
 }


### PR DESCRIPTION
Add overloads for .PublishAsync and .SubscribeAsync to pass in a data parameter and hopefully avoid creating unnecessary closures. 

When we do

	pubSub.PublishAsync(message, config => ...)

if we need to reference any data from the surrounding context it will allocate a closure on the heap. Multiply this times however many messages you publish. Compare to:

    pubSub.PublishAsync(message, contextualData, static (config, data) => ...)

Here we can use a static callback method and avoid allocating a closure. 
I have done the same thing for .SubscribeAsync, though I suspect Subscribes happen far less often so the big win is the change to .PublishAsync