### PR TITLE
Fix ObjectDisposedException in PersistentChannel During Semaphore Rel…

### DIFF
--- a/Source/EasyNetQ/Persistent/PersistentChannel.cs
+++ b/Source/EasyNetQ/Persistent/PersistentChannel.cs
@@ -98,7 +98,14 @@ public class PersistentChannel : IPersistentChannel
             }
             finally
             {
-                releaser.Dispose();
+                try
+                {
+                    releaser.Dispose();
+                }
+                catch (Exception exception)
+                {
+                    logger.LogWarning(exception, "Semaphore was already disposed during channel release!");
+                }
             }
         }
 


### PR DESCRIPTION
**Description:**
This PR addresses an issue where an ObjectDisposedException can occur during the release of a semaphore in the PersistentChannel when RabbitMQ connections are being closed or disposed. Although the message is often successfully published, the exception can disrupt the application flow or flood the logs with unnecessary warnings.
![image](https://github.com/user-attachments/assets/c562bf56-afb2-4a53-950e-9f34b1ef945c)


**Root Cause:**
	•	The issue occurs when the SemaphoreSlim used for synchronizing access to RabbitMQ channels is disposed while another thread is still attempting to release it.
	•	This typically happens during application shutdown or when the RabbitMQ connection is being reset.
	•	The current implementation does not handle this edge case, resulting in an unhandled ObjectDisposedException.

**Proposed Fix:**
	•	Safely release the semaphore by wrapping the Dispose() call in a try-catch block.
	•	If the semaphore is already disposed, log a warning instead of letting the exception propagate.
	•	This ensures that the application can continue running smoothly without being interrupted by this non-critical exception.
**Impact:**
	•	This fix is non-breaking and improves the robustness of EasyNetQ’s message publishing flow.
	•	No changes to the public API or existing behavior.
	•	Safer shutdown and better error handling.