### PR TITLE
Fixed consumer shutdown process

### DIFF
--- a/Source/EasyNetQ/Consumer/InternalConsumer.cs
+++ b/Source/EasyNetQ/Consumer/InternalConsumer.cs
@@ -251,17 +251,6 @@ public class InternalConsumer : IInternalConsumer
         foreach (var consumer in consumers.Values)
         {
             consumer.ConsumerCancelled -= AsyncBasicConsumerOnConsumerCancelled;
-            foreach (var consumerTag in consumer.ConsumerTags)
-            {
-                try
-                {
-                    model?.BasicCancelNoWait(consumerTag);
-                }
-                catch (AlreadyClosedException)
-                {
-                }
-            }
-
             consumer.Dispose();
         }
 


### PR DESCRIPTION
It fixes #1849.

Long story short: *BasicCancelNoWait* method has a side effect which breaks EasyNetQ consumer shutdown process.

The long story:
When connection is lost we have Consumer.[OnConnectionDisconnected](https://github.com/EasyNetQ/EasyNetQ/blob/a76e647fb4ff7b89271468eecc77b70f9614b8a6/Source/EasyNetQ/Consumer/Consumer.cs#L196) method call that calls [StopConsuming](https://github.com/EasyNetQ/EasyNetQ/blob/a76e647fb4ff7b89271468eecc77b70f9614b8a6/Source/EasyNetQ/Consumer/InternalConsumer.cs#L245)

The method code is the following:
```c#
public void StopConsuming()
{
    if (disposed) throw new ObjectDisposedException(nameof(InternalConsumer));

    using var _ = mutex.Acquire();

    foreach (var consumer in consumers.Values)
    {
        consumer.ConsumerCancelled -= AsyncBasicConsumerOnConsumerCancelled;
        foreach (var consumerTag in consumer.ConsumerTags)
        {
            try
            {
                model?.BasicCancelNoWait(consumerTag);
            }
            catch (AlreadyClosedException)
            {
            }
        }

        consumer.Dispose();
    }

    consumers.Clear();
}
```
If understand it right *BasicCancelNoWait* method just tells the rabbitmq server that the app has done it's job and the corresponding consumer isn't required. So in other words the client tells the server that it finished consuming. I've checked rabbitmq.client source code and I see that rabbitmq.client doesn't use *BasicCancel* and its overloads for connection and consumer recovery. Moreover it looks like that this method is just for graceful consumer shutdown in case of established connection between a client and a server.

So if we have lost connection to the server we can't notify it. But since we use fire and forget method overload it looks like that there will be no problems. 

But lets take a look at method ModelBase.[BasicCancelNoWait](https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/b3840a9f34a0659c1ec5d5c80352d3a3648e9371/projects/RabbitMQ.Client/client/impl/ModelBase.cs#L1079) :

```c#
public void BasicCancelNoWait(string consumerTag)
{
    _Private_BasicCancel(consumerTag, true);

    lock (_consumers)
    {
        _consumers.Remove(consumerTag);
    }
}
```
We are interested in this line: `_consumers.Remove(consumerTag);`

Also we need ModelBase.[OnSessionShutdown](https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/b3840a9f34a0659c1ec5d5c80352d3a3648e9371/projects/RabbitMQ.Client/client/impl/ModelBase.cs#L473) method implementation:

```c#
public void OnSessionShutdown(object sender, ShutdownEventArgs reason)
{
    ConsumerDispatcher.Quiesce();
    SetCloseReason(reason);
    OnModelShutdown(reason);
    BroadcastShutdownToConsumers(_consumers, reason);
    ConsumerDispatcher.Shutdown(this).GetAwaiter().GetResult(); ;
}
```

And the last but not the least is AsyncBasicConsumer.[OnCancel](https://github.com/EasyNetQ/EasyNetQ/blob/a76e647fb4ff7b89271468eecc77b70f9614b8a6/Source/EasyNetQ/Consumer/AsyncBasicConsumer.cs#L47) wich is prevented from calling:

```c#
public override async Task OnCancel(params string[] consumerTags)
{
    await base.OnCancel(consumerTags).ConfigureAwait(false);

    if (logger.IsInfoEnabled())
    {
        logger.InfoFormat(
            "Consumer with consumerTags {consumerTags} has cancelled",
            string.Join(", ", consumerTags)
        );
    }
}
```
To sum up: *BasicCancelNoWait* call clears *_consumers* collection and when we call *BroadcastShutdownToConsumers* we have empty consumers list and we cannot properly notify the existing consumers.


Probably InternalConsumer.[Dispose](https://github.com/EasyNetQ/EasyNetQ/blob/a76e647fb4ff7b89271468eecc77b70f9614b8a6/Source/EasyNetQ/Consumer/InternalConsumer.cs#L275) have such an issue but I haven't checked it.
