### PR TITLE
Add BenchmarkDotNet benchmarks for consume pipeline and serializers

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -16,7 +16,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <AssemblyOriginatorKeyFile>..\..\Assets\EasyNetQ.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\Assets\EasyNetQ.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign>false</PublicSign>
     <NoWarn>$(NoWarn);1591;8002</NoWarn>

--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -6,6 +6,7 @@
         <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
     </PropertyGroup>
     <ItemGroup>
+        <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
         <PackageVersion Include="docker.dotnet" Version="3.125.15" />
         <PackageVersion Include="EasyNetQ.Management.Client" Version="3.0.1" />
         <PackageVersion Include="FluentAssertions" Version="8.8.0" />

--- a/Source/EasyNetQ.Benchmarks/ConsumePipelineBenchmarks.cs
+++ b/Source/EasyNetQ.Benchmarks/ConsumePipelineBenchmarks.cs
@@ -1,0 +1,74 @@
+using BenchmarkDotNet.Attributes;
+using EasyNetQ.Consumer;
+using EasyNetQ.Serialization.SystemTextJson;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace EasyNetQ.Benchmarks;
+
+[MemoryDiagnoser]
+public class ConsumePipelineBenchmarks
+{
+    private ConsumeDelegate consumeDelegate = null!;
+    private ConsumeContext smallContext;
+    private ConsumeContext mediumContext;
+    private ConsumeContext largeContext;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        var serializer = new SystemTextJsonSerializerV2();
+        var typeNameSerializer = new DefaultTypeNameSerializer();
+        var messageSerializationStrategy = new DefaultMessageSerializationStrategy(
+            typeNameSerializer, serializer, new DefaultCorrelationIdGenerationStrategy()
+        );
+
+        // Minimal DI container matching the real consume pipeline dependencies
+        var services = new ServiceCollection();
+        services.AddSingleton<IConsumeErrorStrategy>(SimpleConsumeErrorStrategy.Ack);
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        var provider = services.BuildServiceProvider();
+
+        // Handler collection with a no-op typed handler (simulates user handler)
+        var handlerCollection = new HandlerCollection();
+        handlerCollection.Add<SmallMessage>((_, _, _) => Task.FromResult(AckStrategies.AckAsync));
+        handlerCollection.Add<MediumMessage>((_, _, _) => Task.FromResult(AckStrategies.AckAsync));
+        handlerCollection.Add<LargeMessage>((_, _, _) => Task.FromResult(AckStrategies.AckAsync));
+
+        // Build the pipeline as RabbitAdvancedBus does:
+        // UseConsumeErrorStrategy -> UseConsumeInterceptors -> Deserialize + Dispatch
+        consumeDelegate = new ConsumePipelineBuilder()
+            .UseConsumeErrorStrategy()
+            .UseConsumeInterceptors()
+            .Use(_ => ctx =>
+            {
+                var deserializedMessage = messageSerializationStrategy.DeserializeMessage(ctx.Properties, ctx.Body);
+                var handler = handlerCollection.GetHandler(deserializedMessage.MessageType);
+                return new ValueTask<AckStrategyAsync>(handler(deserializedMessage, ctx.ReceivedInfo, ctx.CancellationToken));
+            })
+            .Build();
+
+        var receivedInfo = new MessageReceivedInfo("consumer", 1UL, false, "exchange", "routing.key", "queue");
+
+        smallContext = CreateContext(messageSerializationStrategy, SampleMessages.CreateSmall(), receivedInfo, provider);
+        mediumContext = CreateContext(messageSerializationStrategy, SampleMessages.CreateMedium(), receivedInfo, provider);
+        largeContext = CreateContext(messageSerializationStrategy, SampleMessages.CreateLarge(), receivedInfo, provider);
+    }
+
+    private static ConsumeContext CreateContext<T>(
+        IMessageSerializationStrategy strategy, T message, MessageReceivedInfo receivedInfo, IServiceProvider services)
+    {
+        using var serialized = strategy.SerializeMessage(new Message<T>(message));
+        return new ConsumeContext(receivedInfo, serialized.Properties, serialized.Body.ToArray(), services, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public ValueTask<AckStrategyAsync> Consume_Small() => consumeDelegate(smallContext);
+
+    [Benchmark]
+    public ValueTask<AckStrategyAsync> Consume_Medium() => consumeDelegate(mediumContext);
+
+    [Benchmark]
+    public ValueTask<AckStrategyAsync> Consume_Large() => consumeDelegate(largeContext);
+}

--- a/Source/EasyNetQ.Benchmarks/EasyNetQ.Benchmarks.csproj
+++ b/Source/EasyNetQ.Benchmarks/EasyNetQ.Benchmarks.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\EasyNetQ\EasyNetQ.csproj" />
+        <ProjectReference Include="..\EasyNetQ.Serialization.NewtonsoftJson\EasyNetQ.Serialization.NewtonsoftJson.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Source/EasyNetQ.Benchmarks/Messages.cs
+++ b/Source/EasyNetQ.Benchmarks/Messages.cs
@@ -1,0 +1,114 @@
+using EasyNetQ;
+
+namespace EasyNetQ.Benchmarks;
+
+public class SmallMessage
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+}
+
+public class MediumMessage
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+    public string Email { get; set; } = "";
+    public string Description { get; set; } = "";
+    public DateTime CreatedAt { get; set; }
+    public List<string> Tags { get; set; } = [];
+    public Dictionary<string, string> Metadata { get; set; } = [];
+}
+
+public class LargeMessage
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+    public string Email { get; set; } = "";
+    public string Description { get; set; } = "";
+    public DateTime CreatedAt { get; set; }
+    public List<string> Tags { get; set; } = [];
+    public Dictionary<string, string> Metadata { get; set; } = [];
+    public List<LargeMessageItem> Items { get; set; } = [];
+}
+
+public class LargeMessageItem
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = "";
+    public decimal Price { get; set; }
+    public int Quantity { get; set; }
+}
+
+[Exchange(Name = "custom-exchange")]
+[Queue(Name = "custom-queue")]
+public class AttributedMessage
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+}
+
+public static class SampleMessages
+{
+    public static SmallMessage CreateSmall() => new()
+    {
+        Id = 1,
+        Name = "Test"
+    };
+
+    public static MediumMessage CreateMedium() => new()
+    {
+        Id = 42,
+        Name = "John Doe",
+        Email = "john@example.com",
+        Description = "A medium-sized message with several properties for benchmarking purposes.",
+        CreatedAt = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc),
+        Tags = ["benchmark", "test", "performance", "easynetq"],
+        Metadata = new Dictionary<string, string>
+        {
+            ["source"] = "benchmark",
+            ["version"] = "1.0",
+            ["environment"] = "production"
+        }
+    };
+
+    public static LargeMessage CreateLarge() => new()
+    {
+        Id = 99,
+        Name = "Jane Smith",
+        Email = "jane@example.com",
+        Description = "A large message containing a collection of items for benchmarking serialization performance with realistic payloads.",
+        CreatedAt = new DateTime(2024, 6, 1, 14, 0, 0, DateTimeKind.Utc),
+        Tags = ["benchmark", "test", "performance", "easynetq", "large", "payload", "serialization"],
+        Metadata = new Dictionary<string, string>
+        {
+            ["source"] = "benchmark",
+            ["version"] = "2.0",
+            ["environment"] = "production",
+            ["region"] = "us-east-1",
+            ["priority"] = "high"
+        },
+        Items = Enumerable.Range(1, 50).Select(i => new LargeMessageItem
+        {
+            Id = i,
+            Title = $"Item {i} - Product with a moderately long description for realism",
+            Price = 9.99m + i,
+            Quantity = i * 2
+        }).ToList()
+    };
+
+    public static object Create(string size) => size switch
+    {
+        "Small" => CreateSmall(),
+        "Medium" => CreateMedium(),
+        "Large" => CreateLarge(),
+        _ => throw new ArgumentException($"Unknown size: {size}", nameof(size))
+    };
+
+    public static Type GetType(string size) => size switch
+    {
+        "Small" => typeof(SmallMessage),
+        "Medium" => typeof(MediumMessage),
+        "Large" => typeof(LargeMessage),
+        _ => throw new ArgumentException($"Unknown size: {size}", nameof(size))
+    };
+}

--- a/Source/EasyNetQ.Benchmarks/Program.cs
+++ b/Source/EasyNetQ.Benchmarks/Program.cs
@@ -1,0 +1,3 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/Source/EasyNetQ.Benchmarks/RESULTS.md
+++ b/Source/EasyNetQ.Benchmarks/RESULTS.md
@@ -1,0 +1,80 @@
+# EasyNetQ Benchmark Results
+
+``` ini
+BenchmarkDotNet v0.14.0, macOS 26.3 (25D125) [Darwin 25.3.0]
+Apple M3 Max, 1 CPU, 16 logical and 16 physical cores
+.NET SDK 10.0.103
+  [Host]     : .NET 8.0.24 (8.0.2426.7010), Arm64 RyuJIT AdvSIMD
+  DefaultJob : .NET 8.0.24 (8.0.2426.7010), Arm64 RyuJIT AdvSIMD
+```
+
+## Consume Pipeline
+
+Full end-to-end consume hot path: error strategy middleware &rarr; interceptor middleware &rarr; deserialization (TypeNameSerializer + SystemTextJsonV2 + MessageFactory) &rarr; handler dispatch.
+
+| Method         | Mean        | Error     | StdDev    | Gen0   | Gen1   | Allocated |
+|--------------- |------------:|----------:|----------:|-------:|-------:|----------:|
+| Consume_Small  |    383.5 ns |   1.67 ns |   1.56 ns | 0.0334 |      - |     280 B |
+| Consume_Medium |  1,257.8 ns |   8.36 ns |   7.82 ns | 0.2193 |      - |   1,848 B |
+| Consume_Large  | 17,041.9 ns | 112.89 ns | 105.60 ns | 1.6174 | 0.0610 |  13,736 B |
+
+### Payload sizes
+
+- **Small** (2 fields): ~29 bytes JSON
+- **Medium** (7 fields incl. list + dictionary): ~300 bytes JSON
+- **Large** (7 fields + 50-item collection): ~5 KB JSON
+
+### Key observations
+
+- Small message consume takes **~384 ns** with **280 B** allocated per message
+- Cost scales roughly linearly with payload: dominated by JSON deserialization
+- Large messages trigger Gen1 GC collections due to 13.7 KB allocations
+
+## Serializer Comparison
+
+Comparing SystemTextJson (v1), SystemTextJson V2 (default), and Newtonsoft.Json across three payload sizes.
+
+| Method                       | Size   | Mean        | Error    | StdDev   | Gen0   | Gen1   | Allocated |
+|----------------------------- |------- |------------:|---------:|---------:|-------:|-------:|----------:|
+| SystemTextJson_Serialize     | Small  |    151.0 ns |  0.80 ns |  0.75 ns | 0.0238 |      - |     200 B |
+| SystemTextJsonV2_Serialize   | Small  |    151.0 ns |  0.68 ns |  0.53 ns | 0.0238 |      - |     200 B |
+| Newtonsoft_Serialize         | Small  |    351.8 ns |  1.80 ns |  1.69 ns | 0.3133 | 0.0010 |   2,624 B |
+| SystemTextJson_Deserialize   | Small  |    148.1 ns |  0.38 ns |  0.36 ns | 0.0076 |      - |      64 B |
+| SystemTextJsonV2_Deserialize | Small  |    148.1 ns |  0.49 ns |  0.46 ns | 0.0076 |      - |      64 B |
+| Newtonsoft_Deserialize       | Small  |    429.2 ns |  4.72 ns |  4.41 ns | 0.4358 | 0.0019 |   3,648 B |
+| SystemTextJson_Serialize     | Medium |    600.6 ns |  3.40 ns |  3.18 ns | 0.0610 |      - |     512 B |
+| SystemTextJsonV2_Serialize   | Medium |    609.3 ns | 10.17 ns |  9.52 ns | 0.0610 |      - |     512 B |
+| Newtonsoft_Serialize         | Medium |  1,117.6 ns |  5.61 ns |  5.25 ns | 0.3452 | 0.0019 |   2,896 B |
+| SystemTextJson_Deserialize   | Medium |    980.3 ns |  6.47 ns |  5.73 ns | 0.1945 |      - |   1,632 B |
+| SystemTextJsonV2_Deserialize | Medium |    986.6 ns |  8.66 ns |  8.10 ns | 0.1945 |      - |   1,632 B |
+| Newtonsoft_Deserialize       | Medium |  1,790.0 ns |  4.59 ns |  4.07 ns | 0.5798 | 0.0038 |   4,856 B |
+| SystemTextJson_Serialize     | Large  |  9,113.0 ns | 47.82 ns | 44.73 ns | 0.0610 |      - |     512 B |
+| SystemTextJsonV2_Serialize   | Large  |  9,205.5 ns | 53.04 ns | 47.02 ns | 0.0610 |      - |     512 B |
+| Newtonsoft_Serialize         | Large  | 18,564.7 ns | 48.38 ns | 42.89 ns | 1.2207 |      - |  11,640 B |
+| SystemTextJson_Deserialize   | Large  | 16,806.9 ns | 98.04 ns | 81.87 ns | 1.5869 | 0.0610 |  13,520 B |
+| SystemTextJsonV2_Deserialize | Large  | 16,732.1 ns | 73.65 ns | 68.89 ns | 1.5869 | 0.0610 |  13,520 B |
+| Newtonsoft_Deserialize       | Large  | 31,849.6 ns | 66.68 ns | 62.37 ns | 2.4414 | 0.0610 |  20,424 B |
+
+### Key observations
+
+- **SystemTextJson V1 and V2 perform identically** across all payload sizes
+- **Newtonsoft is ~2x slower** than SystemTextJson for both serialization and deserialization
+- **Serialization allocations**: SystemTextJson allocates a fixed 200-512 B (pooled buffer) regardless of payload growth; Newtonsoft allocates 2.6-11.6 KB scaling with size
+- **Deserialization allocations**: SystemTextJson allocates 64 B - 13.5 KB (dominated by the deserialized object); Newtonsoft adds 3.6-6.9 KB overhead on top
+- For small messages, Newtonsoft allocates **57x more** on serialize (2,624 B vs 200 B)
+
+## Running benchmarks
+
+```bash
+# Full run
+dotnet run --project Source/EasyNetQ.Benchmarks -c Release -- --filter '*'
+
+# Consume pipeline only
+dotnet run --project Source/EasyNetQ.Benchmarks -c Release -- --filter '*ConsumePipelineBenchmarks*'
+
+# Serializer comparison only
+dotnet run --project Source/EasyNetQ.Benchmarks -c Release -- --filter '*SerializerBenchmarks*'
+
+# Quick smoke test (dry run)
+dotnet run --project Source/EasyNetQ.Benchmarks -c Release -- --filter '*' --job dry
+```

--- a/Source/EasyNetQ.Benchmarks/SerializerBenchmarks.cs
+++ b/Source/EasyNetQ.Benchmarks/SerializerBenchmarks.cs
@@ -1,0 +1,79 @@
+using BenchmarkDotNet.Attributes;
+using EasyNetQ.Serialization.NewtonsoftJson;
+using EasyNetQ.Serialization.SystemTextJson;
+
+namespace EasyNetQ.Benchmarks;
+
+[MemoryDiagnoser]
+public class SerializerBenchmarks
+{
+    private ISerializer systemTextJson = null!;
+    private ISerializer systemTextJsonV2 = null!;
+    private ISerializer newtonsoft = null!;
+
+    private object message = null!;
+    private Type messageType = null!;
+
+    private ReadOnlyMemory<byte> systemTextJsonBytes;
+    private ReadOnlyMemory<byte> systemTextJsonV2Bytes;
+    private ReadOnlyMemory<byte> newtonsoftBytes;
+
+    [Params("Small", "Medium", "Large")]
+    public string Size { get; set; } = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        systemTextJson = new SystemTextJsonSerializer();
+        systemTextJsonV2 = new SystemTextJsonSerializerV2();
+        newtonsoft = new NewtonsoftJsonSerializer();
+
+        message = SampleMessages.Create(Size);
+        messageType = SampleMessages.GetType(Size);
+
+        using var stj = systemTextJson.MessageToBytes(messageType, message);
+        systemTextJsonBytes = stj.Memory.ToArray();
+
+        using var stj2 = systemTextJsonV2.MessageToBytes(messageType, message);
+        systemTextJsonV2Bytes = stj2.Memory.ToArray();
+
+        using var nj = newtonsoft.MessageToBytes(messageType, message);
+        newtonsoftBytes = nj.Memory.ToArray();
+    }
+
+    [Benchmark]
+    public void SystemTextJson_Serialize()
+    {
+        using var result = systemTextJson.MessageToBytes(messageType, message);
+    }
+
+    [Benchmark]
+    public void SystemTextJsonV2_Serialize()
+    {
+        using var result = systemTextJsonV2.MessageToBytes(messageType, message);
+    }
+
+    [Benchmark]
+    public void Newtonsoft_Serialize()
+    {
+        using var result = newtonsoft.MessageToBytes(messageType, message);
+    }
+
+    [Benchmark]
+    public object SystemTextJson_Deserialize()
+    {
+        return systemTextJson.BytesToMessage(messageType, systemTextJsonBytes);
+    }
+
+    [Benchmark]
+    public object SystemTextJsonV2_Deserialize()
+    {
+        return systemTextJsonV2.BytesToMessage(messageType, systemTextJsonV2Bytes);
+    }
+
+    [Benchmark]
+    public object Newtonsoft_Deserialize()
+    {
+        return newtonsoft.BytesToMessage(messageType, newtonsoftBytes);
+    }
+}

--- a/Source/EasyNetQ.slnx
+++ b/Source/EasyNetQ.slnx
@@ -27,6 +27,9 @@
     <Project Path="EasyNetQ.Serialization.Tests/EasyNetQ.Serialization.Tests.csproj" />
     <Project Path="EasyNetQ.Tests/EasyNetQ.Tests.csproj" />
   </Folder>
+  <Folder Name="/Benchmarks/">
+    <Project Path="EasyNetQ.Benchmarks/EasyNetQ.Benchmarks.csproj" />
+  </Folder>
   <Project Path="EasyNetQ.Hosepipe/EasyNetQ.Hosepipe.csproj" />
   <Project Path="EasyNetQ/EasyNetQ.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary
- Add `EasyNetQ.Benchmarks` project with BenchmarkDotNet benchmarks focused on the message consumption hot path
- **ConsumePipelineBenchmarks**: full end-to-end consume pipeline (error strategy middleware → interceptor middleware → deserialization → handler dispatch) with small/medium/large payloads
- **SerializerBenchmarks**: compare SystemTextJson vs V2 vs Newtonsoft across 3 payload sizes
- Fix `AssemblyOriginatorKeyFile` path in `Directory.Build.props` to use `$(MSBuildThisFileDirectory)` so BenchmarkDotNet's auto-generated projects can resolve the SNK

## Results highlights (Apple M3 Max, .NET 8.0)

### Consume pipeline
| Method | Mean | Allocated |
|---|---:|---:|
| Consume_Small | 383.5 ns | 280 B |
| Consume_Medium | 1,257.8 ns | 1,848 B |
| Consume_Large | 17,041.9 ns | 13,736 B |

### Serializer comparison (small payload)
| Serializer | Serialize | Deserialize | Serialize Alloc | Deserialize Alloc |
|---|---:|---:|---:|---:|
| SystemTextJson | 151 ns | 148 ns | 200 B | 64 B |
| SystemTextJson V2 | 151 ns | 148 ns | 200 B | 64 B |
| Newtonsoft | 352 ns | 429 ns | 2,624 B | 3,648 B |

## Test plan
- [x] `dotnet build Source/EasyNetQ.Benchmarks -c Release` succeeds
- [x] `dotnet run --project Source/EasyNetQ.Benchmarks -c Release -- --list flat` discovers all 9 benchmarks
- [x] Full benchmark run completes successfully
- [x] `dotnet format --verify-no-changes` passes