### PR TITLE
fix: Made sure DefaultConsumeErrorStrategy disposes channel when work is done

### DIFF
--- a/Source/EasyNetQ/Consumer/DefaultConsumeErrorStrategy.cs
+++ b/Source/EasyNetQ/Consumer/DefaultConsumeErrorStrategy.cs
@@ -72,7 +72,7 @@ public class DefaultConsumeErrorStrategy : IConsumeErrorStrategy
 
         try
         {
-            var channel = await connection.CreateChannelAsync(
+            using var channel = await connection.CreateChannelAsync(
                 new CreateChannelOptions(configuration.PublisherConfirms, configuration.PublisherConfirms),
                 cancellationToken);
 


### PR DESCRIPTION
Today I had a lot of channel could not created exceptions because max channels per connection was reached.

So I figured out that the channels are not disposed.