### PR TITLE
Fixed ssl options mapping

### DIFF
--- a/Source/EasyNetQ.Tests/PersistentConnectionTests.cs
+++ b/Source/EasyNetQ.Tests/PersistentConnectionTests.cs
@@ -1,3 +1,4 @@
+using EasyNetQ.ConnectionString;
 using EasyNetQ.Persistent;
 using EasyNetQ.Tests.Mocking;
 using Microsoft.Extensions.Logging;
@@ -98,5 +99,29 @@ public class PersistentConnectionTests
 
         connection.Status.State.Should().Be(PersistentConnectionState.Connected);
         await mockBuilder.ConnectionFactory.Received(1).CreateConnectionAsync(Arg.Any<IList<AmqpTcpEndpoint>>());
+    }
+
+    [Fact]
+    public async Task Should_pass_ssl_servername_the_same_as_hostname()
+    {
+        var config = new ConnectionStringParser().Parse("host=test-host:5671;ssl=true");
+
+        await using var mockBuilder = new MockBuilder();
+        using var connection = new PersistentConnection(
+            PersistentConnectionType.Producer,
+            Substitute.For<ILogger<IPersistentConnection>>(),
+            config,
+            mockBuilder.ConnectionFactory,
+            mockBuilder.EventBus
+        );
+
+        connection.Status.State.Should().Be(PersistentConnectionState.NotInitialised);
+
+        await connection.CreateChannelAsync();
+
+        await mockBuilder.ConnectionFactory.Received(1)
+            .CreateConnectionAsync(Arg.Is<IList<AmqpTcpEndpoint>>(eps => eps.Single().Ssl.ServerName == eps.Single().HostName));
+
+        connection.Status.State.Should().Be(PersistentConnectionState.Connected);
     }
 }

--- a/Source/EasyNetQ/Persistent/PersistentConnection.cs
+++ b/Source/EasyNetQ/Persistent/PersistentConnection.cs
@@ -203,7 +203,7 @@ public class PersistentConnection : IPersistentConnection
             CertificateValidationCallback = option.CertificateValidationCallback,
             CheckCertificateRevocation = option.CheckCertificateRevocation,
             Enabled = option.Enabled,
-            ServerName = option.ServerName ?? host,
+            ServerName = string.IsNullOrEmpty(option.ServerName) ? host : option.ServerName,
             Version = option.Version,
         };
 }


### PR DESCRIPTION
This PR fixes the issue #1907 

The problem: when we are trying to use ssl connection via ConnectionStringParser the connection cannot be established due to an   RemoteCertificateNameMismatch error caused by ssl certificate validation callback.

The root cause and analysis: regression has been introduced in the new easynetq version. 

In v7 ServerName mapping looks like this 
https://github.com/EasyNetQ/EasyNetQ/blob/a76e647fb4ff7b89271468eecc77b70f9614b8a6/Source/EasyNetQ/Persistent/PersistentConnection.cs#L192

But in the new version there is a null check like this
https://github.com/EasyNetQ/EasyNetQ/blob/948af25d49c778113a27f5ac1cd9c0fa235e7b48/Source/EasyNetQ/Persistent/PersistentConnection.cs#L206

The problem here is that if look at how the `option` object is bieng created we will see that we create it in the `ConnectionConfiguration`  ctor using the default ctor for SslOption class whichf by default initializes ServerName field by an empty string

https://github.com/EasyNetQ/EasyNetQ/blob/948af25d49c778113a27f5ac1cd9c0fa235e7b48/Source/EasyNetQ/ConnectionConfiguration.cs#L46

https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/745505ac7238ecfc0357d52fdd7e4543b17ffdda/projects/RabbitMQ.Client/SslOption.cs#L66

So this leads to a case when null check `option.ServerName ?? host` just doesn't work as expected since ServerName is initialized by an empty string. As a result we are passing wrong ssl info to AmqpTcpEndpoint and later when rabbitmq client tries to establish an ssl connection using the provided ServerName it just fails since ServerName doesn't meet the server certificate.

https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/745505ac7238ecfc0357d52fdd7e4543b17ffdda/projects/RabbitMQ.Client/Impl/SslHelper.cs#L93

The fix: it quite straight forward. We need to replace null check by null or empty string check.