### PR TITLE
Use NuGet trusted publishing (OIDC) instead of a long-lived API key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    environment: release
+    permissions:
+      contents: read
+      id-token: write # required for NuGet trusted publishing (OIDC)
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Setup .NET Core ${{ matrix.dotnet }}
+      - name: Setup .NET Core 8.x
         uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '8.*'
@@ -88,5 +92,10 @@ jobs:
         run: dotnet build ${{ github.workspace }}/Source/EasyNetQ.slnx --configuration Release
       - name: Pack
         run: dotnet pack ${{ github.workspace }}/Source/EasyNetQ.slnx --configuration Release --no-build --include-symbols -p:PackageOutputPath="${{ github.workspace }}/Packages"
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: EasyNetQ
       - name: Publish
-        run: dotnet nuget push '${{ github.workspace }}/Packages/*.*' --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_TOKEN }}
+        run: dotnet nuget push '${{ github.workspace }}/Packages/*.*' --source https://api.nuget.org/v3/index.json --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }}


### PR DESCRIPTION
Switches NuGet publishing from the long-lived `NUGET_TOKEN` secret to [trusted publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing) (OIDC).

The `publish-to-nuget` job now exchanges the GitHub Actions OIDC token for a short-lived (1 hour) nuget.org API key via `NuGet/login@v1`, scoped to the **EasyNetQ organization** account rather than an individual profile.

### Changes

- `id-token: write` permission on the publish job so GitHub issues the OIDC token
- `environment: release` so the trusted publishing policy can be pinned to it, and so a manual approval gate can be added later
- `NuGet/login@v1` step with `user: EasyNetQ` (must match the policy's package owner)
- `dotnet nuget push` uses `steps.nuget-login.outputs.NUGET_API_KEY` instead of `secrets.NUGET_TOKEN`

### Required setup before merging

**On nuget.org** (signed in as an EasyNetQ org member) — username menu -> Trusted Publishing -> add a policy:

| Field | Value |
| --- | --- |
| Package Owner | `EasyNetQ` (the **organization**, not a personal account) |
| Repository Owner | `EasyNetQ` |
| Repository | `EasyNetQ` |
| Workflow File | `ci.yml` |
| Environment | `release` |

**On GitHub** — done: the `release` environment has been created (no protection rules). Optionally add required reviewers or a tag-only deployment branch rule for a manual gate before publish.

Keep `NUGET_TOKEN` until the first tagged release publishes successfully, then delete the secret.

### Notes

- The policy is bound to the org member who creates it — if that account leaves the EasyNetQ org, the policy goes inactive until they are re-added.
- The policy applies to all packages owned by the EasyNetQ org, not just those built here.
